### PR TITLE
MNT-22009 - When setting permissions async, nodes with the aspect app…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ branches:
   only:
     - master
     - /release\/.*/
-    - fix/MNT-22009_async_permissions_deleted_files
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ branches:
   only:
     - master
     - /release\/.*/
+    - fix/MNT-22009_async_permissions_deleted_files
 
 env:
   global:


### PR DESCRIPTION
…lied cannot be deleted

* Added unit test that deletes a node with the sys:pendingFixAcl aspect
before the job runs
* Added verification to the job to verify if node is in archive store
and if so, it shall not process that node and remove sys:pendingFixAcl aspect and properties