### PR TITLE
MNT-22036 : REST API always applies versioning

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -2914,6 +2914,7 @@ public class NodesImpl implements Nodes
         String versionComment = null;
         String relativePath = null;
         String renditionNames = null;
+        String versioningState = null;
 
         Map<String, Object> qnameStrProps = new HashMap<>();
         Map<QName, Serializable> properties = null;
@@ -2969,6 +2970,10 @@ public class NodesImpl implements Nodes
 
                 case "renditions":
                     renditionNames = getStringOrNull(field.getValue());
+                    break;
+
+            case "versionstate":
+                    versioningState = getStringOrNull(field.getValue());
                     break;
 
                 default:
@@ -3042,11 +3047,27 @@ public class NodesImpl implements Nodes
                     throw new ConstraintViolatedException(fileName + " already exists.");
                 }
             }
-            
+
             // Note: pending REPO-159, we currently auto-enable versioning on new upload (but not when creating empty file)
             if (versionMajor == null)
             {
                 versionMajor = true;
+            }
+
+            // MNT-22036 add versioningState property for newly created nodes.
+            if (null != versioningState)
+            {
+                switch (versioningState)
+                {
+                case "none":
+                    versionMajor = null;
+                    break;
+                case "major":
+                    versionMajor = true;
+                    break;
+                default:
+                    versionMajor = false;
+                }
             }
 
             // Create a new file.

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -2972,7 +2972,7 @@ public class NodesImpl implements Nodes
                     renditionNames = getStringOrNull(field.getValue());
                     break;
 
-            case "versionstate":
+            case "versioningstate":
                     versioningState = getStringOrNull(field.getValue());
                     break;
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -2984,11 +2984,16 @@ public class NodesImpl implements Nodes
                 case "renditions":
                     renditionNames = getStringOrNull(field.getValue());
                     break;
-
-            case "versioningenabled":
+                case "versioningenabled":
                     String versioningEnabledStringValue = getStringOrNull(field.getValue());
                     if (null != versioningEnabledStringValue)
                     {
+                        // MNT-22036 versioningenabled parameter was added to disable versioning of newly created nodes.
+                        // The default API mechanism should not be changed/affected.
+                        // Versioning is enabled by default when creating a node using form-data.
+                        // To preserve this, versioningEnabled value must be 'true' for any given value typo/valuesNotSupported (except case-insensitive 'false')
+                        // .equalsIgnoreCase("false") will return true only when the input value is 'false'
+                        // !.equalsIgnoreCase("false") will return false only when the input value is 'false'
                         versioningEnabled = !versioningEnabledStringValue.equalsIgnoreCase("false");
                     }
                     break;

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -1848,6 +1848,19 @@ public class NodesImpl implements Nodes
         {
             versionMajor = Boolean.valueOf(str);
         }
+        String versioningEnabledStringValue = parameters.getParameter("versioningEnabled");
+        if(null != versioningEnabledStringValue)
+        {
+            boolean versioningEnabled = Boolean.parseBoolean(versioningEnabledStringValue);
+            if(versioningEnabled)
+            {
+                versionMajor = (null != versionMajor) ? versionMajor : true;
+            }
+            else
+            {
+                versionMajor = null;
+            }
+        }
         String versionComment = parameters.getParameter(PARAM_VERSION_COMMENT);
 
         // Create the node
@@ -2914,7 +2927,7 @@ public class NodesImpl implements Nodes
         String versionComment = null;
         String relativePath = null;
         String renditionNames = null;
-        String versioningState = null;
+        boolean versioningEnabled = true;
 
         Map<String, Object> qnameStrProps = new HashMap<>();
         Map<QName, Serializable> properties = null;
@@ -2972,8 +2985,12 @@ public class NodesImpl implements Nodes
                     renditionNames = getStringOrNull(field.getValue());
                     break;
 
-            case "versioningstate":
-                    versioningState = getStringOrNull(field.getValue());
+            case "versioningenabled":
+                    String versioningEnabledStringValue = getStringOrNull(field.getValue());
+                    if(null != versioningEnabledStringValue)
+                    {
+                        versioningEnabled = !versioningEnabledStringValue.equalsIgnoreCase("false");
+                    }
                     break;
 
                 default:
