### PR TITLE
MNT-22036 : REST API always applies versioning

### DIFF
--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -5632,7 +5632,6 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
 
         // Default behaviour, expect to be MAJOR Version 1.0
         Map<String, Object> documentProperties = documentResponse.getProperties();
-        assertEquals(2, documentProperties.size());
         assertEquals("MAJOR", documentProperties.get("cm:versionType"));
         assertEquals("1.0", documentProperties.get("cm:versionLabel"));
 
@@ -5684,7 +5683,6 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
 
         documentProperties = documentResponse.getProperties();
-        assertEquals(2, documentProperties.size());
         assertEquals("MAJOR", documentProperties.get("cm:versionType"));
         assertEquals("1.0", documentProperties.get("cm:versionLabel"));
 
@@ -5699,7 +5697,6 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
 
         documentProperties = documentResponse.getProperties();
-        assertEquals(2, documentProperties.size());
         assertEquals("MAJOR", documentProperties.get("cm:versionType"));
         assertEquals("1.0", documentProperties.get("cm:versionLabel"));
 
@@ -5714,7 +5711,6 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
 
         documentProperties = documentResponse.getProperties();
-        assertEquals(2, documentProperties.size());
         assertEquals("MINOR", documentProperties.get("cm:versionType"));
         assertEquals("0.1", documentProperties.get("cm:versionLabel"));
 

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -5605,6 +5605,283 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertTrue(((ArrayList) (propUpdateResponse.get("custom:locations"))).size() == 1);
     }
 
