### PR TITLE
ACS-1033 : Spring upgrade to 5.3.2

### DIFF
--- a/core/src/main/java/org/alfresco/util/transaction/SpringAwareUserTransaction.java
+++ b/core/src/main/java/org/alfresco/util/transaction/SpringAwareUserTransaction.java
@@ -19,6 +19,8 @@
 package org.alfresco.util.transaction;
 
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Collections;
 
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
@@ -135,6 +137,8 @@ public class SpringAwareUserTransaction
     private long threadId = Long.MIN_VALUE;
     /** make sure that we clean up the thread transaction stack properly */
     private boolean finalized = false;
+
+    private Collection<String> labels = Collections.emptyList();
     
     /**
      * Creates a user transaction that defaults to {@link TransactionDefinition#PROPAGATION_REQUIRED}.
@@ -198,6 +202,21 @@ public class SpringAwareUserTransaction
     public String getQualifier()
     {
         return null;
+    }
+
+    /**
+     * Associate one or more labels with this transaction attribute.
+     * <p>This may be used for applying specific transactional behavior
+     * or follow a purely descriptive nature.
+     */
+    public void setLabels(Collection<String> labels) {
+        this.labels = labels;
+    }
+    
+    @Override
+    public Collection<String> getLabels()
+    {
+        return this.labels;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.11</dependency.acs-event-model.version>
 
-        <dependency.spring.version>5.2.9.RELEASE</dependency.spring.version>
+        <dependency.spring.version>5.3.2</dependency.spring.version>
         <dependency.antlr.version>3.5.2</dependency.antlr.version>
         <dependency.jackson.version>2.11.3</dependency.jackson.version>
         <dependency.jackson-databind.version>2.11.2</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>${dependency.spring.version}</version>
+                <version>5.2.12.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.11</dependency.acs-event-model.version>
 
-        <dependency.spring.version>5.3.2</dependency.spring.version>
+        <dependency.spring.version>5.3.0</dependency.spring.version>
         <dependency.antlr.version>3.5.2</dependency.antlr.version>
         <dependency.jackson.version>2.11.3</dependency.jackson.version>
         <dependency.jackson-databind.version>2.11.2</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.11</dependency.acs-event-model.version>
 
-        <dependency.spring.version>5.2.12.RELEASE</dependency.spring.version>
+        <dependency.spring.version>5.3.2</dependency.spring.version>
         <dependency.antlr.version>3.5.2</dependency.antlr.version>
         <dependency.jackson.version>2.11.3</dependency.jackson.version>
         <dependency.jackson-databind.version>2.11.2</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.11</dependency.acs-event-model.version>
 
-        <dependency.spring.version>5.3.0</dependency.spring.version>
+        <dependency.spring.version>5.3.2</dependency.spring.version>
         <dependency.antlr.version>3.5.2</dependency.antlr.version>
         <dependency.jackson.version>2.11.3</dependency.jackson.version>
         <dependency.jackson-databind.version>2.11.2</dependency.jackson-databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -371,12 +371,12 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>${dependency.spring.version}</version>
+                <version>5.2.12.RELEASE</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>5.2.12.RELEASE</version>
+                <version>${dependency.spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>5.2.12.RELEASE</version>
+                <version>${dependency.spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.11</dependency.acs-event-model.version>
 
-        <dependency.spring.version>5.3.2</dependency.spring.version>
+        <dependency.spring.version>5.2.12.RELEASE</dependency.spring.version>
         <dependency.antlr.version>3.5.2</dependency.antlr.version>
         <dependency.jackson.version>2.11.3</dependency.jackson.version>
         <dependency.jackson-databind.version>2.11.2</dependency.jackson-databind.version>

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/quickshare/QuickShareRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/quickshare/QuickShareRestApiTest.java
@@ -106,7 +106,8 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
     private final static String TEST_NAME = "test node";
     private static byte[] TEST_CONTENT = null;
     private final static String TEST_MIMETYPE_JPEG = MimetypeMap.MIMETYPE_IMAGE_JPEG;
-    private final static String TEST_MIMETYPE_PNG = MimetypeMap.MIMETYPE_IMAGE_PNG;
+    private final static String TEST_MIMETYPE_PNG =
+        MimetypeMap.MIMETYPE_IMAGE_PNG + ";charset=UTF-8";
     private static File quickFile = null;
 
     private MutableAuthenticationService authenticationService;
@@ -243,7 +244,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
         // get content thumbnail for node (authenticated)
         rsp = sendRequest(new GetRequest(AUTH_CONTENT_THUMBNAIL_URL.replace("{node_ref_3}", testNodeRef_3).replace("{thumbnailname}", "doclib")), expectedStatusOK, USER_ONE);
         String type = rsp.getContentType();
-        assertEquals(TEST_MIMETYPE_PNG+";charset=UTF-8", type);
+        assertEquals(TEST_MIMETYPE_PNG, type);
         
         // As user two ...
         
@@ -279,7 +280,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
         // get content thumbnail for share (note: can be unauthenticated)
         rsp = sendRequest(new GetRequest(SHARE_CONTENT_THUMBNAIL_URL.replace("{shared_id}", sharedId).replace("{thumbnailname}", "doclib")), expectedStatusOK, USER_TWO);
         type = rsp.getContentType();
-        assertEquals(TEST_MIMETYPE_PNG+";charset=UTF-8", type);
+        assertEquals(TEST_MIMETYPE_PNG, type);
         
         // As user one ...
         

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/quickshare/QuickShareRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/quickshare/QuickShareRestApiTest.java
@@ -106,8 +106,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
     private final static String TEST_NAME = "test node";
     private static byte[] TEST_CONTENT = null;
     private final static String TEST_MIMETYPE_JPEG = MimetypeMap.MIMETYPE_IMAGE_JPEG;
-    private final static String TEST_MIMETYPE_PNG =
-        MimetypeMap.MIMETYPE_IMAGE_PNG + ";charset=UTF-8";
+    private final static String TEST_MIMETYPE_PNG = MimetypeMap.MIMETYPE_IMAGE_PNG;
     private static File quickFile = null;
 
     private MutableAuthenticationService authenticationService;
@@ -244,7 +243,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
         // get content thumbnail for node (authenticated)
         rsp = sendRequest(new GetRequest(AUTH_CONTENT_THUMBNAIL_URL.replace("{node_ref_3}", testNodeRef_3).replace("{thumbnailname}", "doclib")), expectedStatusOK, USER_ONE);
         String type = rsp.getContentType();
-        assertEquals(TEST_MIMETYPE_PNG, type);
+        assertEquals(TEST_MIMETYPE_PNG + ";charset=UTF-8", type);
         
         // As user two ...
         
@@ -280,7 +279,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
         // get content thumbnail for share (note: can be unauthenticated)
         rsp = sendRequest(new GetRequest(SHARE_CONTENT_THUMBNAIL_URL.replace("{shared_id}", sharedId).replace("{thumbnailname}", "doclib")), expectedStatusOK, USER_TWO);
         type = rsp.getContentType();
-        assertEquals(TEST_MIMETYPE_PNG, type);
+        assertEquals(TEST_MIMETYPE_PNG + ";charset=UTF-8", type);
         
         // As user one ...
         

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/quickshare/QuickShareRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/quickshare/QuickShareRestApiTest.java
@@ -243,7 +243,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
         // get content thumbnail for node (authenticated)
         rsp = sendRequest(new GetRequest(AUTH_CONTENT_THUMBNAIL_URL.replace("{node_ref_3}", testNodeRef_3).replace("{thumbnailname}", "doclib")), expectedStatusOK, USER_ONE);
         String type = rsp.getContentType();
-        assertEquals(TEST_MIMETYPE_PNG, type);
+        assertEquals(TEST_MIMETYPE_PNG+";charset=UTF-8", type);
         
         // As user two ...
         
@@ -279,7 +279,7 @@ public class QuickShareRestApiTest extends BaseWebScriptTest
         // get content thumbnail for share (note: can be unauthenticated)
         rsp = sendRequest(new GetRequest(SHARE_CONTENT_THUMBNAIL_URL.replace("{shared_id}", sharedId).replace("{thumbnailname}", "doclib")), expectedStatusOK, USER_TWO);
         type = rsp.getContentType();
-        assertEquals(TEST_MIMETYPE_PNG, type);
+        assertEquals(TEST_MIMETYPE_PNG+";charset=UTF-8", type);
         
         // As user one ...
         

--- a/repository/src/test/java/org/alfresco/repo/transaction/TransactionServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/transaction/TransactionServiceImplTest.java
@@ -29,8 +29,6 @@ import javax.transaction.RollbackException;
 import javax.transaction.Status;
 import javax.transaction.UserTransaction;
 
-import junit.framework.TestCase;
-
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.domain.dialect.Dialect;
 import org.alfresco.repo.domain.dialect.PostgreSQLDialect;
@@ -45,17 +43,12 @@ import org.alfresco.service.cmr.security.PersonService;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.service.transaction.ReadOnlyServerException;
-import org.alfresco.test_category.OwnJVMTestsCategory;
-import org.alfresco.util.ApplicationContextHelper;
 import org.alfresco.util.BaseSpringTest;
 import org.alfresco.util.PropertyMap;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.springframework.context.ApplicationContext;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.TransientDataAccessResourceException;
-import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -192,7 +185,7 @@ public class TransactionServiceImplTest extends BaseSpringTest
             @SuppressWarnings("unused")
             int i = 0;
         }
-        catch (UncategorizedSQLException e)
+        catch (Exception e)
         {
             // or this - for PostgreSQL (org.postgresql.util.PSQLException: ERROR: transaction is read-only)
             if (dialect instanceof PostgreSQLDialect)


### PR DESCRIPTION
  - Update rest api test as per https://github.com/spring-projects/spring-framework/commit/5de549d7d4324c7e30ac607e15ebac444f8c3f28
  - prior to spring 5.3.0, AbstractFallbackSQLExceptionTranslator was returning UncategorizedSQLException (wrapping the initial one) when not able to identify an exception - now it returns null (https://github.com/spring-projects/spring-framework/commit/e9cded560d6ecb73aa5bfca57e06b09fa0013294#diff-c6aa1c6a4b11e8a722808e945c4c5b6ef471c42871c7ce830554dde81ad7f2c2L89)