### PR TITLE
revert of webscripts to version 8.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency.cxf.version>3.4.1</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
         <dependency.pdfbox.version>2.0.21</dependency.pdfbox.version>
-        <dependency.webscripts.version>8.14</dependency.webscripts.version>
+        <dependency.webscripts.version>8.12</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.66</dependency.bouncycastle.version>
         <dependency.mockito-core.version>3.6.0</dependency.mockito-core.version>
         <dependency.org-json.version>20200518</dependency.org-json.version>


### PR DESCRIPTION
This revert is required to allow AGS to build. A reintroduction of this changes will be applied after West drayton