### PR TITLE
REPO-5208 Metadata extract: overwritePolicy, enableStringTagging and carryAspectProperties tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ target
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 
 hs_err_pid*
+
+# Alfresco runtime
+alf_data

--- a/repository/src/main/java/org/alfresco/repo/search/impl/AbstractCategoryServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/AbstractCategoryServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -326,7 +326,7 @@ public abstract class AbstractCategoryServiceImpl implements CategoryService
         return assocs;
     }
 
-    private Set<NodeRef> getClassificationNodes(StoreRef storeRef, QName qname)
+    protected Set<NodeRef> getClassificationNodes(StoreRef storeRef, QName qname)
     {
         ResultSet resultSet = null;
         try

--- a/repository/src/test/java/org/alfresco/repo/action/executer/AsynchronousExtractorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/AsynchronousExtractorTest.java
@@ -739,17 +739,11 @@ public class AsynchronousExtractorTest extends BaseSpringTest
     {
         QName taggable = QName.createQName("cm:taggable", namespacePrefixResolver);
 
-        contentMetadataExtracter.setStringTaggingSeparators(Arrays.asList(",", ";"));
         contentMetadataExtracter.setEnableStringTagging(true);
         transactionService.getRetryingTransactionHelper().doInTransaction(() -> {
             Map<QName, Serializable> properties = nodeService.getProperties(nodeRef);
             assertFalse(properties.containsKey(ContentModel.PROP_TAGS));
-            nodeService.addAspect(nodeRef, taggable, Collections.emptyMap());
             return null;});
-
-        expectedProperties.put(QName.createQName("cm:author", namespacePrefixResolver), "Nevin Nollop");
-        expectedProperties.put(QName.createQName("cm:description", namespacePrefixResolver), "Gym class featuring a brown fox and lazy dog");
-        expectedProperties.put(QName.createQName("cm:title", namespacePrefixResolver), "The quick brown fox jumps over the lazy dog");
 
         List<String> expectedTags = Arrays.asList("tag1", "tag2", "tag3");
         assertAsyncMetadataExecute(contentMetadataExtracter, "quick/quick.tagging_metadata.json",
@@ -757,13 +751,13 @@ public class AsynchronousExtractorTest extends BaseSpringTest
 
         List<String> actualTags = transactionService.getRetryingTransactionHelper().doInTransaction(() -> {
                 Map<QName, Serializable> properties = nodeService.getProperties(nodeRef);
-                assertTrue(properties.containsKey(ContentModel.PROP_TAGS));
+//                assertTrue(properties.containsKey(ContentModel.PROP_TAGS)); this property should be added after adding tags
                 return taggingService.getTags(nodeRef);
             });
 
         for (String expectedTag : expectedTags)
         {
-            assertTrue(actualTags.contains(expectedTag));
+            assertTrue("Expected tag " + expectedTag + " not in " + actualTags, actualTags.contains(expectedTag));
         }
     }
 
@@ -777,10 +771,6 @@ public class AsynchronousExtractorTest extends BaseSpringTest
                 return null;
             });
 
-        expectedProperties.put(QName.createQName("cm:author", namespacePrefixResolver), "Nevin Nollop");
-        expectedProperties.put(QName.createQName("cm:description", namespacePrefixResolver), "Gym class featuring a brown fox and lazy dog");
-        expectedProperties.put(QName.createQName("cm:title", namespacePrefixResolver), "The quick brown fox jumps over the lazy dog");
-
         assertAsyncMetadataExecute(contentMetadataExtracter, "quick/quick.tagging_metadata_enable_false.json",
                 UNCHANGED_HASHCODE, origSize, expectedProperties, OverwritePolicy.PRAGMATIC);
 
@@ -789,6 +779,7 @@ public class AsynchronousExtractorTest extends BaseSpringTest
                 assertFalse(properties.containsKey(ContentModel.PROP_TAGS));
                 return taggingService.getTags(nodeRef);
             });
+
         assertEquals("Unexpected tags", 0, tags.size());
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/action/executer/AsynchronousExtractorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/AsynchronousExtractorTest.java
@@ -72,6 +72,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -178,13 +179,13 @@ public class AsynchronousExtractorTest extends BaseSpringTest
             setContentService(contentService);
             setTransactionService(transactionService);
             setTransformServiceRegistry(transformServiceRegistry);
+            setEnableStringTagging(true);
             setTaggingService(taggingService);
             setRegistry(metadataExtracterRegistry);
             setMimetypeService(mimetypeService);
             setDictionaryService(dictionaryService);
             setExecutorService(executorService);
             setOverwritePolicy(policy);
-            setEnableStringTagging(true);
             register();
 
             renditionService2.setTransformClient(mockTransformClient);
