### PR TITLE
Feature/repo 5395 backport new query acc optimisations

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/search/SearchApiWebscript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/SearchApiWebscript.java
@@ -143,6 +143,7 @@ public class SearchApiWebscript extends AbstractWebScript implements RecognizedP
     
                 webScriptResponse.addHeader("X-Response-Stats", sb.toString());
             }
+
             //Write response
             setResponse(webScriptResponse, DEFAULT_SUCCESS);
             renderJsonResponse(webScriptResponse, toRender, assistant.getJsonHelper());

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBStats.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBStats.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.search.impl.querymodel.impl.db;
+
+import org.springframework.util.StopWatch;
+
+public final class DBStats
+{
+    public static final ThreadLocal<StopWatch> QUERY_STOPWATCH = new ThreadLocal<StopWatch>();
+    public static final ThreadLocal<SingleTaskRestartableWatch> ACL_READ_STOPWATCH = new ThreadLocal<SingleTaskRestartableWatch>();
+    public static final ThreadLocal<SingleTaskRestartableWatch> ACL_OWNER_STOPWATCH = new ThreadLocal<SingleTaskRestartableWatch>();
+    public static final ThreadLocal<SingleTaskRestartableWatch> HANDLER_STOPWATCH = new ThreadLocal<SingleTaskRestartableWatch>();
+    
+    private DBStats() {}
+    
+    public static void resetStopwatches() {
+        QUERY_STOPWATCH.set(new StopWatch());
+        HANDLER_STOPWATCH.set(new SingleTaskRestartableWatch("tot"));
+        ACL_READ_STOPWATCH.set(new SingleTaskRestartableWatch("acl"));
+        ACL_OWNER_STOPWATCH.set(new SingleTaskRestartableWatch("own"));
+    }
+    
+    public static StopWatch queryStopWatch() {
+        return QUERY_STOPWATCH.get();
+    }
+    
+    public static SingleTaskRestartableWatch aclReadStopWatch() {
+        return ACL_READ_STOPWATCH.get();
+    }
+    
+    public static SingleTaskRestartableWatch aclOwnerStopWatch() {
+        return ACL_OWNER_STOPWATCH.get();
+    }
+    
+    public static SingleTaskRestartableWatch handlerStopWatch() {
+        return HANDLER_STOPWATCH.get();
+    }
+}
+
+

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/SingleTaskRestartableWatch.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/SingleTaskRestartableWatch.java
@@ -1,0 +1,76 @@
+package org.alfresco.repo.search.impl.querymodel.impl.db;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+/*-
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+@NotThreadSafe
+public class SingleTaskRestartableWatch
+{
+    private final String name;
+
+    private long startTimeNanos;
+    private long totalTimeNanos;
+
+    public SingleTaskRestartableWatch(String name)
+    {
+        this.name = name;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void start()
+    {
+        startTimeNanos = System.nanoTime();
+    }
+
+    public void stop()
+    {
+        long elapsedNanos = System.nanoTime() - startTimeNanos;
+        totalTimeNanos += elapsedNanos;
+    }
+
+    public long getTotalTimeNanos()
+    {
+        return totalTimeNanos;
+    }
+
+    public long getTotalTimeMicros()
+    {
+        return TimeUnit.NANOSECONDS.toMicros(totalTimeNanos);
+    }
+
+    public long getTotalTimeMillis()
+    {
+        return TimeUnit.NANOSECONDS.toMillis(totalTimeNanos);
+    }
+}

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-SqlMap.xml
@@ -5,7 +5,7 @@
 <mapper namespace="alfresco.metadata.query">
 
   <select id="select_byDynamicQuery" fetchSize="200" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultMap="alfresco.node.result_Node">
-      <include refid="sql_select_byDynamicQuery"/>   
+    <include refid="sql_select_byDynamicQuery"/>   
   </select>
 
 </mapper>

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -117,6 +117,7 @@
         <property name="nodeDAO" ref="nodeDAO"/>
         <property name="tenantService" ref="tenantService"/>
         <property name="nodesCache" ref="node.nodesCache"/>
+        <property name="aspectsCache" ref="node.aspectsCache"/>
         <property name="propertiesCache" ref="node.propertiesCache"/>
         <property name="metadataIndexCheck2">
             <ref bean="metadataQueryIndexesCheck2" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -108,7 +108,6 @@
     
     <bean id="search.dbQueryEngineImpl" class="org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine" >
         <property name="permissionService" ref="permissionService"/>
-        <property name="ownableService" ref="ownableService"/>
         <property name="dictionaryService" ref="dictionaryService" />
         <property name="namespaceService" ref="namespaceService" />
         <property name="sqlSessionTemplate" ref="repoSqlSessionTemplate"/>
@@ -119,6 +118,7 @@
         <property name="nodesCache" ref="node.nodesCache"/>
         <property name="aspectsCache" ref="node.aspectsCache"/>
         <property name="propertiesCache" ref="node.propertiesCache"/>
+        <property name="aclCrudDAO" ref="aclCrudDAO"/>
         <property name="metadataIndexCheck2">
             <ref bean="metadataQueryIndexesCheck2" />
         </property>

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -26,7 +26,6 @@
 package org.alfresco.repo.search.impl.querymodel.impl.db;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,18 +36,23 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+import org.alfresco.repo.cache.SimpleCache;
 import org.alfresco.repo.cache.lookup.EntityLookupCache;
 import org.alfresco.repo.domain.node.Node;
 import org.alfresco.repo.domain.node.NodeEntity;
+import org.alfresco.repo.domain.node.NodeVersionKey;
+import org.alfresco.repo.domain.node.StoreEntity;
 import org.alfresco.repo.search.impl.querymodel.QueryOptions;
 import org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine.NodePermissionAssessor;
 import org.alfresco.repo.security.permissions.impl.acegi.FilteringResultSet;
-import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
+import org.alfresco.service.namespace.QName;
 import org.apache.ibatis.executor.result.DefaultResultContext;
 import org.apache.ibatis.session.ResultContext;
 import org.apache.ibatis.session.ResultHandler;
@@ -66,20 +70,28 @@ public class DBQueryEngineTest
     private DBQuery dbQuery;
     private ResultContext<Node> resultContext;
     private QueryOptions options;
-    private EntityLookupCache<Long, Node, NodeRef> nodesCache;
+    private SimpleCache<NodeVersionKey, Map<QName, Serializable>> propertiesCache;
+    private SimpleCache<Serializable, Serializable> nodesCache;
 
+    @SuppressWarnings("unchecked")
     @Before
     public void setup()
     {
-        template = mock(SqlSessionTemplate.class);
-        nodesCache = mock(EntityLookupCache.class);
         engine = new DBQueryEngine();
-        engine.setSqlSessionTemplate(template);
-        engine.setNodesCache(nodesCache);
         assessor = mock(NodePermissionAssessor.class);
         dbQuery = mock(DBQuery.class);
         resultContext = spy(new DefaultResultContext<>());
         options = createQueryOptions();
+
+        template = mock(SqlSessionTemplate.class);
+        engine.setSqlSessionTemplate(template);
+
+        propertiesCache = mock(SimpleCache.class);
+        engine.setPropertiesCache(propertiesCache);
+        
+        engine.nodesCache = mock(EntityLookupCache.class);
+        
+        DBStats.resetStopwatches();
     }
     
     @Test
@@ -266,7 +278,12 @@ public class DBQueryEngineTest
     private Node createNode(int id) 
     {
         Node node = spy(NodeEntity.class);
+
         when(node.getId()).thenReturn((long)id);
+
+        StoreEntity store = mock(StoreEntity.class);
+        when(node.getStore()).thenReturn(store );
+        
         return node;
     }
     

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -38,15 +39,16 @@ import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.alfresco.repo.cache.SimpleCache;
 import org.alfresco.repo.cache.lookup.EntityLookupCache;
 import org.alfresco.repo.domain.node.Node;
-import org.alfresco.repo.domain.node.NodeEntity;
 import org.alfresco.repo.domain.node.NodeVersionKey;
 import org.alfresco.repo.domain.node.StoreEntity;
+import org.alfresco.repo.domain.permissions.AuthorityEntity;
 import org.alfresco.repo.search.impl.querymodel.QueryOptions;
 import org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine.NodePermissionAssessor;
 import org.alfresco.repo.security.permissions.impl.acegi.FilteringResultSet;
@@ -71,7 +73,6 @@ public class DBQueryEngineTest
     private ResultContext<Node> resultContext;
     private QueryOptions options;
     private SimpleCache<NodeVersionKey, Map<QName, Serializable>> propertiesCache;
-    private SimpleCache<Serializable, Serializable> nodesCache;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -153,7 +154,7 @@ public class DBQueryEngineTest
     }
     
     @Test
-    public void shouldNotConsiderInaccessibleNodesInResultSet()
+    public void shouldResultSetHaveCorrectAmountOfRequiredNodesWhenSomeAreExcludedDueToDeclinedPermission()
     {
         withMaxItems(5);
         List<Node> nodes = createNodes(20);
@@ -202,19 +203,7 @@ public class DBQueryEngineTest
         assertEquals(0, result.length());
         verify(resultContext).stop();
     }
-    
-    @Test
-    public void shouldNodePermissionAssessorLimitisBeOverridenWhenSetValuesAreProvidedInQueryOptions()
-    {
-        when(options.getMaxPermissionChecks()).thenReturn(2000);
-        when(options.getMaxPermissionCheckTimeMillis()).thenReturn(20000L);
-        
-        NodePermissionAssessor assessor = engine.createAssessor(options);
-        
-        assertEquals(assessor.getMaxPermissionChecks(), 2000);
-        assertEquals(assessor.getMaxPermissionCheckTimeMillis(), 20000L);
-    }
-        
+            
     private void prepareTemplate(DBQuery dbQuery, List<Node> nodes)
     {
         doAnswer(invocation -> {
@@ -277,7 +266,7 @@ public class DBQueryEngineTest
     
     private Node createNode(int id) 
     {
-        Node node = spy(NodeEntity.class);
+        Node node = spy(Node.class);
 
         when(node.getId()).thenReturn((long)id);
 

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/NodePermissionAssessorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/NodePermissionAssessorTest.java
@@ -27,10 +27,18 @@ package org.alfresco.repo.search.impl.querymodel.impl.db;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.alfresco.repo.domain.node.Node;
+import org.alfresco.repo.domain.permissions.AclCrudDAO;
 import org.alfresco.repo.search.impl.querymodel.impl.db.DBQueryEngine.NodePermissionAssessor;
+import org.alfresco.service.cmr.security.PermissionService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -65,7 +73,6 @@ public class NodePermissionAssessorTest
         performChecks(20);
         
         assertTrue(assessor.shouldQuitChecks());
-        verify(assessor, times(5)).isReallyIncluded(node);
     }
     
     @Test
@@ -104,7 +111,14 @@ public class NodePermissionAssessorTest
     
     private NodePermissionAssessor createAssessor()
     {
-        NodePermissionAssessor assessor = spy(new DBQueryEngine().new NodePermissionAssessor());
+        AclCrudDAO aclCrudDAO = mock(AclCrudDAO.class);
+        PermissionService permissionService = mock(PermissionService.class);
+
+        DBQueryEngine engine = new DBQueryEngine();
+        engine.setPermissionService(permissionService);
+        engine.setAclCrudDAO(aclCrudDAO);
+        
+        NodePermissionAssessor assessor = spy(engine.new NodePermissionAssessor());
         doReturn(true).when(assessor).isReallyIncluded(any(Node.class));
         return assessor;
     }


### PR DESCRIPTION
This PR represents the result of the code backport from [feature/repo-5354_demo-a](https://github.com/Alfresco/alfresco-enterprise-repo/tree/feature/repo-5354_demo-a). The new changes include: better stats reporting via API and a point of extension to support the denormalised owner column feature which is mostly implemented on the ent. repo version ([see companion PR](https://github.com/Alfresco/alfresco-enterprise-repo/pull/65)).