### PR TITLE
Changes to poms  to support compatibility with JDK9+ module system

### DIFF
--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -188,7 +188,12 @@
                     <groupId>org.codehaus.woodstox</groupId>
                     <artifactId>woodstox-core-asl</artifactId>
                 </exclusion>
-            </exclusions>
+                <!-- [ACS-544] Excluded as conflicts with JDK9+ as it includes javax.transaction -->
+                <exclusion>
+                  <groupId>org.apache.geronimo.specs</groupId>
+                  <artifactId>geronimo-jta_1.1_spec</artifactId>
+                </exclusion>
+             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,13 @@
                 <groupId>xalan</groupId>
                 <artifactId>xalan</artifactId>
                 <version>2.7.2-alfresco</version>
+                <exclusions>
+                    <!-- [ACS-544] Excluded to avoid conflict in JDK9+ as it includes javax.xml and w3c.org -->
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.alfresco.services</groupId>
@@ -490,6 +497,13 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>${dependency.xercesImpl.version}</version>
+                <exclusions>
+                    <!-- [ACS-544] Excluded to avoid conflict in JDK9+ as it includes javax.xml and w3c.org -->
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Newer metadata-extractor, used in TIKA, see ACS-370 -->
             <dependency>
@@ -697,4 +711,3 @@
     </build>
 
 </project>
-

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -249,11 +249,7 @@
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-        </dependency>
+        <!-- [ACS-544] xml-apis dependency excluded to avoid conflict in JDK9+ as it includes javax.xml and w3c. -->
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
@@ -424,6 +420,11 @@
               <exclusion>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>woodstox-core-asl</artifactId>
+              </exclusion>
+              <!-- [ACS-544] Excluded as conflicts with JDK9+ as it includes javax.transaction -->
+              <exclusion>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-jta_1.1_spec</artifactId>
               </exclusion>
             </exclusions>
         </dependency>
@@ -1004,6 +1005,11 @@
               <exclusion>
                   <groupId>javax.annotation</groupId>
                   <artifactId>javax.annotation-api</artifactId>
+              </exclusion>
+              <!-- [ACS-544] Excluded as conflicts with JDK9+ as it includes javax.transaction -->
+              <exclusion>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-jta_1.1_spec</artifactId>
               </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
In the current build some packages ("javax.xml" and "org.w3c" for example) are accessible via the JRE System Library AND via other jar files pulled by Maven as transitive dependencies, such as xml-apis.jar. Being on the classpath, they are treated as part of the unnamed module, and the "uniquely visible" constraint is violated.

Please see https://issues.alfresco.com/jira/browse/ACS-544 for full detailed explanation