### PR TITLE
SEARCH-2656 query fragments with mandatory modifier must be added as mandatory, even if the default connective is a disjunction

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneDisjunction.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneDisjunction.java
@@ -76,6 +76,7 @@ public class LuceneDisjunction<Q, S, E extends Throwable> extends BaseDisjunctio
                     {
                     case DEFAULT:
                     case MANDATORY:
+                        expressionBuilder.addRequired(constraintQuery, constraint.getBoost());
                     case OPTIONAL:
                         expressionBuilder.addOptional(constraintQuery, constraint.getBoost());
                         break;


### PR DESCRIPTION
The problem is that queries like +a +b will be converted to “a OR b” because the “+” modifier is ignored when the default connective is a Disjunction. The expected result must be: “a AND b”