### PR TITLE
Merge commits for 6.2.2.3 changes to release/6.2.2

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/webdav/auth/BaseSSOAuthenticationFilter.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/auth/BaseSSOAuthenticationFilter.java
@@ -208,7 +208,7 @@ public abstract class BaseSSOAuthenticationFilter extends BaseAuthenticationFilt
         {
             match = container.getRegistry().findWebScript(req.getMethod(), getScriptUrl(req));
         }
-        catch (NotFoundException notFoundEx)
+        catch (NotFoundException | IllegalArgumentException Ex)
         {
             getLogger().debug(req.getMethod() + " " + getScriptUrl(req) + "not found in Public API Container.");
         }

--- a/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/AlfrescoCreate-RepoTables.sql
+++ b/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/AlfrescoCreate-RepoTables.sql
@@ -179,7 +179,9 @@ CREATE TABLE alf_transaction
     change_txn_id VARCHAR(56) NOT NULL,
     commit_time_ms BIGINT,
     PRIMARY KEY (id),
-    KEY idx_alf_txn_ctms (commit_time_ms),
+    KEY idx_alf_txn_ctms (commit_time_ms, id),
+    KEY idx_alf_txn_ctms_sc (commit_time_ms),
+    KEY idx_alf_txn_id_ctms (id, commit_time_ms),
     KEY fk_alf_txn_svr (server_id),
     CONSTRAINT fk_alf_txn_svr FOREIGN KEY (server_id) REFERENCES alf_server (id)
 ) ENGINE=InnoDB;
@@ -222,6 +224,8 @@ CREATE TABLE alf_node
     KEY idx_alf_node_crd (audit_created, store_id, type_qname_id),
     KEY idx_alf_node_mor (audit_modifier, store_id, type_qname_id),
     KEY idx_alf_node_mod (audit_modified, store_id, type_qname_id),
+    KEY idx_alf_node_ver (version),
+    KEY idx_alf_node_txn (transaction_id),
     CONSTRAINT fk_alf_node_acl FOREIGN KEY (acl_id) REFERENCES alf_access_control_list (id),
     CONSTRAINT fk_alf_node_store FOREIGN KEY (store_id) REFERENCES alf_store (id),
     CONSTRAINT fk_alf_node_tqn FOREIGN KEY (type_qname_id) REFERENCES alf_qname (id),

--- a/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/Schema-Reference-ALF.xml
+++ b/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/Schema-Reference-ALF.xml
@@ -1681,6 +1681,16 @@
             <columnname>type_qname_id</columnname>
           </columnnames>
         </index>
+        <index name="idx_alf_node_ver" unique="false">
+          <columnnames>
+            <columnname>version</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_node_txn" unique="false">
+          <columnnames>
+            <columnname>transaction_id</columnname>
+          </columnnames>
+        </index>
       </indexes>
     </table>
     <table name="alf_node_aspects">
@@ -2673,6 +2683,18 @@
       <indexes>
         <index name="idx_alf_txn_ctms" unique="false">
           <columnnames>
+            <columnname>commit_time_ms</columnname>
+            <columnname>id</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_ctms_sc" unique="false">
+          <columnnames>
+            <columnname>commit_time_ms</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_id_ctms" unique="false">
+          <columnnames>
+            <columnname>id</columnname>
             <columnname>commit_time_ms</columnname>
           </columnnames>
         </index>

--- a/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/AlfrescoCreate-RepoTables.sql
+++ b/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/AlfrescoCreate-RepoTables.sql
@@ -196,6 +196,8 @@ CREATE TABLE alf_transaction
     CONSTRAINT fk_alf_txn_svr FOREIGN KEY (server_id) REFERENCES alf_server (id)
 );
 CREATE INDEX idx_alf_txn_ctms ON alf_transaction (commit_time_ms, id);
+CREATE INDEX idx_alf_txn_ctms_sc ON alf_transaction (commit_time_ms);
+CREATE INDEX idx_alf_txn_id_ctms ON alf_transaction (id, commit_time_ms);
 CREATE INDEX fk_alf_txn_svr ON alf_transaction (server_id);
 
 CREATE SEQUENCE alf_store_seq START WITH 1 INCREMENT BY 1;
@@ -244,6 +246,8 @@ CREATE INDEX fk_alf_node_acl ON alf_node (acl_id);
 CREATE INDEX fk_alf_node_store ON alf_node (store_id);
 CREATE INDEX idx_alf_node_tqn ON alf_node (type_qname_id, store_id, id);
 CREATE INDEX fk_alf_node_loc ON alf_node (locale_id);
