### PR TITLE
ACS-1146 Replace *javax* dependencies with *jakarta* libraries

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,7 +86,6 @@
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-core</artifactId>
-         <version>2.3.0.1</version>
       </dependency>
       <dependency>
          <groupId>org.codehaus.guessencoding</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,8 +17,8 @@
          <artifactId>jakarta.xml.bind-api</artifactId>
       </dependency>
       <dependency>
-         <groupId>com.sun.xml.bind</groupId>
-         <artifactId>jaxb-core</artifactId>
+         <groupId>org.glassfish.jaxb</groupId>
+         <artifactId>jaxb-runtime</artifactId>
       </dependency>
       <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-jta_1.1_spec -->
       <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,6 +11,21 @@
    </parent>
 
    <dependencies>
+      <!-- Jakarta... -->
+      <dependency>
+         <groupId>jakarta.xml.bind</groupId>
+         <artifactId>jakarta.xml.bind-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>com.sun.xml.bind</groupId>
+         <artifactId>jaxb-core</artifactId>
+      </dependency>
+      <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-jta_1.1_spec -->
+      <dependency>
+         <groupId>jakarta.transaction</groupId>
+         <artifactId>jakarta.transaction-api</artifactId>
+      </dependency>
+
       <dependency>
          <groupId>commons-codec</groupId>
          <artifactId>commons-codec</artifactId>
@@ -80,21 +95,9 @@
          <artifactId>spring-surf-core-configservice</artifactId>
       </dependency>
       <dependency>
-         <groupId>jakarta.xml.bind</groupId>
-         <artifactId>jakarta.xml.bind-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>com.sun.xml.bind</groupId>
-         <artifactId>jaxb-core</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.codehaus.guessencoding</groupId>
          <artifactId>guessencoding</artifactId>
          <version>1.4</version>
-      </dependency>
-      <dependency>
-         <groupId>jakarta.transaction</groupId>
-         <artifactId>jakarta.transaction-api</artifactId>
       </dependency>
       <dependency>
          <groupId>joda-time</groupId>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -154,7 +154,6 @@
         <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
-            <version>1.1.1</version>
         </dependency>
         <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-jta_1.1_spec -->
         <dependency>
@@ -165,13 +164,11 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>1.3.5</version>
         </dependency>
         <!-- REPO-5047 - Replaces com.sun.activation:javax.activation -->
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>2.0.0</version>
         </dependency>
         <!-- the cxf libs were updated, see dependencyManagement section -->
         <dependency>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -129,6 +129,10 @@
         </dependency>
 
         <!-- Jakarta... -->
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+        </dependency>
         <!-- REPO-5047 - Replaces com.sun.activation:javax.activation -->
         <dependency>
             <groupId>com.sun.activation</groupId>
@@ -143,11 +147,6 @@
         <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
-        </dependency>
-        <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-jta_1.1_spec -->
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -127,9 +127,29 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!--
-            | compile dependencies
-            -->
+
+        <!-- Jakarta... -->
+        <!-- REPO-5047 - Replaces com.sun.activation:javax.activation -->
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+        </dependency>
+        <!-- REPO-5047 - Replaces javax.annotation:javax.annotation-api -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec -->
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+        </dependency>
+        <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-jta_1.1_spec -->
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jibx</groupId>
             <artifactId>jibx-run</artifactId>
@@ -150,26 +170,7 @@
             <artifactId>woodstox-core</artifactId>
             <version>6.2.3</version>
         </dependency>
-        <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec -->
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-        </dependency>
-        <!-- REPO-5047 - Replaces org.apache.geronimo.specs:geronimo-jta_1.1_spec -->
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-        </dependency>
-        <!-- REPO-5047 - Replaces javax.annotation:javax.annotation-api -->
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <!-- REPO-5047 - Replaces com.sun.activation:javax.activation -->
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-        </dependency>
+
         <!-- the cxf libs were updated, see dependencyManagement section -->
         <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -263,15 +263,6 @@
                     <groupId>asm</groupId>
                     <artifactId>asm</artifactId>
                 </exclusion>
