### PR TITLE
SEARCH-2491 Rename LuceneQueryBuilderContext, LuceneQueryParserAdaptor and LuceneQueryParserExpressionAdaptor.

### DIFF
--- a/data-model/src/main/java/org/alfresco/opencmis/dictionary/CMISPropertyLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/dictionary/CMISPropertyLuceneBuilder.java
@@ -28,8 +28,8 @@ package org.alfresco.opencmis.dictionary;
 import java.io.Serializable;
 import java.util.Collection;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 
 
@@ -45,14 +45,14 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param not Boolean
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E;
 
     /**
      * @param value Serializable
@@ -61,7 +61,7 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param value Serializable
@@ -70,7 +70,7 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param not Boolean
@@ -78,7 +78,7 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneIn(LuceneQueryParserAdaptor<Q, S, E> lqpa, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneIn(QueryParserAdaptor<Q, S, E> lqpa, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E;
 
     /**
      * @param value PredicateMode
@@ -87,7 +87,7 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param value Serializable
@@ -96,7 +96,7 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param value Serializable
@@ -105,7 +105,7 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param value Serializable
@@ -113,14 +113,14 @@ public interface CMISPropertyLuceneBuilder
      * @return the query - may be null if no query is required
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E;
 
     /**
      * @param lqpa TODO
      * @return the sort field
      * @throws E 
      */
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa) throws E;
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa) throws E;
     
     /**
      * @return the field name

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/AbstractSimpleLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/AbstractSimpleLuceneBuilder.java
@@ -27,9 +27,9 @@ package org.alfresco.opencmis.mapping;
 
 import java.io.Serializable;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.namespace.QName;
@@ -66,13 +66,13 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     protected abstract QName getQNameForExists();
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         return lqpa.getFieldQuery(getLuceneFieldName(), getValueAsString(value), AnalysisMode.IDENTIFIER, luceneFunction);
     }
     
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         if (not)
         {
@@ -85,7 +85,7 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -93,7 +93,7 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -101,7 +101,7 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -109,7 +109,7 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -117,7 +117,7 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -131,7 +131,7 @@ public abstract class AbstractSimpleLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa) throws E
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa) throws E
     {
         return getLuceneFieldName();
     }

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/BaseLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/BaseLuceneBuilder.java
@@ -29,9 +29,9 @@ import java.io.Serializable;
 import java.util.Collection;
 
 import org.alfresco.opencmis.dictionary.CMISPropertyLuceneBuilder;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserExpressionAdaptor;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserExpressionAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 
 /**
@@ -50,33 +50,33 @@ public class BaseLuceneBuilder implements CMISPropertyLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E 
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneIn(LuceneQueryParserAdaptor<Q, S, E> lqpa, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneIn(QueryParserAdaptor<Q, S, E> lqpa, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E
     {
-        LuceneQueryParserExpressionAdaptor<Q, E> expressionAdaptor = lqpa.getExpressionAdaptor();
+        QueryParserExpressionAdaptor<Q, E> expressionAdaptor = lqpa.getExpressionAdaptor();
         for(Serializable value : values)
         {
             expressionAdaptor.addOptional(buildLuceneEquality(lqpa, value, mode, LuceneFunction.FIELD));
@@ -92,25 +92,25 @@ public class BaseLuceneBuilder implements CMISPropertyLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         return lqpa.getNegatedQuery(buildLuceneEquality(lqpa, value, mode, luceneFunction));
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
     {
         throw new UnsupportedOperationException();
     }
@@ -122,7 +122,7 @@ public class BaseLuceneBuilder implements CMISPropertyLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa) throws E
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa) throws E
     {
         throw new UnsupportedOperationException();
     }

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/BaseTypeIdLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/BaseTypeIdLuceneBuilder.java
@@ -29,9 +29,9 @@ import java.io.Serializable;
 
 import org.alfresco.opencmis.dictionary.CMISDictionaryService;
 import org.alfresco.opencmis.dictionary.TypeDefinitionWrapper;
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisInvalidArgumentException;
@@ -56,13 +56,13 @@ public class BaseTypeIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         return lqpa.getFieldQuery("TYPE", getType(getValueAsString(value)), AnalysisMode.IDENTIFIER, luceneFunction);     
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         if (not)
         {

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/DirectLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/DirectLuceneBuilder.java
@@ -27,7 +27,7 @@ package org.alfresco.opencmis.mapping;
 
 import java.io.Serializable;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
@@ -52,7 +52,7 @@ public class DirectLuceneBuilder extends AbstractSimpleLuceneBuilder
     }
     
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa) throws E
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa) throws E
     {
         String field = getLuceneFieldName();
         // need to find the real field to use

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/FixedValueLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/FixedValueLuceneBuilder.java
@@ -30,8 +30,8 @@ import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.util.EqualsHelper;
@@ -58,7 +58,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         if (EqualsHelper.nullSafeEquals(value, value))
         {
@@ -71,7 +71,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         if (not)
         {
@@ -100,7 +100,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
 
     @Override
     @SuppressWarnings("unchecked")
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         if (value instanceof Comparable)
         {
@@ -122,7 +122,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
 
     @Override
     @SuppressWarnings("unchecked")
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         if (value instanceof Comparable)
         {
@@ -143,7 +143,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneIn(LuceneQueryParserAdaptor<Q, S, E> lqpa, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneIn(QueryParserAdaptor<Q, S, E> lqpa, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E
     {
         boolean in = false;
         for (Serializable value : values)
@@ -166,7 +166,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         if (!EqualsHelper.nullSafeEquals(value, value))
         {
@@ -180,7 +180,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
 
     @Override
     @SuppressWarnings("unchecked")
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         if (value instanceof Comparable)
         {
@@ -201,7 +201,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
 
     @Override
     @SuppressWarnings("unchecked")
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         if (value instanceof Comparable)
         {
@@ -222,7 +222,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
     {
         if (value != null)
         {
@@ -255,7 +255,7 @@ public class FixedValueLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa)
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa)
     {
         throw new UnsupportedOperationException();
     }

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/ObjectIdLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/ObjectIdLuceneBuilder.java
@@ -28,9 +28,9 @@ package org.alfresco.opencmis.mapping;
 import java.io.Serializable;
 import java.util.ArrayList;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
@@ -66,7 +66,7 @@ public class ObjectIdLuceneBuilder extends BaseLuceneBuilder
         return "ID";
     }
 
-    private <Q, S, E extends Throwable> StoreRef getStore(LuceneQueryParserAdaptor<Q, S, E> lqpa)
+    private <Q, S, E extends Throwable> StoreRef getStore(QueryParserAdaptor<Q, S, E> lqpa)
     {
     	ArrayList<StoreRef> stores = lqpa.getSearchParameters().getStores();
     	if(stores.size() < 1)
@@ -77,7 +77,7 @@ public class ObjectIdLuceneBuilder extends BaseLuceneBuilder
     	return stores.get(0);
     }
 
-    private <Q, S, E extends Throwable> String getValueAsString(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value)
+    private <Q, S, E extends Throwable> String getValueAsString(QueryParserAdaptor<Q, S, E> lqpa, Serializable value)
     {
     	String nodeRefStr = null;
         if(!NodeRef.isNodeRef((String)value))
@@ -97,7 +97,7 @@ public class ObjectIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(lqpa, value);
@@ -105,7 +105,7 @@ public class ObjectIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         if (not)
         {
@@ -117,36 +117,36 @@ public class ObjectIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                                LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_ID + " can not be used in a 'greater than' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                                        LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_ID
                 + " can not be used in a 'greater than or equals' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                             LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_ID + " can not be used in a 'less than' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                                     LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_ID + " can not be used in a 'less than or equals' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(lqpa, value);
@@ -160,7 +160,7 @@ public class ObjectIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa)
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa)
     {
         return getLuceneFieldName();
     }

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/ObjectTypeIdLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/ObjectTypeIdLuceneBuilder.java
@@ -29,9 +29,9 @@ import java.io.Serializable;
 
 import org.alfresco.opencmis.dictionary.CMISDictionaryService;
 import org.alfresco.opencmis.dictionary.TypeDefinitionWrapper;
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.apache.chemistry.opencmis.commons.PropertyIds;
@@ -72,8 +72,8 @@ public class ObjectTypeIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                             LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -83,7 +83,7 @@ public class ObjectTypeIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         if (not)
         {
@@ -95,43 +95,43 @@ public class ObjectTypeIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                                LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_TYPE_ID + " can not be used in a 'greater than' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                                        LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_TYPE_ID
                 + " can not be used in a 'greater than or equals' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                               LuceneFunction luceneFunction) throws E
     {
         return lqpa.getNegatedQuery(buildLuceneEquality(lqpa, value, mode, luceneFunction));
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                             LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_TYPE_ID + " can not be used in a 'less than' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                                     LuceneFunction luceneFunction) throws E
     {
         throw new CmisInvalidArgumentException("Property " + PropertyIds.OBJECT_TYPE_ID + " can not be used in a 'less than or equals' comparison");
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(value);
@@ -147,7 +147,7 @@ public class ObjectTypeIdLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa)
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa)
     {
         return getLuceneFieldName();
     }

--- a/data-model/src/main/java/org/alfresco/opencmis/mapping/ParentLuceneBuilder.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/mapping/ParentLuceneBuilder.java
@@ -28,9 +28,9 @@ package org.alfresco.opencmis.mapping;
 import java.io.Serializable;
 import java.util.ArrayList;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
@@ -60,7 +60,7 @@ public class ParentLuceneBuilder extends BaseLuceneBuilder
 		this.dictionaryService = dictionaryService;
     }
 
-    private <Q, S, E extends Throwable> StoreRef getStore(LuceneQueryParserAdaptor<Q, S, E> lqpa)
+    private <Q, S, E extends Throwable> StoreRef getStore(QueryParserAdaptor<Q, S, E> lqpa)
     {
     	ArrayList<StoreRef> stores = lqpa.getSearchParameters().getStores();
     	if(stores.size() < 1)
@@ -77,7 +77,7 @@ public class ParentLuceneBuilder extends BaseLuceneBuilder
         return "PARENT";
     }
     
-    private <Q, S, E extends Throwable> String getValueAsString(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value)
+    private <Q, S, E extends Throwable> String getValueAsString(QueryParserAdaptor<Q, S, E> lqpa, Serializable value)
     {
     	String nodeRefStr = (String)value;
         if(!NodeRef.isNodeRef((String)value))
@@ -93,8 +93,8 @@ public class ParentLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
-            LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, PredicateMode mode,
+                                                             LuceneFunction luceneFunction) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(lqpa, value);
@@ -102,7 +102,7 @@ public class ParentLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, Boolean not) throws E
     {
         if (not)
         {
@@ -114,7 +114,7 @@ public class ParentLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, Serializable value, Boolean not) throws E
     {
         String field = getLuceneFieldName();
         String stringValue = getValueAsString(lqpa, value);
@@ -128,7 +128,7 @@ public class ParentLuceneBuilder extends BaseLuceneBuilder
     }
 
     @Override
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa)
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa)
     {
         return getLuceneFieldName();
     }

--- a/data-model/src/main/java/org/alfresco/opencmis/search/CMISFTSQueryParser.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/search/CMISFTSQueryParser.java
@@ -30,7 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
 import org.alfresco.repo.search.impl.parsers.CMIS_FTSLexer;
 import org.alfresco.repo.search.impl.parsers.CMIS_FTSParser;
 import org.alfresco.repo.search.impl.parsers.FTSQueryException;

--- a/data-model/src/main/java/org/alfresco/opencmis/search/CmisFunctionEvaluationContext.java
+++ b/data-model/src/main/java/org/alfresco/opencmis/search/CmisFunctionEvaluationContext.java
@@ -34,9 +34,9 @@ import org.alfresco.opencmis.dictionary.CMISDictionaryService;
 import org.alfresco.opencmis.dictionary.CMISNodeInfo;
 import org.alfresco.opencmis.dictionary.PropertyDefinitionWrapper;
 import org.alfresco.opencmis.dictionary.TypeDefinitionWrapper;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.repo.search.impl.querymodel.FunctionArgument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
@@ -258,8 +258,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
         this.score = score;
     }
 
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
-            PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
+                                                             PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneEquality(lqpa, value, mode, luceneFunction);
@@ -272,7 +272,7 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * buildLuceneExists(org.alfresco.repo.search.impl.lucene.LuceneQueryParser,
      * org.alfresco.service.namespace.QName, java.lang.Boolean)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Boolean not) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Boolean not) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneExists(lqpa, not);
@@ -287,8 +287,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * org.alfresco.service.namespace.QName, java.io.Serializable,
      * org.alfresco.repo.search.impl.querymodel.PredicateMode)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
-            PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
+                                                                PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneGreaterThan(lqpa, value, mode, luceneFunction);
@@ -303,8 +303,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * org.alfresco.service.namespace.QName, java.io.Serializable,
      * org.alfresco.repo.search.impl.querymodel.PredicateMode)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
-            PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
+                                                                        PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneGreaterThanOrEquals(lqpa, value, mode, luceneFunction);
@@ -319,8 +319,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * java.lang.Boolean,
      * org.alfresco.repo.search.impl.querymodel.PredicateMode)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneIn(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Collection<Serializable> values,
-            Boolean not, PredicateMode mode) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneIn(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Collection<Serializable> values,
+                                                       Boolean not, PredicateMode mode) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneIn(lqpa, values, not, mode);
@@ -335,8 +335,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * org.alfresco.service.namespace.QName, java.io.Serializable,
      * org.alfresco.repo.search.impl.querymodel.PredicateMode)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
-            PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
+                                                               PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneInequality(lqpa, value, mode, luceneFunction);
@@ -351,8 +351,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * org.alfresco.service.namespace.QName, java.io.Serializable,
      * org.alfresco.repo.search.impl.querymodel.PredicateMode)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
-            PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
+                                                             PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneLessThan(lqpa, value, mode, luceneFunction);
@@ -367,8 +367,8 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * org.alfresco.service.namespace.QName, java.io.Serializable,
      * org.alfresco.repo.search.impl.querymodel.PredicateMode)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
-            PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value,
+                                                                     PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().buildLuceneLessThanOrEquals(lqpa, value, mode, luceneFunction);
@@ -382,7 +382,7 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * org.alfresco.service.namespace.QName, java.io.Serializable,
      * java.lang.Boolean)
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, Boolean not)
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, Boolean not)
             throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
@@ -395,7 +395,7 @@ public class CmisFunctionEvaluationContext implements FunctionEvaluationContext
      * @see org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext#
      * getLuceneSortField(org.alfresco.service.namespace.QName)
      */
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName) throws E
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa, String propertyName) throws E
     {
         PropertyDefinitionWrapper propertyDef = cmisDictionaryService.findProperty(propertyName);
         return propertyDef.getPropertyLuceneBuilder().getLuceneSortField(lqpa);

--- a/data-model/src/main/java/org/alfresco/repo/search/adaptor/AnalysisMode.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/adaptor/AnalysisMode.java
@@ -23,20 +23,23 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.adaptor.lucene;
+package org.alfresco.repo.search.adaptor;
 
-/**
- * @author Andy
- *
- */
-public interface LuceneQueryParserExpressionAdaptor<Q, E extends Throwable>
+public enum AnalysisMode
 {
-    public void addRequired(Q q) throws E;
-    public void addExcluded(Q q) throws E;
-    public void addOptional(Q q) throws E;
-    public void addRequired(Q q, float boost) throws E;
-    public void addExcluded(Q q, float boost) throws E;
-    public void addOptional(Q q, float boost) throws E;
-    public Q getQuery() throws E;
-    public Q getNegatedQuery() throws E;
+    DEFAULT
+    ,
+    TOKENISE
+    ,
+    IDENTIFIER
+    ,
+    FUZZY
+    ,
+    PREFIX
+    , 
+    WILD
+    ,
+    LIKE
+    ;
+
 }

--- a/data-model/src/main/java/org/alfresco/repo/search/adaptor/LuceneFunction.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/adaptor/LuceneFunction.java
@@ -23,23 +23,30 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.adaptor.lucene;
 
-public enum AnalysisMode
+package org.alfresco.repo.search.adaptor;
+
+/**
+ * Functions that can be applied to lucene fields
+ * 
+ * Currently upper and lower that perform a case insensitive match for untokenised fields.
+ * (If the field is tokenised the match should already be case insensitive.)
+ * 
+ * @author andyh
+ *
+ */
+public enum LuceneFunction
 {
-    DEFAULT
-    ,
-    TOKENISE
-    ,
-    IDENTIFIER
-    ,
-    FUZZY
-    ,
-    PREFIX
-    , 
-    WILD
-    ,
-    LIKE
-    ;
-
-}
+    /**
+     * Match as if the field was converted to upper case.
+     */
+    UPPER, 
+    /**
+     * Match as if the field was converted to lower case.
+     */
+    LOWER, 
+    /**
+     * A normal lucene field match.
+     */
+    FIELD;
+}   

