### PR TITLE
MNT-22055 : Metadata extraction fails for certain documents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,10 @@
         <dependency.jaxb.version>2.3.2</dependency.jaxb.version>
         <dependency.groovy.version>2.5.9</dependency.groovy.version>
         <dependency.javax.mail.version>1.6.2</dependency.javax.mail.version>
-        <dependency.tika.version>1.21-20190624-alfresco-patched</dependency.tika.version>
+        <dependency.tika.version>1.24.1</dependency.tika.version>
         <dependency.spring-security.version>5.1.9.RELEASE</dependency.spring-security.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
-        <dependency.poi.version>4.1.1</dependency.poi.version>
+        <dependency.poi.version>4.1.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.keycloak.version>11.0.0-alfresco-001</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.4.1.Final</dependency.jboss.logging.version>
@@ -482,12 +482,6 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>${dependency.xercesImpl.version}</version>
-            </dependency>
-            <!-- Newer metadata-extractor, used in TIKA, see ACS-370 -->
-            <dependency>
-                <groupId>com.drewnoakes</groupId>
-                <artifactId>metadata-extractor</artifactId>
-                <version>2.13.0</version>
             </dependency>
             <!-- upgrade dependency from TIKA -->
             <dependency>

--- a/repository/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
+++ b/repository/src/main/java/org/alfresco/repo/content/metadata/TikaAutoMetadataExtracter.java
@@ -68,11 +68,10 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
     protected static Log logger = LogFactory.getLog(TikaAutoMetadataExtracter.class);
     private static AutoDetectParser parser;
     private static TikaConfig config;
-    private static String EXIF_IMAGE_HEIGHT_TAG = "Exif Image Height";
-    private static String EXIF_IMAGE_WIDTH_TAG = "Exif Image Width";
+    private static String EXIF_IMAGE_HEIGHT_TAG = "Exif SubIFD:Exif Image Height";
+    private static String EXIF_IMAGE_WIDTH_TAG = "Exif SubIFD:Exif Image Width";
     private static String JPEG_IMAGE_HEIGHT_TAG = "Image Height";
     private static String JPEG_IMAGE_WIDTH_TAG = "Image Width";
-    private static String COMPRESSION_TAG = "Compression";
 
     public static ArrayList<String> SUPPORTED_MIMETYPES;
     private static ArrayList<String> buildMimeTypes(TikaConfig tikaConfig)
@@ -127,16 +126,12 @@ public class TikaAutoMetadataExtracter extends TikaPoweredMetadataExtracter
         if(MimetypeMap.MIMETYPE_IMAGE_JPEG.equals(metadata.get(Metadata.CONTENT_TYPE)))
         {
             //check if the image has exif information
-            if(metadata.get(EXIF_IMAGE_WIDTH_TAG) != null
-                    && metadata.get(EXIF_IMAGE_HEIGHT_TAG) != null
-                    && metadata.get(COMPRESSION_TAG) != null)
+            if (metadata.get(EXIF_IMAGE_WIDTH_TAG) != null && metadata.get(EXIF_IMAGE_HEIGHT_TAG) != null)
             {
                 //replace the exif size properties that will be embedded in the node with
                 //the guessed dimensions from Tika
-                putRawValue(TIFF.IMAGE_LENGTH.getName(), extractSize(metadata.get(EXIF_IMAGE_HEIGHT_TAG)), properties);
-                putRawValue(TIFF.IMAGE_WIDTH.getName(), extractSize(metadata.get(EXIF_IMAGE_WIDTH_TAG)), properties);
-                putRawValue(JPEG_IMAGE_HEIGHT_TAG, metadata.get(EXIF_IMAGE_HEIGHT_TAG), properties);
-                putRawValue(JPEG_IMAGE_WIDTH_TAG, metadata.get(EXIF_IMAGE_WIDTH_TAG), properties);
+                putRawValue(TIFF.IMAGE_LENGTH.getName(), extractSize(metadata.get(JPEG_IMAGE_HEIGHT_TAG)), properties);
+                putRawValue(TIFF.IMAGE_WIDTH.getName(), extractSize(metadata.get(JPEG_IMAGE_WIDTH_TAG)), properties);
             }
         }
         return properties;


### PR DESCRIPTION
   Bump tika to 1.24.1
   Remove metadata-extractor dependency
   Bump poi to 4.1.2
