### PR TITLE
ACS-778: Fixed IDS authentication component.

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceAuthenticationComponent.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceAuthenticationComponent.java
@@ -25,6 +25,9 @@
  */
 package org.alfresco.repo.security.authentication.identityservice;
 
+import java.net.ConnectException;
+
+import org.alfresco.error.ExceptionStackUtil;
 import org.alfresco.repo.management.subsystems.ActivateableBean;
 import org.alfresco.repo.security.authentication.AbstractAuthenticationComponent;
 import org.alfresco.repo.security.authentication.AuthenticationException;
@@ -90,6 +93,23 @@ public class IdentityServiceAuthenticationComponent extends AbstractAuthenticati
             }
 
             throw new AuthenticationException("Failed to authenticate user against Keycloak.", e);
+        }
+        catch (RuntimeException e)
+        {
+            Throwable cause = ExceptionStackUtil.getCause(e, ConnectException.class);
+            if (cause != null)
+            {
+                if (logger.isWarnEnabled())
+                {
+                    logger.warn("Couldn't connect to Keycloak server to authenticate user. Reason: " + cause.getMessage());
+                }
+                throw new AuthenticationException("Couldn't connect to Keycloak server to authenticate user.", cause);
+            }
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Error occurred while authenticating user against Keycloak. Reason: " + e.getMessage());
+            }
+            throw new AuthenticationException("Error occurred while authenticating user against Keycloak.", e);
         }
     }
 

--- a/repository/src/test/java/org/alfresco/AppContext05TestSuite.java
+++ b/repository/src/test/java/org/alfresco/AppContext05TestSuite.java
@@ -58,6 +58,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.security.person.HomeFolderProviderSynchronizerTest.class,
     org.alfresco.repo.domain.permissions.FixedAclUpdaterTest.class,
     org.alfresco.repo.security.authentication.external.DefaultRemoteUserMapperTest.class,
+    org.alfresco.repo.security.authentication.identityservice.IdentityServiceAuthenticationComponentTest.class,
     org.alfresco.repo.security.authentication.identityservice.IdentityServiceRemoteUserMapperTest.class,
     org.alfresco.repo.security.authentication.subsystems.SubsystemChainingFtpAuthenticatorTest.class,
     org.alfresco.repo.security.authentication.external.LocalAuthenticationServiceTest.class,


### PR DESCRIPTION
The IDS Auth component may fail with other exceptions (e.g. connection error) not just with user authentication, therefore the fix captures those exceptions and re-throw AuthenticationException so other authentication components in the chain can have a go at authenticating the user.  