@@ -3053,22 +3070,8 @@ public class NodesImpl implements Nodes
             {
                 versionMajor = true;
             }
-
-            // MNT-22036 add versioningState property for newly created nodes.
-            if (null != versioningState)
-            {
-                switch (versioningState)
-                {
-                case "none":
-                    versionMajor = null;
-                    break;
-                case "major":
-                    versionMajor = true;
-                    break;
-                default:
-                    versionMajor = false;
-                }
-            }
+            // MNT-22036 add versioningEnabled property for newly created nodes.
+            versionMajor = versioningEnabled ? versionMajor : null;
 
             // Create a new file.
             NodeRef nodeRef = createNewFile(parentNodeRef, fileName, nodeTypeQName, content, properties, assocTypeQName, parameters, versionMajor, versionComment);

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -1849,10 +1849,10 @@ public class NodesImpl implements Nodes
             versionMajor = Boolean.valueOf(str);
         }
         String versioningEnabledStringValue = parameters.getParameter("versioningEnabled");
-        if(null != versioningEnabledStringValue)
+        if (null != versioningEnabledStringValue)
         {
             boolean versioningEnabled = Boolean.parseBoolean(versioningEnabledStringValue);
-            if(versioningEnabled)
+            if (versioningEnabled)
             {
                 versionMajor = (null != versionMajor) ? versionMajor : true;
             }
@@ -2987,7 +2987,7 @@ public class NodesImpl implements Nodes
 
             case "versioningenabled":
                     String versioningEnabledStringValue = getStringOrNull(field.getValue());
-                    if(null != versioningEnabledStringValue)
+                    if (null != versioningEnabledStringValue)
                     {
                         versioningEnabled = !versioningEnabledStringValue.equalsIgnoreCase("false");
                     }

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -5626,7 +5626,7 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         // 6:  majorVersion true    -  versioningEnabled true     Expect: MAJOR version
         // 7:  majorVersion false   -  versioningEnabled true     Expect: Minor version
         // 8:  majorVersion not set -  versioningEnabled False    Expect: versioning disabled
-        // 9:  majorVersion not set -  versioningEnabled False1   Expect: MAJOR version
+        // 9:  majorVersion not set -  versioningEnabled invalid   Expect: MAJOR version
 
         // Scenario 1:
         String fileName = "myfile" + UUID.randomUUID() + ".txt";
@@ -5740,7 +5740,7 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         // Scenario 9:
         fileName = "myfile" + UUID.randomUUID() + ".txt";
         multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
-        multiPartBuilder.setVersioningEnabled("False1");
+        multiPartBuilder.setVersioningEnabled("invalid");
 
         reqBody = multiPartBuilder.build();
         response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
@@ -5766,7 +5766,7 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         // 6: majorVersion true    -  versioningEnabled true     Expect: MAJOR version
         // 7: majorVersion false   -  versioningEnabled true     Expect: Minor version
         // 8: majorVersion not set -  versioningEnabled False    Expect: versioning disabled
-        // 9: majorVersion not set -  versioningEnabled False1   Expect: versioning disabled
+        // 9: majorVersion not set -  versioningEnabled invalid   Expect: versioning disabled
         // 10 majorVersion not set -  versioningenabled true     Expect: versioning disabled
 
         Document d1 = new Document();
@@ -5869,7 +5869,7 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         //Scenario 9:
         d1.setName("testDoc" + UUID.randomUUID());
         requestHeaders = new HashMap<>();
-        requestHeaders.put("versioningEnabled","False1");
+        requestHeaders.put("versioningEnabled","invalid");
 
         response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
         documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -5612,6 +5612,124 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertTrue(((ArrayList) (propUpdateResponse.get("custom:locations"))).size() == 1);
     }
 