--- a/data-model/src/main/java/org/alfresco/repo/search/adaptor/QueryConstants.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/adaptor/QueryConstants.java
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.adaptor.lucene;
+package org.alfresco.repo.search.adaptor;
 
 /**
  * This class defines 

--- a/data-model/src/main/java/org/alfresco/repo/search/adaptor/QueryParserAdaptor.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/adaptor/QueryParserAdaptor.java
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.adaptor.lucene;
+package org.alfresco.repo.search.adaptor;
 
 import java.util.List;
 
@@ -33,8 +33,8 @@ import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.search.SearchParameters;
 
 /**
- * Adaptor class principally to wrap lucene parser implementations and encapsulate changes between lucene versions
- * of query building.
+ * Adaptor class to wrap search parser implementations and encapsulate changes between search versions of query
+ * building.
  * 
  * @param <Q> the query type used by the query engine implementation
  * @param <S> the sort type used by the query engine implementation
@@ -43,7 +43,7 @@ import org.alfresco.service.cmr.search.SearchParameters;
  * @author Andy
  *
  */
-public interface LuceneQueryParserAdaptor<Q, S, E extends Throwable>
+public interface QueryParserAdaptor<Q, S, E extends Throwable>
 {
 
     /**
@@ -215,9 +215,9 @@ public interface LuceneQueryParserAdaptor<Q, S, E extends Throwable>
     
     /**
      * Utility to build conjunctions, disjunctions and negation
-     * @return LuceneQueryParserExpressionAdaptor
+     * @return QueryParserExpressionAdaptor
      */
-    LuceneQueryParserExpressionAdaptor<Q, E> getExpressionAdaptor();
+    QueryParserExpressionAdaptor<Q, E> getExpressionAdaptor();
 
     /**
      * A query that matches all alfresco nodes (not extra stuff that may be in the underlying index)

--- a/data-model/src/main/java/org/alfresco/repo/search/adaptor/QueryParserExpressionAdaptor.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/adaptor/QueryParserExpressionAdaptor.java
@@ -23,26 +23,20 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.querymodel.impl.lucene;
-
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
-import org.alfresco.service.namespace.NamespacePrefixResolver;
+package org.alfresco.repo.search.adaptor;
 
 /**
  * @author Andy
  *
  */
-public interface LuceneQueryBuilderContext<Q, S, E extends Throwable>
+public interface QueryParserExpressionAdaptor<Q, E extends Throwable>
 {
-
-    /**
-     * @return - the parser
-     */
-    public abstract LuceneQueryParserAdaptor<Q, S, E> getLuceneQueryParserAdaptor();
-
-    /**
-     * @return - the namespace prefix resolver
-     */
-    public abstract NamespacePrefixResolver getNamespacePrefixResolver();
-
+    public void addRequired(Q q) throws E;
+    public void addExcluded(Q q) throws E;
+    public void addOptional(Q q) throws E;
+    public void addRequired(Q q, float boost) throws E;
+    public void addExcluded(Q q, float boost) throws E;
+    public void addOptional(Q q, float boost) throws E;
+    public Q getQuery() throws E;
+    public Q getNegatedQuery() throws E;
 }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/QueryParserUtils.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/QueryParserUtils.java
@@ -27,7 +27,7 @@ package org.alfresco.repo.search.impl;
 
 import java.util.HashSet;
 
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.service.cmr.dictionary.AspectDefinition;
 import org.alfresco.service.cmr.dictionary.ClassDefinition;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContext.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContext.java
@@ -31,9 +31,9 @@ import java.util.HashSet;
 import java.util.Map;
 
 import org.alfresco.repo.dictionary.IndexTokenisationMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.repo.search.impl.querymodel.FunctionArgument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
@@ -136,54 +136,54 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
         this.defaultNamespace = defaultNamespace;
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Boolean not) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Boolean not) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction)
+    public  <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction)
     throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneIn(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneIn(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction)
+    public  <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction)
     throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, Boolean not) throws E