+    @Test
+    public void versioningEnabledMultipartNodeCreationTest() throws Exception
+    {
+        setRequestContext(user1);
+        String myNodeId = getMyNodeId();
+        // Test Scenarios:
+        // 1:  majorVersion not set -  versioningEnabled not set  Expect: MAJOR version
+        // 2:  majorVersion not set -  versioningEnabled false    Expect: versioning disabled
+        // 3:  majorVersion true    -  versioningEnabled false    Expect: versioning disabled
+        // 4:  majorVersion false   -  versioningEnabled false    Expect: versioning disabled
+        // 5:  majorVersion not set -  versioningEnabled true     Expect: MAJOR version
+        // 6:  majorVersion true    -  versioningEnabled true     Expect: MAJOR version
+        // 7:  majorVersion false   -  versioningEnabled true     Expect: Minor version
+        // 8:  majorVersion not set -  versioningEnabled False    Expect: versioning disabled
+        // 9:  majorVersion not set -  versioningEnabled invalid   Expect: MAJOR version
+
+        // Scenario 1:
+        String fileName = "myfile" + UUID.randomUUID() + ".txt";
+        File file = getResourceFile("quick-2.pdf");
+        MultiPartBuilder multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+
+        MultiPartRequest reqBody = multiPartBuilder.build();
+        HttpResponse response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        Document documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        // Default behaviour, expect to be MAJOR Version 1.0
+        Map<String, Object> documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 2:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningEnabled("false");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 3:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(true);
+        multiPartBuilder.setVersioningEnabled("false");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 4:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(false);
+        multiPartBuilder.setVersioningEnabled("false");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 5:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningEnabled("true");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 6:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(true);
+        multiPartBuilder.setVersioningEnabled("true");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 7:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setMajorVersion(false);
+        multiPartBuilder.setVersioningEnabled("true");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals(2, documentProperties.size());
+        assertEquals("MINOR", documentProperties.get("cm:versionType"));
+        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
+
+        // Scenario 8:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningEnabled("False");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        // Scenario 9:
+        fileName = "myfile" + UUID.randomUUID() + ".txt";
+        multiPartBuilder = MultiPartBuilder.create().setFileData(new FileData(fileName, file));
+        multiPartBuilder.setVersioningEnabled("invalid");
+
+        reqBody = multiPartBuilder.build();
+        response = post(getNodeChildrenUrl(myNodeId), reqBody.getBody(), null, reqBody.getContentType(), 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+    }
+
+    @Test
+    public void versioningEnabledJSONNodeCreationTest() throws Exception
+    {
+        setRequestContext(user1);
+        String myNodeId = getMyNodeId();
+
+        // Test Scenarios:
+        // 1: majorVersion not set -  versioningEnabled not set  Expect: versioning disabled
+        // 2: majorVersion not set -  versioningEnabled false    Expect: versioning disabled
+        // 3: majorVersion true    -  versioningEnabled false    Expect: versioning disabled
+        // 4: majorVersion false   -  versioningEnabled false    Expect: versioning disabled
+        // 5: majorVersion not set -  versioningEnabled true     Expect: MAJOR version
+        // 6: majorVersion true    -  versioningEnabled true     Expect: MAJOR version
+        // 7: majorVersion false   -  versioningEnabled true     Expect: Minor version
+        // 8: majorVersion not set -  versioningEnabled False    Expect: versioning disabled
+        // 9: majorVersion not set -  versioningEnabled invalid   Expect: versioning disabled
+        // 10 majorVersion not set -  versioningenabled true     Expect: versioning disabled
+
+        Document d1 = new Document();
+        Map<String, String> requestHeaders = new HashMap<>();
+
+        //Scenario 1:
+        d1.setName("testDoc" + UUID.randomUUID());
+        d1.setNodeType(TYPE_CM_CONTENT);
+
+        HttpResponse response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        Document documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        Map<String, Object> documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 2:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","false");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 3:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","false");
+        requestHeaders.put("majorVersion","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 4:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","false");
+        requestHeaders.put("majorVersion","false");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 5:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        //Scenario 6:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","true");
+        requestHeaders.put("majorVersion","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MAJOR", documentProperties.get("cm:versionType"));
+        assertEquals("1.0", documentProperties.get("cm:versionLabel"));
+
+        //Scenario 7:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","true");
+        requestHeaders.put("majorVersion","false");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertEquals("MINOR", documentProperties.get("cm:versionType"));
+        assertEquals("0.1", documentProperties.get("cm:versionLabel"));
+
+        //Scenario 8:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","False");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 9:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningEnabled","invalid");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+
+        //Scenario 10:
+        d1.setName("testDoc" + UUID.randomUUID());
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("versioningenabled","true");
+
+        response = post(getNodeChildrenUrl(myNodeId), toJsonAsStringNonNull(d1),requestHeaders, null, null, 201);
+        documentResponse = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
+
+        documentProperties = documentResponse.getProperties();
+        assertNull(documentProperties);
+    }
+
     @Test public void testAuditableProperties() throws Exception
     {
         setRequestContext(user1);

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/util/MultiPartBuilder.java
@@ -43,7 +43,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * <i><b>multipart/form-data</b></i> builder.
@@ -57,6 +56,7 @@ public class MultiPartBuilder
     private String updateNodeRef;
     private String description;
     private String contentTypeQNameStr;
+    private String versioningEnabled;
     private List<String> aspects = Collections.emptyList();
     private Boolean majorVersion;
     private Boolean overwrite;
@@ -76,6 +76,7 @@ public class MultiPartBuilder
         this.updateNodeRef = that.updateNodeRef;
         this.description = that.description;
         this.contentTypeQNameStr = that.contentTypeQNameStr;
+        this.versioningEnabled = that.versioningEnabled;
         this.aspects = new ArrayList<>(that.aspects);
         this.majorVersion = that.majorVersion;
         this.overwrite = that.overwrite;
@@ -122,6 +123,12 @@ public class MultiPartBuilder
     public MultiPartBuilder setContentTypeQNameStr(String contentTypeQNameStr)
     {
         this.contentTypeQNameStr = contentTypeQNameStr;
+        return this;
+    }
+
+    public MultiPartBuilder setVersioningEnabled(String versioningEnabled)
+    {
+        this.versioningEnabled = versioningEnabled;
         return this;
     }
 
@@ -278,6 +285,7 @@ public class MultiPartBuilder
         addPartIfNotNull(parts, "updatenoderef", updateNodeRef);
         addPartIfNotNull(parts, "description", description);
         addPartIfNotNull(parts, "contenttype", contentTypeQNameStr);
+        addPartIfNotNull(parts, "versioningenabled", versioningEnabled);
         addPartIfNotNull(parts, "aspects", getCommaSeparated(aspects));
         addPartIfNotNull(parts, "majorversion", majorVersion);
         addPartIfNotNull(parts, "overwrite", overwrite);


### PR DESCRIPTION
MNT-22036 : REST API always applies versioning
  Add property boolean versioningEnabled
  Add versioningEnabled to node creation using multipart/form-data
  Add versioningEnabled to node creation using JSON
  Add unit tests for node creation using JSON.
(cherry picked from commit 09c2c950818bc083cc35acf1af3b03920bbd8daa)