+    @Test
+    public void versioningStatePropetyMultipartUploadTest() throws Exception
+    {
+        setRequestContext(user1);
+        String myNodeId = getMyNodeId();
+
+        // Scenario 1 majorVersion and versionState multipart values are not set.
+        String fileName = "myfile" + UUID.randomUUID() + ".txt";
+        File file = getResourceFile("quick-2.pdf");
+        MultiPartBuilder multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+
+        MultiPartRequest reqBody = multiPartBuilder.build();
+        HttpResponse response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        Document documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        // Default behaviour, expect to be MAJOR Version 1.0
+        Map<String, Object> documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 2 majorVersion is not set versionState is set to none.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningState("none");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 3 majorVersion is set to true and versionState is set to none.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(true);
+        multiPartBuilder.setVersioningState("none");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 4 majorVersion is set to false and versionState is set to none.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(false);
+        multiPartBuilder.setVersioningState("none");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 5 majorVersion is not set versionState is set to minor.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningState("minor");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MINOR", documentProperties.get("cm:versionType"));
+        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 6 majorVersion is set to true and versionState is set to minor.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(true);
+        multiPartBuilder.setVersioningState("minor");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MINOR", documentProperties.get("cm:versionType"));
+        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 7 majorVersion is not set versionState is set to major.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningState("major");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 8 majorVersion is set to false and versionState is set to major.
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(false);
+        multiPartBuilder.setVersioningState("major");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+    }
+
     @Test public void testAuditableProperties() throws Exception
     {
         setRequestContext(user1);

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -5613,12 +5613,22 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
     }
 
     @Test