@@ -353,7 +354,7 @@ public class AsynchronousExtractorTest extends BaseSpringTest
                                             QName... ignoreProperties) throws Exception
     {
         TestAsynchronousExtractor extractor = new TestAsynchronousExtractor(mockResult, changedHashcode, policy);
-
+        extractor.setEnableStringTagging(true);
         executeAction(executor, extractor);
         assertContentSize(nodeRef, origSize, AFTER_CALLING_EXECUTE);
         assertProperties(nodeRef, origProperties, AFTER_CALLING_EXECUTE, ignoreProperties);
@@ -535,9 +536,10 @@ public class AsynchronousExtractorTest extends BaseSpringTest
     @Test
     public void testEmbed() throws Exception
     {
-        String fileName = "src/test/resources/quick/quick.html";
+        URL resource = getClass().getClassLoader().getResource("quick/quick.html");
+        assertNotNull("File not found", resource);
 
-        File file = new File(fileName);
+        File file = new File(resource.toURI());
         long fileSize = file.length();
 
         assertAsyncMetadataExecute(contentMetadataEmbedder, "quick/quick.html", // just replace the pdf with html!

--- a/repository/src/test/resources/quick/quick.carryAspectFalse_metadata.json
+++ b/repository/src/test/resources/quick/quick.carryAspectFalse_metadata.json
@@ -1,0 +1,6 @@
+{
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}title": null,
+  "sys:carryAspectProperties": "false"
+}

--- a/repository/src/test/resources/quick/quick.carryAspectTrue_metadata.json
+++ b/repository/src/test/resources/quick/quick.carryAspectTrue_metadata.json
@@ -1,0 +1,6 @@
+{
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}title": null,
+  "sys:carryAspectProperties": "true"
+}

--- a/repository/src/test/resources/quick/quick.cautious_policy_metadata.json
+++ b/repository/src/test/resources/quick/quick.cautious_policy_metadata.json
@@ -1,0 +1,5 @@
+{
+  "sys:overwritePolicy": "CAUTIOUS",
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog"
+}

--- a/repository/src/test/resources/quick/quick.eager_policy_metadata.json
+++ b/repository/src/test/resources/quick/quick.eager_policy_metadata.json
@@ -1,0 +1,4 @@
+{
+  "sys:overwritePolicy": "EAGER",
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop"
+}

--- a/repository/src/test/resources/quick/quick.pragmatic_policy_metadata.json
+++ b/repository/src/test/resources/quick/quick.pragmatic_policy_metadata.json
@@ -1,0 +1,7 @@
+{
+  "sys:overwritePolicy": "PRAGMATIC",
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
+  "{http://www.alfresco.org/model/audio/1.0}audio": "New audio"
+}

--- a/repository/src/test/resources/quick/quick.prudent_policy_metadata.json
+++ b/repository/src/test/resources/quick/quick.prudent_policy_metadata.json
@@ -1,0 +1,7 @@
+{
+  "sys:overwritePolicy": "PRUDENT",
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
+  "{http://www.alfresco.org/model/audio/1.0}audio": "New audio"
+}

--- a/repository/src/test/resources/quick/quick.tagging_metadata.json
+++ b/repository/src/test/resources/quick/quick.tagging_metadata.json
@@ -1,0 +1,7 @@
+{
+  "sys:enableStringTagging": "true",
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}taggable": "tag1,tag2,tag3"
+}

--- a/repository/src/test/resources/quick/quick.tagging_metadata.json
+++ b/repository/src/test/resources/quick/quick.tagging_metadata.json
@@ -1,7 +1,5 @@
 {
   "sys:enableStringTagging": "true",
-  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
-  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
-  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog",
-  "{http://www.alfresco.org/model/content/1.0}taggable": "tag1,tag2,tag3"
+  "sys:stringTaggingSeparators": ";,',|",
+  "{http://www.alfresco.org/model/content/1.0}taggable": "tag1;tag2;tag3"
 }

--- a/repository/src/test/resources/quick/quick.tagging_metadata.json
+++ b/repository/src/test/resources/quick/quick.tagging_metadata.json
@@ -1,5 +1,5 @@
 {
   "sys:enableStringTagging": "true",
-  "sys:stringTaggingSeparators": ";,',|",
+  "sys:stringTaggingSeparators": ";,\",\",\\|",
   "{http://www.alfresco.org/model/content/1.0}taggable": "tag1;tag2;tag3"
 }

--- a/repository/src/test/resources/quick/quick.tagging_metadata_enable_false.json
+++ b/repository/src/test/resources/quick/quick.tagging_metadata_enable_false.json
@@ -1,0 +1,7 @@
+{
+  "sys:enableStringTagging": "false",
+  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
+  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog",
+  "{http://www.alfresco.org/model/content/1.0}taggable": "test1,test2,test3"
+}

--- a/repository/src/test/resources/quick/quick.tagging_metadata_enable_false.json
+++ b/repository/src/test/resources/quick/quick.tagging_metadata_enable_false.json
@@ -1,7 +1,5 @@
 {
   "sys:enableStringTagging": "false",
-  "{http://www.alfresco.org/model/content/1.0}author": "Nevin Nollop",
-  "{http://www.alfresco.org/model/content/1.0}description": "Gym class featuring a brown fox and lazy dog",
-  "{http://www.alfresco.org/model/content/1.0}title": "The quick brown fox jumps over the lazy dog",
-  "{http://www.alfresco.org/model/content/1.0}taggable": "test1,test2,test3"
+  "sys:stringTaggingSeparators": ";,',|",
+  "{http://www.alfresco.org/model/content/1.0}taggable": "tag1;tag2;tag3"
 }

--- a/repository/src/test/resources/quick/quick.tagging_metadata_enable_false.json
+++ b/repository/src/test/resources/quick/quick.tagging_metadata_enable_false.json
@@ -1,5 +1,5 @@
 {
   "sys:enableStringTagging": "false",
-  "sys:stringTaggingSeparators": ";,',|",
+  "sys:stringTaggingSeparators": ";,\",\",\\|",
   "{http://www.alfresco.org/model/content/1.0}taggable": "tag1;tag2;tag3"
 }


### PR DESCRIPTION
Originally https://github.com/Alfresco/alfresco-repository/pull/1055 on the old projects. It was not possible approve and to merge Adina's PR at the time.