-                <!-- Duplicate classes from com.sun.xml.bind:jaxb-core-->
-                <exclusion>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>txw2</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.istack</groupId>
-                    <artifactId>istack-commons-runtime</artifactId>
-                </exclusion>
                 <!-- Duplicates classes from jakarta.jws:jakarta.jws-api -->
                 <exclusion>
                     <groupId>org.apache.geronimo.specs</groupId>

--- a/packaging/tests/tas-integration/pom.xml
+++ b/packaging/tests/tas-integration/pom.xml
@@ -39,14 +39,14 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
 
         <dependency>

--- a/packaging/tests/tas-integration/pom.xml
+++ b/packaging/tests/tas-integration/pom.xml
@@ -41,14 +41,12 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
-            <version>${dependency.javax.mail.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
-            <version>${dependency.javax.mail.version}</version>
         </dependency>
 
         <dependency>

--- a/packaging/tests/tas-restapi/pom.xml
+++ b/packaging/tests/tas-restapi/pom.xml
@@ -59,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/packaging/war/pom.xml
+++ b/packaging/war/pom.xml
@@ -62,8 +62,8 @@
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <!-- 'provided' dependencies, not packaged in war -->
         <dependency>

--- a/packaging/war/pom.xml
+++ b/packaging/war/pom.xml
@@ -60,12 +60,10 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.soap</groupId>
             <artifactId>javax.xml.soap-api</artifactId>
-            <version>1.4.0</version>
         </dependency>
         <!-- 'provided' dependencies, not packaged in war -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,7 @@
         <dependency.xercesImpl.version>2.12.1</dependency.xercesImpl.version>
         <dependency.slf4j.version>1.7.30</dependency.slf4j.version>
         <dependency.gytheio.version>0.12</dependency.gytheio.version>
-        <dependency.jaxb.version>2.3.3</dependency.jaxb.version>
         <dependency.groovy.version>2.5.9</dependency.groovy.version>
-        <dependency.javax.mail.version>1.6.2</dependency.javax.mail.version>
         <dependency.tika.version>1.25</dependency.tika.version>
         <dependency.spring-security.version>5.4.1</dependency.spring-security.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
@@ -87,6 +85,17 @@
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>
         <dependency.awaitility.version>4.0.3</dependency.awaitility.version>
 
+        <dependency.javax-jaxb-api.version>2.3.3</dependency.javax-jaxb-api.version>
+        <!--<dependency.javax-ws-api.version></dependency.javax-ws-api.version>-->
+        <dependency.javax-soap-api.version>1.4.0</dependency.javax-soap-api.version>
+        <dependency.jakarta-activation-api.version>2.0.0</dependency.jakarta-activation-api.version>
+        <dependency.javax-annotation-api.version>1.3.5</dependency.javax-annotation-api.version>
+        <dependency.jakarta-transaction-api.version>1.3.3</dependency.jakarta-transaction-api.version>
+        <dependency.javax-jws-api.version>1.1.1</dependency.javax-jws-api.version>
+        <dependency.javax-mail-api.version>1.6.2</dependency.javax-mail-api.version>
+        <dependency.javax-json-api.version>1.1.4</dependency.javax-json-api.version>
+        <dependency.javax-rpc-api.version>1.1</dependency.javax-rpc-api.version>
+
         <alfresco.googledrive.version>3.2.0</alfresco.googledrive.version>
         <alfresco.aos-module.version>1.4.0-M1</alfresco.aos-module.version>
 
@@ -95,7 +104,6 @@
         <dependency.mariadb.version>2.7.1</dependency.mariadb.version>
         <dependency.tas-utility.version>3.0.41</dependency.tas-utility.version>
         <dependency.rest-assured.version>3.3.0</dependency.rest-assured.version>
-        <dependency.javax.json.version>1.1.4</dependency.javax.json.version>
         <dependency.tas-restapi.version>1.51</dependency.tas-restapi.version>
         <dependency.tas-cmis.version>1.26</dependency.tas-cmis.version>
         <dependency.tas-email.version>1.8</dependency.tas-email.version>
@@ -124,6 +132,92 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Javax... -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${dependency.javax-jaxb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>2.3.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${dependency.javax-jaxb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${dependency.javax-jaxb-api.version}</version>
+            </dependency>
+
+
+
+
+
+            <dependency>
+                <groupId>javax.xml.soap</groupId>
+                <artifactId>javax.xml.soap-api</artifactId>
+                <version>${dependency.javax-soap-api.version}</version>
+            </dependency>
+
+
+
+
+
+
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>${dependency.jakarta-activation-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${dependency.javax-annotation-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${dependency.jakarta-transaction-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.jws</groupId>
+                <artifactId>jakarta.jws-api</artifactId>
+                <version>${dependency.javax-jws-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>javax.mail</artifactId>
+                <version>${dependency.javax-mail-api.version}</version>
+                <exclusions>
+                    <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
+                    <exclusion>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.json</artifactId>
+                <version>${dependency.javax-json-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml</groupId>
+                <artifactId>jaxrpc-api</artifactId>
+                <version>${dependency.javax-rpc-api.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-jlan-embed</artifactId>
@@ -248,11 +342,7 @@
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.4</version>
             </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${dependency.jaxb.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
@@ -375,11 +465,6 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${dependency.jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
@@ -543,12 +628,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.json</artifactId>
-                <version>${dependency.javax.json.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.alfresco.tas</groupId>
                 <artifactId>restapi</artifactId>
                 <version>${dependency.tas-restapi.version}</version>
@@ -583,11 +662,6 @@
                 <artifactId>dataprep</artifactId>
                 <version>${dependency.tas-dataprep.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.transaction</groupId>
-                <artifactId>jakarta.transaction-api</artifactId>
-                <version>1.3.3</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,16 +139,6 @@
                 <version>${dependency.jakarta-jaxb-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <version>2.3.0.1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${dependency.jakarta-jaxb-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>${dependency.jakarta-jaxb-api.version}</version>
@@ -727,6 +717,16 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-spring</artifactId>
                 <version>${dependency.camel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-impl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,10 @@
         <dependency.jakarta-activation-api.version>2.0.0</dependency.jakarta-activation-api.version>
         <dependency.jakarta-annotation-api.version>1.3.5</dependency.jakarta-annotation-api.version>
         <dependency.jakarta-transaction-api.version>1.3.3</dependency.jakarta-transaction-api.version>
-        <dependency.jakarta-jws-api.version>1.1.1</dependency.jakarta-jws-api.version>
-        <dependency.jakarta-mail-api.version>1.6.2</dependency.jakarta-mail-api.version>
-        <dependency.jakarta-json-api.version>1.1.4</dependency.jakarta-json-api.version>
-        <dependency.jakarta-rpc-api.version>1.1</dependency.jakarta-rpc-api.version>
+        <dependency.jakarta-jws-api.version>2.1.0</dependency.jakarta-jws-api.version>
+        <dependency.jakarta-mail-api.version>1.6.5</dependency.jakarta-mail-api.version>
+        <dependency.jakarta-json-api.version>1.1.6</dependency.jakarta-json-api.version>
+        <dependency.jakarta-rpc-api.version>1.1.4</dependency.jakarta-rpc-api.version>
 
         <alfresco.googledrive.version>3.2.0</alfresco.googledrive.version>
         <alfresco.aos-module.version>1.4.0-M1</alfresco.aos-module.version>
@@ -191,32 +191,35 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.mail</groupId>
-                <artifactId>javax.mail-api</artifactId>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
                 <version>${dependency.jakarta-mail-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
+                <artifactId>jakarta.mail</artifactId>
                 <version>${dependency.jakarta-mail-api.version}</version>
-                <exclusions>
-                    <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
-                    <exclusion>
-                        <groupId>javax.activation</groupId>
-                        <artifactId>activation</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${dependency.jakarta-json-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.json</artifactId>
+                <artifactId>jakarta.json</artifactId>
                 <version>${dependency.jakarta-json-api.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.xml</groupId>
-                <artifactId>jaxrpc-api</artifactId>
+                <groupId>jakarta.xml.rpc</groupId>
+                <artifactId>jakarta.xml.rpc-api</artifactId>
+                <version>${dependency.jakarta-rpc-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.rpc</groupId>
+                <artifactId>jaxrpc-impl</artifactId>
                 <version>${dependency.jakarta-rpc-api.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency.jakarta-jaxb-api.version>2.3.3</dependency.jakarta-jaxb-api.version>
         <dependency.jakarta-ws-api.version>2.3.1</dependency.jakarta-ws-api.version>
         <dependency.jakarta-soap-api.version>1.4.0</dependency.jakarta-soap-api.version>
-        <dependency.jakarta-activation-api.version>2.0.0</dependency.jakarta-activation-api.version>
+        <dependency.jakarta-activation-api.version>1.2.2</dependency.jakarta-activation-api.version>
         <dependency.jakarta-annotation-api.version>1.3.5</dependency.jakarta-annotation-api.version>
         <dependency.jakarta-transaction-api.version>1.3.3</dependency.jakarta-transaction-api.version>
         <dependency.jakarta-jws-api.version>2.1.0</dependency.jakarta-jws-api.version>
@@ -166,6 +166,11 @@
                 <version>${dependency.jakarta-soap-api.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${dependency.jakarta-activation-api.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>
                 <artifactId>jakarta.activation</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,10 @@
         <dependency.awaitility.version>4.0.3</dependency.awaitility.version>
 
         <dependency.javax-jaxb-api.version>2.3.3</dependency.javax-jaxb-api.version>
-        <!--<dependency.javax-ws-api.version></dependency.javax-ws-api.version>-->
+        <dependency.javax-ws-api.version>2.3.1</dependency.javax-ws-api.version>
         <dependency.javax-soap-api.version>1.4.0</dependency.javax-soap-api.version>
         <dependency.jakarta-activation-api.version>2.0.0</dependency.jakarta-activation-api.version>
-        <dependency.javax-annotation-api.version>1.3.5</dependency.javax-annotation-api.version>
+        <dependency.jakarta-annotation-api.version>1.3.5</dependency.jakarta-annotation-api.version>
         <dependency.jakarta-transaction-api.version>1.3.3</dependency.jakarta-transaction-api.version>
         <dependency.javax-jws-api.version>1.1.1</dependency.javax-jws-api.version>
         <dependency.javax-mail-api.version>1.6.2</dependency.javax-mail-api.version>
@@ -154,20 +154,17 @@
                 <version>${dependency.javax-jaxb-api.version}</version>
             </dependency>
 
-
-
-
+            <dependency>
+                <groupId>javax.xml.ws</groupId>
+                <artifactId>jaxws-api</artifactId>
+                <version>${dependency.javax-ws-api.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>javax.xml.soap</groupId>
                 <artifactId>javax.xml.soap-api</artifactId>
                 <version>${dependency.javax-soap-api.version}</version>
             </dependency>
-
-
-
-
-
 
             <dependency>
                 <groupId>com.sun.activation</groupId>
@@ -178,7 +175,7 @@
             <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
-                <version>${dependency.javax-annotation-api.version}</version>
+                <version>${dependency.jakarta-annotation-api.version}</version>
             </dependency>
 
             <dependency>
@@ -193,6 +190,11 @@
                 <version>${dependency.javax-jws-api.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>javax.mail-api</artifactId>
+                <version>${dependency.javax-mail-api.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
@@ -232,6 +234,13 @@
                 <groupId>org.alfresco</groupId>
                 <artifactId>alfresco-heartbeat-data-sender</artifactId>
                 <version>${dependency.alfresco-hb-data-sender.version}</version>
+                <exclusions>
+                    <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>xalan</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,16 +85,16 @@
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>
         <dependency.awaitility.version>4.0.3</dependency.awaitility.version>
 
-        <dependency.javax-jaxb-api.version>2.3.3</dependency.javax-jaxb-api.version>
-        <dependency.javax-ws-api.version>2.3.1</dependency.javax-ws-api.version>
-        <dependency.javax-soap-api.version>1.4.0</dependency.javax-soap-api.version>
+        <dependency.jakarta-jaxb-api.version>2.3.3</dependency.jakarta-jaxb-api.version>
+        <dependency.jakarta-ws-api.version>2.3.1</dependency.jakarta-ws-api.version>
+        <dependency.jakarta-soap-api.version>1.4.0</dependency.jakarta-soap-api.version>
         <dependency.jakarta-activation-api.version>2.0.0</dependency.jakarta-activation-api.version>
         <dependency.jakarta-annotation-api.version>1.3.5</dependency.jakarta-annotation-api.version>
         <dependency.jakarta-transaction-api.version>1.3.3</dependency.jakarta-transaction-api.version>
-        <dependency.javax-jws-api.version>1.1.1</dependency.javax-jws-api.version>
-        <dependency.javax-mail-api.version>1.6.2</dependency.javax-mail-api.version>
-        <dependency.javax-json-api.version>1.1.4</dependency.javax-json-api.version>
-        <dependency.javax-rpc-api.version>1.1</dependency.javax-rpc-api.version>
+        <dependency.jakarta-jws-api.version>1.1.1</dependency.jakarta-jws-api.version>
+        <dependency.jakarta-mail-api.version>1.6.2</dependency.jakarta-mail-api.version>
+        <dependency.jakarta-json-api.version>1.1.4</dependency.jakarta-json-api.version>
+        <dependency.jakarta-rpc-api.version>1.1</dependency.jakarta-rpc-api.version>
 
         <alfresco.googledrive.version>3.2.0</alfresco.googledrive.version>
         <alfresco.aos-module.version>1.4.0-M1</alfresco.aos-module.version>
@@ -136,7 +136,7 @@
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${dependency.javax-jaxb-api.version}</version>
+                <version>${dependency.jakarta-jaxb-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
@@ -146,24 +146,24 @@
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>${dependency.javax-jaxb-api.version}</version>
+                <version>${dependency.jakarta-jaxb-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${dependency.javax-jaxb-api.version}</version>
+                <version>${dependency.jakarta-jaxb-api.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>javax.xml.ws</groupId>
                 <artifactId>jaxws-api</artifactId>
-                <version>${dependency.javax-ws-api.version}</version>
+                <version>${dependency.jakarta-ws-api.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>javax.xml.soap</groupId>
                 <artifactId>javax.xml.soap-api</artifactId>
-                <version>${dependency.javax-soap-api.version}</version>
+                <version>${dependency.jakarta-soap-api.version}</version>
             </dependency>
 
             <dependency>
@@ -187,18 +187,18 @@
             <dependency>
                 <groupId>jakarta.jws</groupId>
                 <artifactId>jakarta.jws-api</artifactId>
-                <version>${dependency.javax-jws-api.version}</version>
+                <version>${dependency.jakarta-jws-api.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>${dependency.javax-mail-api.version}</version>
+                <version>${dependency.jakarta-mail-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
-                <version>${dependency.javax-mail-api.version}</version>
+                <version>${dependency.jakarta-mail-api.version}</version>
                 <exclusions>
                     <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
                     <exclusion>
@@ -211,13 +211,13 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.json</artifactId>
-                <version>${dependency.javax-json-api.version}</version>
+                <version>${dependency.jakarta-json-api.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>javax.xml</groupId>
                 <artifactId>jaxrpc-api</artifactId>
-                <version>${dependency.javax-rpc-api.version}</version>
+                <version>${dependency.jakarta-rpc-api.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.awaitility.version>4.0.3</dependency.awaitility.version>
 
         <dependency.jakarta-jaxb-api.version>2.3.3</dependency.jakarta-jaxb-api.version>
-        <dependency.jakarta-ws-api.version>2.3.1</dependency.jakarta-ws-api.version>
-        <dependency.jakarta-soap-api.version>1.4.0</dependency.jakarta-soap-api.version>
+        <dependency.jakarta-ws-api.version>2.3.3</dependency.jakarta-ws-api.version>
+        <dependency.jakarta-soap-api.version>1.4.2</dependency.jakarta-soap-api.version>
         <dependency.jakarta-activation-api.version>1.2.2</dependency.jakarta-activation-api.version>
         <dependency.jakarta-annotation-api.version>1.3.5</dependency.jakarta-annotation-api.version>
         <dependency.jakarta-transaction-api.version>1.3.3</dependency.jakarta-transaction-api.version>
@@ -155,14 +155,14 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.xml.ws</groupId>
-                <artifactId>jaxws-api</artifactId>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
                 <version>${dependency.jakarta-ws-api.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.xml.soap</groupId>
-                <artifactId>javax.xml.soap-api</artifactId>
+                <groupId>jakarta.xml.soap</groupId>
+                <artifactId>jakarta.xml.soap-api</artifactId>
                 <version>${dependency.jakarta-soap-api.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Javax... -->
+            <!-- Jakarta... -->
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -60,11 +60,6 @@
             <artifactId>chemistry-opencmis-test-tck</artifactId>
             <version>${dependency.opencmis.version}</version>
             <exclusions>
-                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>javax.activation</artifactId>
-                </exclusion>
                 <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api -->
                 <exclusion>
                   <groupId>org.apache.geronimo.specs</groupId>
@@ -152,6 +147,11 @@
             <version>2.0</version>
             <scope>test</scope>
             <exclusions>
+              <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
+              <exclusion>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-jta_1.1_spec</artifactId>
+              </exclusion>
               <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api -->
               <exclusion>
                 <groupId>org.apache.geronimo.specs</groupId>

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -48,6 +48,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Jakarta... -->
+        <dependency>
+            <groupId>javax.xml</groupId>
+            <artifactId>jaxrpc-api</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -79,11 +86,6 @@
             <groupId>org.alfresco.surf</groupId>
             <artifactId>spring-webscripts</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxrpc-api</artifactId>
-        </dependency>
-
         <!-- This is needed at runtime by Web Client, so not really a test dependency -->
         <dependency>
             <groupId>org.apache.chemistry.opencmis</groupId>

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>javax.xml</groupId>
             <artifactId>jaxrpc-api</artifactId>
-            <version>1.1</version>
         </dependency>
 
         <!-- This is needed at runtime by Web Client, so not really a test dependency -->

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -19,8 +19,8 @@
 
         <!-- Jakarta... -->
         <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxrpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
 
         <dependency>

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -141,11 +141,6 @@
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>javax.transaction</groupId>
-                    <artifactId>jta</artifactId>
-                </exclusion>
                 <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -16,38 +16,6 @@
             <artifactId>alfresco-repository</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-data-model</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>javax.activation</artifactId>
-                </exclusion>
-                <!-- REPO-4998 - Exclusion due to classpath conflicts between org.codehaus.woodstox:woodstox-core-asl and com.fasterxml.woodstox:woodstox-core -->
-                <exclusion>
-                  <groupId>org.codehaus.woodstox</groupId>
-                  <artifactId>woodstox-core-asl</artifactId>
-                </exclusion>
-                <!-- Duplicate classes from jakarta.annotation:jakarta.annotation-api-->
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-                <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api -->
-                <exclusion>
-                  <groupId>org.apache.geronimo.specs</groupId>
-                  <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jta_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- Jakarta... -->
         <dependency>
@@ -142,13 +110,6 @@
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
-            <exclusions>
-                <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco.surf</groupId>

--- a/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
@@ -31,7 +31,6 @@ import java.util.List;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
-import javax.servlet.UnavailableException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -13,6 +13,24 @@
     <dependencies>
         <dependency>
             <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-data-model</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api (using jakarta.jws:jakarta.jws-api now - see REPO-5031)-->
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
+                </exclusion>
+                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jta_1.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alfresco</groupId>
             <artifactId>alfresco-jlan-embed</artifactId>
             <exclusions>
                 <exclusion>
@@ -50,14 +68,40 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-greenmail</artifactId>
             <version>${dependency.alfresco-greenmail.version}</version>
         </dependency>
+
+        <!-- Jakarta... -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <!-- Added to replace transitive dependencies com.sun.activation:javax.activation and javax.activation:activation -->
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+        </dependency>
+        <!-- [ACS-544] xml-apis dependency excluded to avoid conflict in JDK9+ as it includes javax.xml and w3c. -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <!-- REPO-5031 Added jakarta.jws:jakarta.jws-api instead of javax.jws:javax.jws-api - since javax.* has moved to jakarta -->
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
@@ -184,10 +228,6 @@
             <version>3.6.3</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>de.schlichtherle.truezip</groupId>
             <artifactId>truezip-driver-zip</artifactId>
             <version>${dependency.truezip.version}</version>
@@ -236,11 +276,6 @@
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
         </dependency>
-        <!-- [ACS-544] xml-apis dependency excluded to avoid conflict in JDK9+ as it includes javax.xml and w3c. -->
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
@@ -263,12 +298,6 @@
             <groupId>net.sf.jsr107cache</groupId>
             <artifactId>jsr107cache</artifactId>
             <version>1.1</version>
-        </dependency>
-
-        <!-- REPO-5031 Added jakarta.jws:jakarta.jws-api instead of javax.jws:javax.jws-api - since javax.* has moved to jakarta -->
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
         </dependency>
 
         <dependency>
@@ -326,11 +355,6 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>
@@ -749,23 +773,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-data-model</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api (using jakarta.jws:jakarta.jws-api now - see REPO-5031)-->
-                <exclusion>
-                  <groupId>org.apache.geronimo.specs</groupId>
-                  <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jta_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
@@ -852,11 +859,6 @@
            <groupId>org.apache.taglibs</groupId>
            <artifactId>taglibs-standard-jstlel</artifactId>
            <version>${dependency.apache.taglibs.version}</version>
-        </dependency>
-        <!-- Added to replace transitive dependencies com.sun.activation:javax.activation and javax.activation:activation -->
-        <dependency>
-           <groupId>com.sun.activation</groupId>
-           <artifactId>jakarta.activation</artifactId>
         </dependency>
         <!-- Repo Event Model-->
         <dependency>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -26,11 +26,6 @@
             <artifactId>alfresco-core</artifactId>
             <version>${project.version}</version>
             <exclusions>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>javax.transaction</groupId>
-                    <artifactId>jta</artifactId>
-                </exclusion>
                 <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>
@@ -727,11 +722,6 @@
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>javax.transaction</groupId>
-                    <artifactId>jta</artifactId>
-                </exclusion>
                 <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>
@@ -763,16 +753,6 @@
             <artifactId>alfresco-data-model</artifactId>
             <version>${project.version}</version>
             <exclusions>
-                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>javax.activation</artifactId>
-                </exclusion>
-                <!-- Duplicate classes from jakarta.annotation:jakarta.annotation-api-->
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
                 <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api (using jakarta.jws:jakarta.jws-api now - see REPO-5031)-->
                 <exclusion>
                   <groupId>org.apache.geronimo.specs</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -61,25 +61,6 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
-        <!-- Added to replace transitive dependencies com.sun.activation:javax.activation and javax.activation:activation -->
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-        </dependency>
-        <!-- [ACS-544] xml-apis dependency excluded to avoid conflict in JDK9+ as it includes javax.xml and w3c. -->
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <!-- REPO-5031 Added jakarta.jws:jakarta.jws-api instead of javax.jws:javax.jws-api - since javax.* has moved to jakarta -->
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
@@ -497,6 +478,11 @@
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
+                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
                 <!-- Duplicate classes from com.sun.mail:jakarta.mail -->
                 <exclusion>
                     <groupId>com.sun.mail</groupId>
@@ -552,6 +538,11 @@
                 <exclusion>
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -834,11 +825,6 @@
               <exclusion>
                 <groupId>org.apache.geronimo.specs</groupId>
                 <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
-              </exclusion>
-              <!-- MNT-20557: Excluding javax.annotation:javax.annotation-api, jakarta.annotation:jakarta.annotation-api will be used instead -->
-              <exclusion>
-                  <groupId>javax.annotation</groupId>
-                  <artifactId>javax.annotation-api</artifactId>
               </exclusion>
               <!-- [ACS-544] Excluded as conflicts with JDK9+ as it includes javax.transaction -->
               <exclusion>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -47,6 +47,13 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-greenmail</artifactId>
             <version>${dependency.alfresco-greenmail.version}</version>
+            <exclusions>
+                <!-- Duplicate classes from com.sun.mail:jakarta.mail -->
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Jakarta... -->
@@ -74,8 +81,12 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
 
         <dependency>
@@ -187,6 +198,7 @@
             <artifactId>subethasmtp</artifactId>
             <version>3.1.7</version>
             <exclusions>
+                <!-- Duplicate classes from com.sun.mail:jakarta.mail -->
                 <exclusion>
                     <groupId>javax.mail</groupId>
                     <artifactId>mail</artifactId>
@@ -456,6 +468,7 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
+                <!-- Duplicate classes from com.sun.mail:jakarta.mail -->
                 <exclusion>
                     <groupId>javax.mail</groupId>
                     <artifactId>mail</artifactId>
@@ -484,6 +497,15 @@
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
+                <!-- Duplicate classes from com.sun.mail:jakarta.mail -->
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.ws</groupId>
+                    <artifactId>jaxws-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -491,6 +513,10 @@
             <artifactId>activiti-spring</artifactId>
             <version>${dependency.activiti.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.ws</groupId>
+                    <artifactId>jaxws-api</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-jdbc</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -35,13 +35,6 @@
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-heartbeat-data-sender</artifactId>
-            <exclusions>
-                <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
@@ -57,10 +50,6 @@
         </dependency>
 
         <!-- Jakarta... -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
@@ -476,6 +465,14 @@
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </exclusion>
                 <!-- Duplicates classes from org.jboss.spec.javax.rmi:jboss-rmi-api and org.jacorb:jacorb-omgapi -->
                 <exclusion>
                     <groupId>org.glassfish.corba</groupId>
@@ -544,6 +541,14 @@
                 <exclusion>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
                 </exclusion>
                 <!-- Duplicates classes from org.jboss.spec.javax.rmi:jboss-rmi-api and org.jacorb:jacorb-omgapi -->
                 <exclusion>
@@ -754,13 +759,6 @@
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
-            <exclusions>
-                <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -57,14 +57,6 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
-            <version>1.6.2</version>
-            <exclusions>
-                <!-- Duplicate classes from com.sun.activation:jakarta.activation-->
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
@@ -253,7 +245,6 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
@@ -283,7 +274,6 @@
         <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
-            <version>1.1.1</version>
         </dependency>
 
         <dependency>
@@ -887,7 +877,6 @@
         <dependency>
            <groupId>com.sun.activation</groupId>
            <artifactId>jakarta.activation</artifactId>
-           <version>2.0.0</version>
         </dependency>
         <!-- Repo Event Model-->
         <dependency>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -15,18 +15,6 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-data-model</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <!-- REPO-5009 Excluded to avoid duplicated classes with javax.jws:javax.jws-api (using jakarta.jws:jakarta.jws-api now - see REPO-5031)-->
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jta_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -36,18 +24,6 @@
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>spring-surf-core-configservice</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-core</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <!-- Duplicates classes from jakarta.xml.bind:jakarta.xml.bind-api -->
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -62,6 +62,14 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
         </dependency>
@@ -492,6 +500,10 @@
                     <groupId>javax.xml.ws</groupId>
                     <artifactId>jaxws-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -502,6 +514,10 @@
                 <exclusion>
                     <groupId>javax.xml.ws</groupId>
                     <artifactId>jaxws-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.soap</groupId>
+                    <artifactId>javax.xml.soap-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>


### PR DESCRIPTION
- group jakarta dependencies in the POMs
- define explicit version properties for the various jakarta APIs
- replace all *javax* libraries with their *jakarta* equivalent
- exclude all *javax* libraries brought in by our dependencies (they can't be handled through _dependencyManagement_ due to the different jar names)
- upgrade the *jakarta* libraries to the latest versions that still use the _javax_ package namespace