+CREATE INDEX idx_alf_node_ver ON alf_node (version);
+CREATE INDEX idx_alf_node_txn ON alf_node (transaction_id);
 
 CREATE INDEX fk_alf_store_root ON alf_store (root_node_id);
 ALTER TABLE alf_store ADD CONSTRAINT fk_alf_store_root FOREIGN KEY (root_node_id) REFERENCES alf_node (id);

--- a/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/Schema-Reference-ALF.xml
+++ b/repository/src/main/resources/alfresco/dbscripts/create/org.alfresco.repo.domain.dialect.PostgreSQLDialect/Schema-Reference-ALF.xml
@@ -1740,6 +1740,16 @@
             <columnname>id</columnname>
           </columnnames>
         </index>
+        <index name="idx_alf_node_ver" unique="false">
+          <columnnames>
+            <columnname>version</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_node_txn" unique="false">
+          <columnnames>
+            <columnname>transaction_id</columnname>
+          </columnnames>
+        </index>
       </indexes>
     </table>
     <table name="alf_node_aspects">
@@ -2751,6 +2761,17 @@
           <columnnames>
             <columnname>commit_time_ms</columnname>
             <columnname>id</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_ctms_sc" unique="false">
+          <columnnames>
+            <columnname>commit_time_ms</columnname>
+          </columnnames>
+        </index>
+        <index name="idx_alf_txn_id_ctms" unique="false">
+          <columnnames>
+            <columnname>id</columnname>
+            <columnname>commit_time_ms</columnname>
           </columnnames>
         </index>
       </indexes>

--- a/repository/src/main/resources/alfresco/dbscripts/db-schema-context.xml
+++ b/repository/src/main/resources/alfresco/dbscripts/db-schema-context.xml
@@ -54,6 +54,7 @@
                 <ref bean="patch.db-V5.1-metadata-query-indexes" />
                 <ref bean="patch.db-V5.2-remove-jbpm-tables-from-db" />
                 <ref bean="patch.db-V6.0-change-set-indexes" />
+                <ref bean="patch.db-V6.3-add-indexes-node-transaction" />
             </list>
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/add-indexes-node-transaction.sql
+++ b/repository/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/add-indexes-node-transaction.sql
@@ -1,0 +1,35 @@
+--
+-- Title:      Update alf_node and alf_transaction indexes for more performance
+-- Database:   MySQL
+-- Since:      V6.3
+-- Author:     Eva Vasques
+--
+-- Please contact support@alfresco.com if you need assistance with the upgrade.
+--
+
+DROP INDEX idx_alf_node_ver;  --(optional)
+CREATE INDEX idx_alf_node_ver ON alf_node (version);
+
+DROP INDEX idx_alf_node_txn;  --(optional)
+CREATE INDEX idx_alf_node_txn ON alf_node (transaction_id);
+
+DROP INDEX idx_alf_txn_ctms;  --(optional)
+CREATE INDEX idx_alf_txn_ctms ON alf_transaction (commit_time_ms, id);
+
+DROP INDEX idx_alf_txn_ctms_sc;  --(optional)
+CREATE INDEX idx_alf_txn_ctms_sc ON alf_transaction (commit_time_ms);
+
+DROP INDEX idx_alf_txn_id_ctms;  --(optional)
+CREATE INDEX idx_alf_txn_id_ctms ON alf_transaction (id, commit_time_ms);
+
+--
+-- Record script finish
+--
+DELETE FROM alf_applied_patch WHERE id = 'patch.db-V6.3-add-indexes-node-transaction';
+INSERT INTO alf_applied_patch
+  (id, description, fixes_from_schema, fixes_to_schema, applied_to_schema, target_schema, applied_on_date, applied_to_server, was_executed, succeeded, report)
+  VALUES
+  (
+    'patch.db-V6.3-add-indexes-node-transaction', 'Create aditional indexes on alf_node and alf_transaction',
+    0, 13005, -1, 13006, null, 'UNKNOWN', ${TRUE}, ${TRUE}, 'Script completed'
+  );

