### PR TITLE
REPO-5191 Bug: T-Engine should provide mapping rather than the repo.

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/content/metadata/AbstractMappingMetadataExtracter.java
+++ b/repository/src/main/java/org/alfresco/repo/content/metadata/AbstractMappingMetadataExtracter.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -1348,8 +1348,9 @@ abstract public class AbstractMappingMetadataExtracter implements MetadataExtrac
 
         try
         {
-            embedInternal(nodeRef, mapSystemToRaw(properties), reader, writer);
-            if(logger.isDebugEnabled())
+            Map<String, Serializable> metadata = mapSystemToRaw(properties);
+            embedInternal(nodeRef, metadata, reader, writer);
+            if (logger.isDebugEnabled())
             {
                logger.debug("Embedded Metadata into " + writer);
             }
@@ -1462,7 +1463,7 @@ abstract public class AbstractMappingMetadataExtracter implements MetadataExtrac
      * @param systemMetadata   Metadata keyed by system properties
      * @return              Returns the metadata keyed by the content file metadata properties
      */
-    private Map<String, Serializable> mapSystemToRaw(Map<QName, Serializable> systemMetadata)
+    protected Map<String, Serializable> mapSystemToRaw(Map<QName, Serializable> systemMetadata)
     {
         Map<String, Serializable> metadataProperties = new HashMap<String, Serializable>(systemMetadata.size() * 2 + 1);
         for (Map.Entry<QName, Serializable> entry : systemMetadata.entrySet())
@@ -2260,46 +2261,5 @@ abstract public class AbstractMappingMetadataExtracter implements MetadataExtrac
     protected void embedInternal(Map<String, Serializable> metadata, ContentReader reader, ContentWriter writer) throws Throwable
     {
         // TODO make this an abstract method once more extracters support embedding
-    }
-
-    public static Map<String, String> convertMetadataToStrings(Map<String, Serializable> properties)
-    {
-        Map<String, String> propertiesAsStrings = new HashMap<>();
-        for (String metadataKey : properties.keySet())
-        {
-            Serializable value = properties.get(metadataKey);
-            if (value == null)
-            {
-                continue;
-            }
-            if (value instanceof Collection<?>)
-            {
-                for (Object singleValue : (Collection<?>) value)
-                {
-                    try
-                    {
-                        // Convert to a string value
-                        propertiesAsStrings.put(metadataKey, DefaultTypeConverter.INSTANCE.convert(String.class, singleValue));
-                    }
-                    catch (TypeConversionException e)
-                    {
-                        logger.info("Could not convert " + metadataKey + ": " + e.getMessage());
-                    }
-                }
-            }
-            else
-            {
-                try
-                {
-                    // Convert to a string value
-                    propertiesAsStrings.put(metadataKey, DefaultTypeConverter.INSTANCE.convert(String.class, value));
-                }
-                catch (TypeConversionException e)
-                {
-                    logger.info("Could not convert " + metadataKey + ": " + e.getMessage());
-                }
-            }
-        }
-        return propertiesAsStrings;
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/action/executer/AsynchronousExtractorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/AsynchronousExtractorTest.java
@@ -621,11 +621,22 @@ public class AsynchronousExtractorTest extends BaseSpringTest
         assertAsyncMetadataExecute(contentMetadataEmbedder, "quick/quick.html",
                 UNCHANGED_HASHCODE, fileSize, expectedProperties, OverwritePolicy.PRAGMATIC);
 
-        // Check the metadata sent to the T-Engine contains one of the fixed property values and a modified test value
-        // that is a collection.
+        // Check the metadata sent to the T-Engine contains one of the fixed property values.
         String metadata = transformOptionsPassedToTEngine.get("metadata");
+        System.err.println("METADATA="+metadata);
         assertTrue("System properties were not set: simple value", metadata.contains("\"{http://www.alfresco.org/model/content/1.0}creator\":\"System\""));
-        assertTrue("System properties were not set: collection value", metadata.contains("\"{http://www.alfresco.org/model/content/1.0}title\":[\"one\",\"two\",\"three\"]"));
+
+        // Check the metadata sent to the T-Engine contains the collection value added by the mockTransform.
+        // The order of elements in the collection may change, so we cannot use a simple string compare.
+        int i = metadata.indexOf("\"{http://www.alfresco.org/model/content/1.0}title\":[");
+        assertTrue("The title is missing: "+metadata, i > 0);
+        int j = metadata.indexOf(']', i);
+        assertTrue("No closing ] : "+metadata.substring(i), j > 0);
+        String collection = metadata.substring(i, j);
+        assertTrue("There should have 3 elements: "+collection, collection.split(",").length == 3);
+        assertTrue("\"one\" is missing", collection.contains("\"one\""));
+        assertTrue("\"two\" is missing", collection.contains("\"two\""));
+        assertTrue("\"three\" is missing", collection.contains("\"three\""));
     }
 
     @Test


### PR DESCRIPTION
Bug found while reviewing documents on how to create a custom metadata extractor. The original refactor had left the repo doing the mapping. It should have been passing the fully qualified repo properties to the T-Engine to do the mapping.

Linked to:
* https://github.com/Alfresco/acs-packaging/pull/1826
* https://github.com/Alfresco/alfresco-transform-core/pull/316