-    public void versioningStatePropetyMultipartUploadTest() throws Exception
+    public void versioningEnabledMultipartNodeCreationTest() throws Exception
     {
         setRequestContext(user1);
         String myNodeId = getMyNodeId();
+        // Test Scenarios:
+        // 1:  majorVersion not set -  versioningEnabled not set  Expect: MAJOR version
+        // 2:  majorVersion not set -  versioningEnabled false    Expect: versioning disabled
+        // 3:  majorVersion true    -  versioningEnabled false    Expect: versioning disabled
+        // 4:  majorVersion false   -  versioningEnabled false    Expect: versioning disabled
+        // 5:  majorVersion not set -  versioningEnabled true     Expect: MAJOR version
+        // 6:  majorVersion true    -  versioningEnabled true     Expect: MAJOR version
+        // 7:  majorVersion false   -  versioningEnabled true     Expect: Minor version
+        // 8:  majorVersion not set -  versioningEnabled False    Expect: versioning disabled
+        // 9:  majorVersion not set -  versioningEnabled False1   Expect: MAJOR version
 
-        // Scenario 1 majorVersion and versionState multipart values are not set.
+        // Scenario 1:
         String fileName = "myfile" + UUID.randomUUID() + ".txt";
         File file = getResourceFile("quick-2.pdf");
         MultiPartBuilder multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
@@ -5633,10 +5643,10 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertEquals("MAJOR", documentProperties.get("cm:versionType"));
         assertEquals("1.0", documentProperties.get("cm:versionLabel"));
 
-        // Scenario 2 majorVersion is not set versionState is set to none.
+        // Scenario 2:
         fileName = "myfile" + UUID.randomUUID() + ".txt";
         multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
-        multiPartBuilder.setVersioningState("none");
+        multiPartBuilder.setVersioningEnabled("false");
 
         reqBody = multiPartBuilder.build();
         response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
@@ -5645,11 +5655,11 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         documentProperties = documentResponse.getProperties();
         assertNull(documentProperties);
 
-        // Scenario 3 majorVersion is set to true and versionState is set to none.
+        // Scenario 3:
         fileName = "myfile" + UUID.randomUUID() + ".txt";
         multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
         multiPartBuilder.setMajorVersion(true);
-        multiPartBuilder.setVersioningState("none");
+        multiPartBuilder.setVersioningEnabled("false");
 
         reqBody = multiPartBuilder.build();
         response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
@@ -5658,11 +5668,11 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         documentProperties = documentResponse.getProperties();
         assertNull(documentProperties);
 
-        // Scenario 4 majorVersion is set to false and versionState is set to none.
+        // Scenario 4:
         fileName = "myfile" + UUID.randomUUID() + ".txt";
         multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
         multiPartBuilder.setMajorVersion(false);
-        multiPartBuilder.setVersioningState("none");
+        multiPartBuilder.setVersioningEnabled("false");
 
         reqBody = multiPartBuilder.build();
         response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
@@ -5671,39 +5681,10 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         documentProperties = documentResponse.getProperties();
         assertNull(documentProperties);
 
-        // Scenario 5 majorVersion is not set versionState is set to minor.
+        // Scenario 5:
         fileName = "myfile" + UUID.randomUUID() + ".txt";
         multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
-        multiPartBuilder.setVersioningState("minor");
-
-        reqBody = multiPartBuilder.build();
-        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
-        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
-
-        documentProperties = documentResponse.getProperties();
-        assertEquals(2, documentProperties.size());
-        assertEquals("MINOR", documentProperties.get("cm:versionType"));
-        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
-
-        // Scenario 6 majorVersion is set to true and versionState is set to minor.
-        fileName = "myfile" + UUID.randomUUID() + ".txt";
-        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
-        multiPartBuilder.setMajorVersion(true);
-        multiPartBuilder.setVersioningState("minor");
-
-        reqBody = multiPartBuilder.build();
-        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
-        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
-
-        documentProperties = documentResponse.getProperties();
-        assertEquals(2, documentProperties.size());
-        assertEquals("MINOR", documentProperties.get("cm:versionType"));
-        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
-
-        // Scenario 7 majorVersion is not set versionState is set to major.
-        fileName = "myfile" + UUID.randomUUID() + ".txt";
-        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
-        multiPartBuilder.setVersioningState("major");
+        multiPartBuilder.setVersioningEnabled("true");
 
         reqBody = multiPartBuilder.build();
         response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
@@ -5714,11 +5695,11 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertEquals("MAJOR", documentProperties.get("cm:versionType"));
         assertEquals("1.0", documentProperties.get("cm:versionLabel"));
 
-        // Scenario 8 majorVersion is set to false and versionState is set to major.
+        // Scenario 6:
         fileName = "myfile" + UUID.randomUUID() + ".txt";
         multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
-        multiPartBuilder.setMajorVersion(false);
-        multiPartBuilder.setVersioningState("major");
+        multiPartBuilder.setMajorVersion(true);
+        multiPartBuilder.setVersioningEnabled("true");
 
         reqBody = multiPartBuilder.build();
         response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
@@ -5728,6 +5709,184 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertEquals(2, documentProperties.size());
         assertEquals("MAJOR", documentProperties.get("cm:versionType"));
         assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 7:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(false);
+        multiPartBuilder.setVersioningEnabled("true");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MINOR", documentProperties.get("cm:versionType"));
+        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 8:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningEnabled("False");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 9:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningEnabled("False1");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+    }
+
+    @Test
+    public void versioningEnabledJSONNodeCreationTest() throws Exception
+    {
+        setRequestContext(user1);
+        String myNodeId = getMyNodeId();
+
+        // Test Scenarios:
+        // 1: majorVersion not set -  versioningEnabled not set  Expect: versioning disabled
+        // 2: majorVersion not set -  versioningEnabled false    Expect: versioning disabled
+        // 3: majorVersion true    -  versioningEnabled false    Expect: versioning disabled
+        // 4: majorVersion false   -  versioningEnabled false    Expect: versioning disabled
+        // 5: majorVersion not set -  versioningEnabled true     Expect: MAJOR version
+        // 6: majorVersion true    -  versioningEnabled true     Expect: MAJOR version
+        // 7: majorVersion false   -  versioningEnabled true     Expect: Minor version
+        // 8: majorVersion not set -  versioningEnabled False    Expect: versioning disabled
+        // 9: majorVersion not set -  versioningEnabled False1   Expect: versioning disabled
+        // 10 majorVersion not set -  versioningenabled true     Expect: versioning disabled
+
+        Document d1 = new Document();
+        Map<String, String> requestHeaders = new HashMap<>();
+
+        //Scenario 1:
+        d1.setName("testDoc" + UUID.randomUUID());
+        d1.setNodeType(TYPE_CM_CONTENT);
+
+        HttpResponse response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        Document documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        Map<String, Object> documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 2:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","false");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 3:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","false");
+        requestHeaders.put("majorVersion","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 4:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","false");
+        requestHeaders.put("majorVersion","false");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 5:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        //Scenario 6:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","true");
+        requestHeaders.put("majorVersion","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        //Scenario 7:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","true");
+        requestHeaders.put("majorVersion","false");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MINOR", documentProperties.get("cm:versionType"));
+        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
+
+        //Scenario 8:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","False");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 9:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","False1");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 10:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningenabled","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
     }
 
     @Test public void testAuditableProperties() throws Exception

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
@@ -56,7 +56,7 @@ public class MultiPartBuilder
     private String updateNodeRef;
     private String description;
     private String contentTypeQNameStr;