--- a/repository/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.PostgreSQLDialect/add-indexes-node-transaction.sql
+++ b/repository/src/main/resources/alfresco/dbscripts/upgrade/6.3/org.alfresco.repo.domain.dialect.PostgreSQLDialect/add-indexes-node-transaction.sql
@@ -1,0 +1,32 @@
+--
+-- Title:      Update alf_node and alf_transaction indexes for more performance
+-- Database:   PostgreSQL
+-- Since:      V6.3
+-- Author:     Eva Vasques
+--
+-- Please contact support@alfresco.com if you need assistance with the upgrade.
+--
+
+DROP INDEX idx_alf_node_ver;  --(optional)
+CREATE INDEX idx_alf_node_ver ON alf_node (version);
+
+DROP INDEX idx_alf_node_txn;  --(optional)
+CREATE INDEX idx_alf_node_txn ON alf_node (transaction_id);
+
+DROP INDEX idx_alf_txn_ctms_sc;  --(optional)
+CREATE INDEX idx_alf_txn_ctms_sc ON alf_transaction (commit_time_ms);
+
+DROP INDEX idx_alf_txn_id_ctms;  --(optional)
+CREATE INDEX idx_alf_txn_id_ctms ON alf_transaction (id, commit_time_ms);
+
+--
+-- Record script finish
+--
+DELETE FROM alf_applied_patch WHERE id = 'patch.db-V6.3-add-indexes-node-transaction';
+INSERT INTO alf_applied_patch
+  (id, description, fixes_from_schema, fixes_to_schema, applied_to_schema, target_schema, applied_on_date, applied_to_server, was_executed, succeeded, report)
+  VALUES
+  (
+    'patch.db-V6.3-add-indexes-node-transaction', 'Create aditional indexes on alf_node and alf_transaction',
+    0, 13005, -1, 13006, null, 'UNKNOWN', ${TRUE}, ${TRUE}, 'Script completed'
+  );

--- a/repository/src/main/resources/alfresco/messages/patch-service.properties
+++ b/repository/src/main/resources/alfresco/messages/patch-service.properties
@@ -401,3 +401,5 @@ patch.updateAdminUserWhenDefault.result=\n\Successfully removed password2 proper
 patch.db-V5.2-remove-jbpm-tables-from-db.description=Removes all JBPM related tables from the database.
 
 patch.db-V6.0-change-set-indexes.description=Add additional indexes to support acl tracking.
+
+patch.db-V6.3-add-indexes-node-transaction.description=Create additional indexes on alf_node and alf_transaction

--- a/repository/src/main/resources/alfresco/patch/patch-services-context.xml
+++ b/repository/src/main/resources/alfresco/patch/patch-services-context.xml
@@ -1397,5 +1397,17 @@
             <value>classpath:alfresco/dbscripts/upgrade/6.0/${db.script.dialect}/change-set-indexes.sql</value>
         </property>
     </bean>
+    
+    <bean id="patch.db-V6.3-add-indexes-node-transaction" class="org.alfresco.repo.admin.patch.impl.SchemaUpgradeScriptPatch" parent="basePatch">
+        <property name="id"><value>patch.db-V6.3-add-indexes-node-transaction</value></property>
+        <property name="description"><value>patch.db-V6.3-add-indexes-node-transaction.description</value></property>
+        <property name="fixesFromSchema"><value>0</value></property>
+        <property name="fixesToSchema"><value>13005</value></property>
+        <property name="targetSchema"><value>13006</value></property>
+        <property name="ignored"><value>${system.new-node-transaction-indexes.ignored}</value></property>
+        <property name="scriptUrl">
+            <value>classpath:alfresco/dbscripts/upgrade/6.3/${db.script.dialect}/add-indexes-node-transaction.sql</value>
+        </property>
+    </bean>
 
 </beans>

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -3,7 +3,7 @@
 repository.name=Main Repository
 
 # Schema number
-version.schema=13005
+version.schema=13006
 
 # Directory configuration
 
@@ -1313,3 +1313,6 @@ system.delete_not_exists.delete_batchsize=1000
 system.delete_not_exists.read_only=false
 system.delete_not_exists.timeout_seconds=-1
 system.prop_table_cleaner.algorithm=V2
+
+# Creates additional indexes on alf_node and alf_transaction. Recommended for large repositories.
+system.new-node-transaction-indexes.ignored=true


### PR DESCRIPTION
…count increase (#1225)

* [MNT-21766]: Significant degradation of performance as file and site count increase (#1217)
- Added the following indexes on alf_transaction:
idx_alf_txn_ctms_sc, cols (commit_time_ms)
idx_alf_txn_id_ctms, cols (id, commit_time_ms)
- Added the following indexes on alf_node:
idx_alf_node_ver, cols (version)
idx_alf_node_txn, cols (transaction_id)
- Created patch patch.db-V6.3-add-indexes-node-transaction
- Updated version.schema to 14002
- Added system property system.new-node-transaction-indexes.ignored, set
as true by default to not apply the patch automatically
- Created the MySQL update dbscripts to add the new indexes - and also
drop and recreate the pre-existing index idx_alf_txn_ctms on alf_transaction that was
inconsistent with the other DBMS: was indexing only commit_time_ms when
on all other DBMS index idx_alf_txn_ctms was on (commit_time_ms, id)
- Created the Postgres update dbscripts to add the new indexes

(cherry picked from commit d70746f63a6e6a2154d2e37c577955a17c42256e)

* Change schema upgrade from to 13005..13006 on patch apply

* Fixed merge from cherry pick, missing colon

(cherry picked from commit 73f94fc5ca0d2ea322d12a59cf3ae980ef94bf1c)