### PR TITLE
MNT-21967 - ClassCastException when using CMIS query with SCORE() fun…

### DIFF
--- a/repository/src/main/java/org/alfresco/opencmis/search/CMISResultSetRow.java
+++ b/repository/src/main/java/org/alfresco/opencmis/search/CMISResultSetRow.java
@@ -177,13 +177,13 @@ public class CMISResultSetRow implements ResultSetRow
         context.setScore(getScore());
         for (Column column : query.getColumns())
         {
-            // When an SCORE selector is included, score must be adapted to range 0..1 due to CMIS specification
-            if (column.getFunction()!= null && column.getFunction().getName().equals(Score.NAME)) 
+            if (column.getAlias().equals(columnName))
             {
-                return getNormalisedScore();
-            }
-            else if (column.getAlias().equals(columnName))
-            {
+                //When an SCORE selector is included, score must be adapted to range 0..1 due to CMIS specification
+                if (column.getFunction()!= null && column.getFunction().getName().equals(Score.NAME)) 
+                {
+                    return getNormalisedScore();
+                }
                 return column.getFunction().getValue(column.getFunctionArguments(), context);
             }
             // Special case for one selector - ignore any table aliases


### PR DESCRIPTION
…ction

* Added missing validation before if columnName is the expected column
before normalizing value to float, in case the column is Score