-    private String versioningState;
+    private String versioningEnabled;
     private List<String> aspects = Collections.emptyList();
     private Boolean majorVersion;
     private Boolean overwrite;
@@ -76,7 +76,7 @@ public class MultiPartBuilder
         this.updateNodeRef = that.updateNodeRef;
         this.description = that.description;
         this.contentTypeQNameStr = that.contentTypeQNameStr;
-        this.versioningState = that.versioningState;
+        this.versioningEnabled = that.versioningEnabled;
         this.aspects = new ArrayList<>(that.aspects);
         this.majorVersion = that.majorVersion;
         this.overwrite = that.overwrite;
@@ -126,9 +126,9 @@ public class MultiPartBuilder
         return this;
     }
 
-    public MultiPartBuilder setVersioningState(String versioningState)
+    public MultiPartBuilder setVersioningEnabled(String versioningEnabled)
     {
-        this.versioningState = versioningState;
+        this.versioningEnabled = versioningEnabled;
         return this;
     }
 
@@ -285,7 +285,7 @@ public class MultiPartBuilder
         addPartIfNotNull(parts, "updatenoderef", updateNodeRef);
         addPartIfNotNull(parts, "description", description);
         addPartIfNotNull(parts, "contenttype", contentTypeQNameStr);
-        addPartIfNotNull(parts, "versioningstate", versioningState);
+        addPartIfNotNull(parts, "versioningenabled", versioningEnabled);
         addPartIfNotNull(parts, "aspects", getCommaSeparated(aspects));
         addPartIfNotNull(parts, "majorversion", majorVersion);
         addPartIfNotNull(parts, "overwrite", overwrite);

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
@@ -43,7 +43,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * <i><b>multipart/form-data</b></i> builder.
@@ -57,6 +56,7 @@ public class MultiPartBuilder
     private String updateNodeRef;
     private String description;
     private String contentTypeQNameStr;
+    private String versioningState;
     private List<String> aspects = Collections.emptyList();
     private Boolean majorVersion;
     private Boolean overwrite;
@@ -76,6 +76,7 @@ public class MultiPartBuilder
         this.updateNodeRef = that.updateNodeRef;
         this.description = that.description;
         this.contentTypeQNameStr = that.contentTypeQNameStr;
+        this.versioningState = that.versioningState;
         this.aspects = new ArrayList<>(that.aspects);
         this.majorVersion = that.majorVersion;
         this.overwrite = that.overwrite;
@@ -122,6 +123,12 @@ public class MultiPartBuilder
     public MultiPartBuilder setContentTypeQNameStr(String contentTypeQNameStr)
     {
         this.contentTypeQNameStr = contentTypeQNameStr;
+        return this;
+    }
+
+    public MultiPartBuilder setVersioningState(String versioningState)
+    {
+        this.versioningState = versioningState;
         return this;
     }
 
@@ -278,6 +285,7 @@ public class MultiPartBuilder
         addPartIfNotNull(parts, "updatenoderef", updateNodeRef);
         addPartIfNotNull(parts, "description", description);
         addPartIfNotNull(parts, "contenttype", contentTypeQNameStr);
+        addPartIfNotNull(parts, "versioningstate", versioningState);
         addPartIfNotNull(parts, "aspects", getCommaSeparated(aspects));
         addPartIfNotNull(parts, "majorversion", majorVersion);
         addPartIfNotNull(parts, "overwrite", overwrite);


### PR DESCRIPTION
   Add versionState form-data property to POST nodes/{nodeId}/children multipart upload.
   Add versionState to MultiPartBuilder.
   Add tests for multipart upload