+    public  <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, Boolean not) throws E
     {
         throw new UnsupportedOperationException();
     }
 
-    public  <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName) throws E
+    public  <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa, String propertyName) throws E
     {
         // Score is special
         if (propertyName.equalsIgnoreCase("Score"))
@@ -263,12 +263,12 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
     }
 
     /**
-     * @param lqpa LuceneQueryParserAdaptor<Q, S, E>
+     * @param lqpa QueryParserAdaptor<Q, S, E>
      * @param field String
      * @return ... extends Throwable
      * @throws E 
      */
-    private  <Q, S, E extends Throwable> String findSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa, String field) throws E
+    private  <Q, S, E extends Throwable> String findSortField(QueryParserAdaptor<Q, S, E> lqpa, String field) throws E
     {
         return lqpa.getSortField(field);
     }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/FTSQueryParser.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/FTSQueryParser.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.Column;
 import org.alfresco.repo.search.impl.querymodel.Constraint;

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/FunctionEvaluationContext.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/FunctionEvaluationContext.java
@@ -29,8 +29,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 
@@ -79,7 +79,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneEquality(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneEquality(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * Note: null and not null are not required to support functions from the spec
@@ -88,7 +88,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneExists(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Boolean not) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneExists(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Boolean not) throws E;
 
     /**
      * @param propertyName String
@@ -98,7 +98,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThan(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param propertyName String
@@ -108,7 +108,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneGreaterThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param propertyName String
@@ -118,7 +118,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLessThan(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneLessThan(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * @param propertyName String
@@ -128,7 +128,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneLessThanOrEquals(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * Note: Like is not required to support functions from the spec
@@ -138,7 +138,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneLike(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, Boolean not) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneLike(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, Boolean not) throws E;
 
     /**
      * @param propertyName String
@@ -148,7 +148,7 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneInequality(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneInequality(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Serializable value, PredicateMode mode, LuceneFunction luceneFunction) throws E;
 
     /**
      * Note: In is not required to support functions from the spec
@@ -158,14 +158,14 @@ public interface FunctionEvaluationContext
      * @return the query
      * @throws E
      */
-    public <Q, S, E extends Throwable> Q buildLuceneIn(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E;
+    public <Q, S, E extends Throwable> Q buildLuceneIn(QueryParserAdaptor<Q, S, E> lqpa, String propertyName, Collection<Serializable> values, Boolean not, PredicateMode mode) throws E;
 
     /**
      * @param propertyName String
      * @return the field used for sorting the given property
      * @throws E 
      */
-    public <Q, S, E extends Throwable> String getLuceneSortField(LuceneQueryParserAdaptor<Q, S, E> lqpa, String propertyName) throws E;
+    public <Q, S, E extends Throwable> String getLuceneSortField(QueryParserAdaptor<Q, S, E> lqpa, String propertyName) throws E;
     
     /**
      * @param propertyName String

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneConjunction.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneConjunction.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserExpressionAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserExpressionAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.Constraint;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
@@ -52,14 +52,14 @@ public class LuceneConjunction<Q, S, E extends Throwable> extends BaseConjunctio
      * (non-Javadoc)
      * 
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.lang.String,
-     *      java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext,
+     *      java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext,
      *      org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
        
-        LuceneQueryParserExpressionAdaptor<Q, E> expressionAdaptor = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
+        QueryParserExpressionAdaptor<Q, E> expressionAdaptor = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
         boolean must = false;
         boolean must_not = false;
         for (Constraint constraint : getConstraints())

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneDisjunction.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneDisjunction.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserExpressionAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserExpressionAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.Constraint;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
@@ -54,13 +54,13 @@ public class LuceneDisjunction<Q, S, E extends Throwable> extends BaseDisjunctio
      * (non-Javadoc)
      * 
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.lang.String,
-     *      java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext,
+     *      java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext,
      *      org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserExpressionAdaptor<Q, E> expressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
+        QueryParserExpressionAdaptor<Q, E> expressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
         ArrayList<Pair<Constraint, Q>> queriestoDisjoin = new ArrayList<>();
         for (Constraint constraint : getConstraints())
         {
@@ -80,7 +80,7 @@ public class LuceneDisjunction<Q, S, E extends Throwable> extends BaseDisjunctio
                         expressionBuilder.addOptional(constraintQuery, constraint.getBoost());
                         break;
                     case EXCLUDE:
-                        LuceneQueryParserExpressionAdaptor<Q, E> subExpressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
+                        QueryParserExpressionAdaptor<Q, E> subExpressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
                         subExpressionBuilder.addRequired(luceneContext.getLuceneQueryParserAdaptor().getMatchAllNodesQuery());
                         subExpressionBuilder.addExcluded(constraintQuery);
                         expressionBuilder.addOptional(subExpressionBuilder.getQuery(),  constraint.getBoost());

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneFunctionalConstraint.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneFunctionalConstraint.java
@@ -51,7 +51,7 @@ public class LuceneFunctionalConstraint<Q, S, E extends Throwable> extends BaseF
     /* (non-Javadoc)
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(org.apache.lucene.search.BooleanQuery, org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService, java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
     {
         Function function = getFunction();
         if(function != null)

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQuery.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQuery.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserExpressionAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserExpressionAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Column;
 import org.alfresco.repo.search.impl.querymodel.Constraint;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
@@ -67,9 +67,9 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
      * 
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilder#buildQuery()
      */
-    public Q buildQuery(Set<String> selectors, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
+    public Q buildQuery(Set<String> selectors, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
     {
-        LuceneQueryParserExpressionAdaptor<Q, E> expressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
+        QueryParserExpressionAdaptor<Q, E> expressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
 
         boolean must = false;
         boolean must_not = false;
@@ -148,10 +148,10 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
      * (non-Javadoc)
      * 
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilder#buildSort(java.lang.String,
-     *      org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext,
+     *      org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext,
      *      org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public S buildSort(Set<String> selectors, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
+    public S buildSort(Set<String> selectors, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
     {
         if ((getOrderings() == null) || (getOrderings().size() == 0))
         {
@@ -161,7 +161,7 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
         return luceneContext.getLuceneQueryParserAdaptor().buildSort(getOrderings(), functionContext);
     }
     
-    public List<SortDefinition> buildSortDefinitions(Set<String> selectors, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public List<SortDefinition> buildSortDefinitions(Set<String> selectors, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
     {
         if ((getOrderings() == null) || (getOrderings().size() == 0))
         {

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQueryBuilder.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQueryBuilder.java
@@ -47,7 +47,7 @@ public interface LuceneQueryBuilder <Q, S, E extends Throwable>
      * @return - the query
      * @throws E
      */
-    public Q buildQuery(Set<String> selectors,  LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E;
+    public Q buildQuery(Set<String> selectors, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E;
 
     /**
      * Build the matching lucene sort
@@ -55,12 +55,12 @@ public interface LuceneQueryBuilder <Q, S, E extends Throwable>
      * @return - the sort spec
      * @throws E 
      */
-    public S buildSort(Set<String> selectors, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E;
+    public S buildSort(Set<String> selectors, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E;
     
     /**
      * Build a sort definition for a sorted result set wrapper
      * @param functionContext FunctionEvaluationContext
      */
-    public List<SortDefinition> buildSortDefinitions(Set<String> selectors, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext);
+    public List<SortDefinition> buildSortDefinitions(Set<String> selectors, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext);
 
 }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQueryBuilderComponent.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQueryBuilderComponent.java
@@ -42,5 +42,5 @@ public interface LuceneQueryBuilderComponent<Q, S, E extends Throwable>
      * @return - the lucene query fragment for this component
      * @throws E
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E;
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E;
 }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneSelector.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneSelector.java
@@ -28,10 +28,9 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
-import org.alfresco.repo.search.impl.querymodel.JoinType;
 import org.alfresco.repo.search.impl.querymodel.impl.BaseSelector;
 import org.alfresco.service.namespace.QName;
 
@@ -54,9 +53,9 @@ public class LuceneSelector<Q, S, E extends Throwable> extends BaseSelector impl
     /* (non-Javadoc)
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(org.apache.lucene.search.BooleanQuery, org.apache.lucene.search.BooleanQuery)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext) throws E
     {
-    	LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+    	QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
     	switch(getJoinType())
     	{
     	case INNER:

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/QueryBuilderContext.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/QueryBuilderContext.java
@@ -23,30 +23,26 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
+package org.alfresco.repo.search.impl.querymodel.impl.lucene;
 
-package org.alfresco.repo.search.adaptor.lucene;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
+import org.alfresco.service.namespace.NamespacePrefixResolver;
 
 /**
- * Functions that can be applied to lucene fields
- * 
- * Currently upper and lower that perform a case insensitive match for untokenised fields.
- * (If the field is tokenised the match should already be case insensitive.)
- * 
- * @author andyh
+ * @author Andy
  *
  */
-public enum LuceneFunction
+public interface QueryBuilderContext<Q, S, E extends Throwable>
 {
+
     /**
-     * Match as if the field was converted to upper case.
+     * @return - the parser
      */
-    UPPER, 
+    public abstract QueryParserAdaptor<Q, S, E> getLuceneQueryParserAdaptor();
+
     /**
-     * Match as if the field was converted to lower case.
+     * @return - the namespace prefix resolver
      */
-    LOWER, 
-    /**
-     * A normal lucene field match.
-     */
-    FIELD;
-}   
+    public abstract NamespacePrefixResolver getNamespacePrefixResolver();
+
+}

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneChild.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneChild.java
@@ -29,14 +29,14 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Child;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.StoreRef;
 
@@ -55,7 +55,7 @@ public class LuceneChild<Q, S, E extends Throwable> extends Child implements Luc
         super();
     }
     
-    private StoreRef getStore(LuceneQueryBuilderContext<Q, S, E> luceneContext)
+    private StoreRef getStore(QueryBuilderContext<Q, S, E> luceneContext)
     {
     	ArrayList<StoreRef> stores = luceneContext.getLuceneQueryParserAdaptor().getSearchParameters().getStores();
     	if(stores.size() < 1)
@@ -73,10 +73,10 @@ public class LuceneChild<Q, S, E extends Throwable> extends Child implements Luc
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_PARENT);
         String id = (String) argument.getValue(functionContext);
         argument = functionArgs.get(ARG_SELECTOR);

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneDescendant.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneDescendant.java
@@ -29,14 +29,14 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Descendant;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.Path;
 import org.alfresco.service.cmr.repository.StoreRef;
@@ -56,7 +56,7 @@ public class LuceneDescendant<Q, S, E extends Throwable> extends Descendant impl
         super();
     }
 
-    private StoreRef getStore(LuceneQueryBuilderContext<Q, S, E> luceneContext)
+    private StoreRef getStore(QueryBuilderContext<Q, S, E> luceneContext)
     {
     	ArrayList<StoreRef> stores = luceneContext.getLuceneQueryParserAdaptor().getSearchParameters().getStores();
     	if(stores.size() < 1)
@@ -74,10 +74,10 @@ public class LuceneDescendant<Q, S, E extends Throwable> extends Descendant impl
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_ANCESTOR);
         String id = (String) argument.getValue(functionContext);
         argument = functionArgs.get(ARG_SELECTOR);

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneEquals.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneEquals.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Equals;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -58,10 +58,10 @@ public class LuceneEquals<Q, S, E extends Throwable> extends Equals  implements 
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         setPropertyAndStaticArguments(functionArgs);
        
         Q query = functionContext.buildLuceneEquality(lqpa, getPropertyName(), getStaticArgument().getValue(functionContext), PredicateMode.ANY, functionContext.getLuceneFunction(getFunctionArgument()));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneExists.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneExists.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Exists;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 
 /**
@@ -52,10 +52,10 @@ public class LuceneExists<Q, S, E extends Throwable> extends Exists implements L
         super();
     }
 
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         PropertyArgument propertyArgument = (PropertyArgument) functionArgs.get(ARG_PROPERTY);
         Argument inverseArgument = functionArgs.get(ARG_NOT);
         Boolean not = DefaultTypeConverter.INSTANCE.convert(Boolean.class, inverseArgument.getValue(functionContext));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSFuzzyTerm.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSFuzzyTerm.java
@@ -28,13 +28,13 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSFuzzyTerm;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * Fuzzy matching
@@ -59,10 +59,10 @@ public class LuceneFTSFuzzyTerm<Q, S, E extends Throwable> extends FTSFuzzyTerm 
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_TERM);
         String term = (String) argument.getValue(functionContext);
         argument = functionArgs.get(ARG_MIN_SIMILARITY);

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSPhrase.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSPhrase.java
@@ -28,15 +28,15 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSPhrase;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -59,10 +59,10 @@ public class LuceneFTSPhrase<Q, S, E extends Throwable> extends FTSPhrase implem
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_PHRASE);
         String term = (String) argument.getValue(functionContext);
 

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSPrefixTerm.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSPrefixTerm.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSPrefixTerm;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * Perfix term
@@ -59,10 +59,10 @@ public class LuceneFTSPrefixTerm<Q, S, E extends Throwable> extends FTSPrefixTer
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_TERM);
         String term = (String) argument.getValue(functionContext);
         // strip trailing wildcard *

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSProximity.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSProximity.java
@@ -28,13 +28,13 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSProximity;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * Proximity
@@ -59,10 +59,10 @@ public class LuceneFTSProximity<Q, S, E extends Throwable> extends FTSProximity 
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_FIRST);
         String first = (String) argument.getValue(functionContext);
         argument = functionArgs.get(ARG_LAST);

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSRange.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSRange.java
@@ -28,15 +28,15 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSRange;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * Range
@@ -60,10 +60,10 @@ public class LuceneFTSRange<Q, S, E extends Throwable> extends FTSRange implemen
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_FROM_INC);
         Boolean fromInc = (Boolean) argument.getValue(functionContext);
         argument = functionArgs.get(ARG_FROM);

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSTerm.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSTerm.java
@@ -28,15 +28,15 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSTerm;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -58,10 +58,10 @@ public class LuceneFTSTerm<Q, S, E extends Throwable> extends FTSTerm implements
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_TERM);
         String term = (String) argument.getValue(functionContext);
         argument = functionArgs.get(ARG_TOKENISATION_MODE);

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSWildTerm.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneFTSWildTerm.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.FTSWildTerm;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * Wild Card
@@ -60,10 +60,10 @@ public class LuceneFTSWildTerm<Q, S, E extends Throwable> extends FTSWildTerm im
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         Argument argument = functionArgs.get(ARG_TERM);
         String term = (String) argument.getValue(functionContext);
 

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneGreaterThan.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneGreaterThan.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.GreaterThan;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -58,10 +58,10 @@ public class LuceneGreaterThan<Q, S, E extends Throwable> extends GreaterThan im
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         setPropertyAndStaticArguments(functionArgs);
        
         Q query = functionContext.buildLuceneGreaterThan(lqpa, getPropertyName(), getStaticArgument().getValue(functionContext), PredicateMode.ANY, functionContext.getLuceneFunction(getFunctionArgument()));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneGreaterThanOrEquals.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneGreaterThanOrEquals.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.GreaterThanOrEquals;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -59,10 +59,10 @@ public class LuceneGreaterThanOrEquals<Q, S, E extends Throwable> extends Greate
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         setPropertyAndStaticArguments(functionArgs);
        
         Q query = functionContext.buildLuceneGreaterThanOrEquals(lqpa, getPropertyName(), getStaticArgument().getValue(functionContext), PredicateMode.ANY, functionContext.getLuceneFunction(getFunctionArgument()));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneIn.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneIn.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.ListArgument;
@@ -40,7 +40,7 @@ import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.In;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 
 /**
@@ -64,10 +64,10 @@ public class LuceneIn<Q, S, E extends Throwable> extends In implements LuceneQue
      * org.alfresco.service.cmr.dictionary.DictionaryService, java.lang.String)
      */
     @SuppressWarnings("unchecked")
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         PropertyArgument propertyArgument = (PropertyArgument) functionArgs.get(ARG_PROPERTY);
         Argument inverseArgument = functionArgs.get(ARG_NOT);
         Boolean not = DefaultTypeConverter.INSTANCE.convert(Boolean.class, inverseArgument.getValue(functionContext));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLessThan.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLessThan.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.LessThan;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -59,10 +59,10 @@ public class LuceneLessThan<Q, S, E extends Throwable> extends LessThan implemen
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         setPropertyAndStaticArguments(functionArgs);
        
         Q query = functionContext.buildLuceneLessThan(lqpa, getPropertyName(), getStaticArgument().getValue(functionContext), PredicateMode.ANY, functionContext.getLuceneFunction(getFunctionArgument()));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLessThanOrEquals.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLessThanOrEquals.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.LessThanOrEquals;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -59,10 +59,10 @@ public class LuceneLessThanOrEquals<Q, S, E extends Throwable> extends LessThanO
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         
         setPropertyAndStaticArguments(functionArgs);
        

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLike.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLike.java
@@ -29,14 +29,14 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Like;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 
 /**
@@ -61,10 +61,10 @@ public class LuceneLike<Q, S, E extends Throwable> extends Like implements Lucen
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         PropertyArgument propertyArgument = (PropertyArgument) functionArgs.get(ARG_PROPERTY);
         Argument inverseArgument = functionArgs.get(ARG_NOT);
         Boolean not = DefaultTypeConverter.INSTANCE.convert(Boolean.class, inverseArgument.getValue(functionContext));

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLower.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneLower.java
@@ -33,7 +33,7 @@ import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Lower;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -52,10 +52,10 @@ public class LuceneLower<Q, S, E extends Throwable> extends Lower implements Luc
     /*
      * (non-Javadoc)
      * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set,
-     * java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext,
+     * java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext,
      * org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
         throw new QueryModelException("Unsupported function in query " + getName());

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneNotEquals.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneNotEquals.java
@@ -28,14 +28,14 @@ package org.alfresco.repo.search.impl.querymodel.impl.lucene.functions;
 import java.util.Map;
 import java.util.Set;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneQueryParserAdaptor;
+import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PredicateMode;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.NotEquals;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -58,10 +58,10 @@ public class LuceneNotEquals<Q, S, E extends Throwable> extends NotEquals implem
      *      org.apache.lucene.search.BooleanQuery, org.alfresco.service.cmr.dictionary.DictionaryService,
      *      java.lang.String)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-        LuceneQueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
+        QueryParserAdaptor<Q, S, E> lqpa = luceneContext.getLuceneQueryParserAdaptor();
         setPropertyAndStaticArguments(functionArgs);
 
         Q query = functionContext.buildLuceneInequality(lqpa, getPropertyName(), getStaticArgument().getValue(functionContext), PredicateMode.ANY, functionContext

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LucenePropertyAccessor.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LucenePropertyAccessor.java
@@ -33,7 +33,7 @@ import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.PropertyAccessor;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -49,9 +49,9 @@ public class LucenePropertyAccessor<Q, S, E extends Throwable> extends PropertyA
     }
     
     /* (non-Javadoc)
-     * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set, java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext, org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
+     * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set, java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext, org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
         throw new QueryModelException("Unsupported function in query "+getName());

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneScore.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneScore.java
@@ -33,7 +33,7 @@ import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Score;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -51,9 +51,9 @@ public class LuceneScore<Q, S, E extends Throwable> extends Score implements Luc
     }
     
     /* (non-Javadoc)
-     * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set, java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext, org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
+     * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set, java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext, org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
         throw new QueryModelException("Unsupported function in query "+getName());

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneUpper.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/functions/LuceneUpper.java
@@ -33,7 +33,7 @@ import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Upper;
 import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent;
-import org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext;
+import org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext;
 
 /**
  * @author andyh
@@ -50,9 +50,9 @@ public class LuceneUpper<Q, S, E extends Throwable> extends Upper implements Luc
     }
 
     /* (non-Javadoc)
-     * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set, java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderContext, org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
+     * @see org.alfresco.repo.search.impl.querymodel.impl.lucene.LuceneQueryBuilderComponent#addComponent(java.util.Set, java.util.Map, org.alfresco.repo.search.impl.querymodel.impl.lucene.QueryBuilderContext, org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext)
      */
-    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, LuceneQueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
+    public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
         throw new QueryModelException("Unsupported function in query "+getName());

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryBuilderPredicatePartCommand.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryBuilderPredicatePartCommand.java
@@ -25,7 +25,7 @@
  */
 package org.alfresco.repo.search.impl.querymodel.impl.db;
 
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
 
 /**
  * @author Andy

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/PropertySupport.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/PropertySupport.java
@@ -33,10 +33,9 @@ import java.util.Set;
 
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.qname.QNameDAO;
-import org.alfresco.repo.search.adaptor.lucene.LuceneFunction;
+import org.alfresco.repo.search.adaptor.LuceneFunction;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
-import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.tenant.TenantService;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/functions/DBFTSPhrase.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/functions/DBFTSPhrase.java
@@ -31,8 +31,8 @@ import java.util.Set;
 
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.qname.QNameDAO;
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/functions/DBFTSPrefixTerm.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/functions/DBFTSPrefixTerm.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.qname.QNameDAO;
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/functions/DBFTSTerm.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/functions/DBFTSTerm.java
@@ -31,8 +31,8 @@ import java.util.Set;
 
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.qname.QNameDAO;
-import org.alfresco.repo.search.adaptor.lucene.AnalysisMode;
-import org.alfresco.repo.search.adaptor.lucene.QueryConstants;
+import org.alfresco.repo.search.adaptor.AnalysisMode;
+import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.repo.search.impl.querymodel.Argument;
 import org.alfresco.repo.search.impl.querymodel.FunctionEvaluationContext;
 import org.alfresco.repo.search.impl.querymodel.PropertyArgument;


### PR DESCRIPTION
Also move them from the package org.alfresco.repo.search.adaptor.lucene to org.alfresco.repo.search.adaptor.