### PR TITLE
MNT-20775 : deleted-nodes with maxitems parameter take longer

### DIFF
--- a/core/src/main/java/org/alfresco/query/AbstractCannedQuery.java
+++ b/core/src/main/java/org/alfresco/query/AbstractCannedQuery.java
@@ -113,7 +113,7 @@ public abstract class AbstractCannedQuery<R> implements CannedQuery<R>
         final List<List<R>> finalPages = pages;
         
         // Has more items beyond requested pages ? ... ie. at least one more page (with at least one result)
-        final boolean hasMoreItems = (rawResults.size() > pagingDetails.getResultsRequiredForPaging());
+        final boolean hasMoreItems = (rawResults.size() > pagingDetails.getResultsRequiredForPaging()) || (totalCount.getFirst() > pagingDetails.getResultsRequiredForPaging());
         
         results = new CannedQueryResults<R>()
         {

--- a/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQuery.java
+++ b/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQuery.java
@@ -57,7 +57,8 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
     private CannedQueryDAO cannedQueryDAO;
     private NodeDAO nodeDAO;
 
-    public GetArchivedNodesCannedQuery(CannedQueryDAO cannedQueryDAO, NodeDAO nodeDAO, MethodSecurityBean<ArchivedNodeEntity> methodSecurity, CannedQueryParameters params)
+    public GetArchivedNodesCannedQuery(CannedQueryDAO cannedQueryDAO, NodeDAO nodeDAO,
+                MethodSecurityBean<ArchivedNodeEntity> methodSecurity, CannedQueryParameters params)
     {
         super(params, methodSecurity);
         this.cannedQueryDAO = cannedQueryDAO;
@@ -126,15 +127,27 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
     {
         Object paramBeanObj = super.getParameters().getParameterBean();
         if (paramBeanObj == null)
-            throw new NullPointerException("Null GetArchivedNodes query params");
+        {
+            throw new NullPointerException(
+                "Required parameters not provided for GetArchivedNodes canned query, unexpected null value for query params");
+        }
 
-        // Get parameters
         GetArchivedNodesCannedQueryParams paramBean = (GetArchivedNodesCannedQueryParams) paramBeanObj;
+        if (paramBean.getParentNodeId() == null)
+        {
+            throw new NullPointerException(
+                "Required parameters not provided for GetArchivedNodes canned queryUnexpected null value for parentNodeId");
+        }
 
-        long resultsRequired = cannedQueryDAO.executeCountQuery(QUERY_NAMESPACE, QUERY_SELECT_COUNT_ARCHIVED_NODES, paramBean);
+        Long totalResultCountLongValue = cannedQueryDAO.executeCountQuery(QUERY_NAMESPACE, QUERY_SELECT_COUNT_ARCHIVED_NODES, paramBean);
 
-        int totalResults = Integer.valueOf((int) resultsRequired);
-        return new Pair<>(totalResults, totalResults);
+        int totalResultCount = totalResultCountLongValue.intValue();
+        if (totalResultCount < 0)
+        {
+            totalResultCount = Integer.MAX_VALUE;
+        }
+
+        return new Pair<>(totalResultCount, totalResultCount);
     }
 
     @Override

--- a/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQuery.java
+++ b/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQuery.java
@@ -4,27 +4,31 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software.
- * If the software was purchased under a paid Alfresco license, the terms of
- * the paid license agreement will prevail.  Otherwise, the software is
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
  * provided under the following open source license terms:
- *
+ * 
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * 
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 
 package org.alfresco.repo.node.archive;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.alfresco.query.CannedQueryParameters;
 import org.alfresco.repo.domain.node.NodeDAO;
@@ -36,13 +40,9 @@ import org.alfresco.util.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 /**
  * Canned query for archived nodes.
- *
+ * 
  * @author Jamal Kaabi-Mofrad
  * @since 4.2
  */
@@ -57,8 +57,7 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
     private CannedQueryDAO cannedQueryDAO;
     private NodeDAO nodeDAO;
 
-    public GetArchivedNodesCannedQuery(CannedQueryDAO cannedQueryDAO, NodeDAO nodeDAO,
-        MethodSecurityBean<ArchivedNodeEntity> methodSecurity, CannedQueryParameters params)
+    public GetArchivedNodesCannedQuery(CannedQueryDAO cannedQueryDAO, NodeDAO nodeDAO, MethodSecurityBean<ArchivedNodeEntity> methodSecurity, CannedQueryParameters params)
     {
         super(params, methodSecurity);
         this.cannedQueryDAO = cannedQueryDAO;
@@ -66,7 +65,8 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
     }
 
-    @Override protected List<ArchivedNodeEntity> queryAndFilter(CannedQueryParameters parameters)
+    @Override
+    protected List<ArchivedNodeEntity> queryAndFilter(CannedQueryParameters parameters)
     {
         Long start = (logger.isDebugEnabled() ? System.currentTimeMillis() : null);
 
@@ -82,17 +82,12 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
             return Collections.emptyList();
         }
 
-        //        int resultsRequired = parameters.getResultsRequired();
-        //        paramBean.setLimit(resultsRequired);
-
         int offset = parameters.getPageDetails().getSkipResults();
         int limit = parameters.getPageDetails().getPageSize();
-        paramBean.setLimit(limit);
-        paramBean.setOffset(offset);
 
         // note: refer to SQL for specific DB filtering and sorting
-        List<ArchivedNodeEntity> results = cannedQueryDAO
-            .executeQuery(QUERY_NAMESPACE, QUERY_SELECT_GET_ARCHIVED_NODES, paramBean, 0, Integer.MAX_VALUE);
+        List<ArchivedNodeEntity> results = cannedQueryDAO.executeQuery(QUERY_NAMESPACE,
+                    QUERY_SELECT_GET_ARCHIVED_NODES, paramBean, offset, limit);
 
         List<NodeRef> nodeRefs = new ArrayList<NodeRef>(results.size());
         for (ArchivedNodeEntity entity : results)
@@ -105,7 +100,8 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
         if (start != null)
         {
-            logger.debug("Base query: " + nodeRefs.size() + " in " + (System.currentTimeMillis() - start) + " msecs");
+            logger.debug("Base query: " + nodeRefs.size() + " in "
+                        + (System.currentTimeMillis() - start) + " msecs");
         }
 
         return results;
@@ -120,11 +116,13 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
         if (start != null)
         {
-            logger.trace("Pre-load: " + nodeRefs.size() + " in " + (System.currentTimeMillis() - start) + " msecs");
+            logger.trace("Pre-load: " + nodeRefs.size() + " in "
+                        + (System.currentTimeMillis() - start) + " msecs");
         }
     }
 
-    @Override protected Pair<Integer, Integer> getTotalResultCount(List<ArchivedNodeEntity> results)
+    @Override
+    protected Pair<Integer, Integer> getTotalResultCount(List<ArchivedNodeEntity> results)
     {
         Object paramBeanObj = super.getParameters().getParameterBean();
         if (paramBeanObj == null)
@@ -133,19 +131,14 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
         // Get parameters
         GetArchivedNodesCannedQueryParams paramBean = (GetArchivedNodesCannedQueryParams) paramBeanObj;
 
-        //        if (paramBean.getParentNodeId() == null || paramBean.getParentNodeId() < 0)
-        //        {
-        //            return Collections.emptyList();
-        //        }
-
         long resultsRequired = cannedQueryDAO.executeCountQuery(QUERY_NAMESPACE, QUERY_SELECT_COUNT_ARCHIVED_NODES, paramBean);
 
         int totalResults = Integer.valueOf((int) resultsRequired);
-
-        return new Pair<Integer, Integer>(totalResults, totalResults);
+        return new Pair<>(totalResults, totalResults);
     }
 
-    @Override protected boolean isApplyPostQueryPaging()
+    @Override
+    protected boolean isApplyPostQueryPaging()
     {
         return false;
     }

--- a/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQuery.java
+++ b/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQuery.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -26,22 +26,23 @@
 
 package org.alfresco.repo.node.archive;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.alfresco.query.CannedQueryParameters;
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.query.CannedQueryDAO;
 import org.alfresco.repo.security.permissions.impl.acegi.AbstractCannedQueryPermissions;
 import org.alfresco.repo.security.permissions.impl.acegi.MethodSecurityBean;
 import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.util.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Canned query for archived nodes.
- * 
+ *
  * @author Jamal Kaabi-Mofrad
  * @since 4.2
  */
@@ -51,12 +52,13 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
     private static final String QUERY_NAMESPACE = "alfresco.query.archivednodes";
     private static final String QUERY_SELECT_GET_ARCHIVED_NODES = "select_GetArchivedNodesCannedQuery";
+    private static final String QUERY_SELECT_COUNT_ARCHIVED_NODES = "select_CountAllArchivedNodes";
 
     private CannedQueryDAO cannedQueryDAO;
     private NodeDAO nodeDAO;
 
     public GetArchivedNodesCannedQuery(CannedQueryDAO cannedQueryDAO, NodeDAO nodeDAO,
-                MethodSecurityBean<ArchivedNodeEntity> methodSecurity, CannedQueryParameters params)
+        MethodSecurityBean<ArchivedNodeEntity> methodSecurity, CannedQueryParameters params)
     {
         super(params, methodSecurity);
         this.cannedQueryDAO = cannedQueryDAO;
@@ -64,8 +66,7 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
     }
 
-    @Override
-    protected List<ArchivedNodeEntity> queryAndFilter(CannedQueryParameters parameters)
+    @Override protected List<ArchivedNodeEntity> queryAndFilter(CannedQueryParameters parameters)
     {
         Long start = (logger.isDebugEnabled() ? System.currentTimeMillis() : null);
 
@@ -75,18 +76,23 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
         // Get parameters
         GetArchivedNodesCannedQueryParams paramBean = (GetArchivedNodesCannedQueryParams) paramBeanObj;
-        
+
         if (paramBean.getParentNodeId() == null || paramBean.getParentNodeId() < 0)
         {
             return Collections.emptyList();
         }
 
-        int resultsRequired = parameters.getResultsRequired();
-        paramBean.setLimit(resultsRequired);
+        //        int resultsRequired = parameters.getResultsRequired();
+        //        paramBean.setLimit(resultsRequired);
+
+        int offset = parameters.getPageDetails().getSkipResults();
+        int limit = parameters.getPageDetails().getPageSize();
+        paramBean.setLimit(limit);
+        paramBean.setOffset(offset);
 
         // note: refer to SQL for specific DB filtering and sorting
-        List<ArchivedNodeEntity> results = cannedQueryDAO.executeQuery(QUERY_NAMESPACE,
-                    QUERY_SELECT_GET_ARCHIVED_NODES, paramBean, 0, Integer.MAX_VALUE);
+        List<ArchivedNodeEntity> results = cannedQueryDAO
+            .executeQuery(QUERY_NAMESPACE, QUERY_SELECT_GET_ARCHIVED_NODES, paramBean, 0, Integer.MAX_VALUE);
 
         List<NodeRef> nodeRefs = new ArrayList<NodeRef>(results.size());
         for (ArchivedNodeEntity entity : results)
@@ -99,8 +105,7 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
         if (start != null)
         {
-            logger.debug("Base query: " + nodeRefs.size() + " in "
-                        + (System.currentTimeMillis() - start) + " msecs");
+            logger.debug("Base query: " + nodeRefs.size() + " in " + (System.currentTimeMillis() - start) + " msecs");
         }
 
         return results;
@@ -115,8 +120,33 @@ public class GetArchivedNodesCannedQuery extends AbstractCannedQueryPermissions<
 
         if (start != null)
         {
-            logger.trace("Pre-load: " + nodeRefs.size() + " in "
-                        + (System.currentTimeMillis() - start) + " msecs");
+            logger.trace("Pre-load: " + nodeRefs.size() + " in " + (System.currentTimeMillis() - start) + " msecs");
         }
+    }
+
+    @Override protected Pair<Integer, Integer> getTotalResultCount(List<ArchivedNodeEntity> results)
+    {
+        Object paramBeanObj = super.getParameters().getParameterBean();
+        if (paramBeanObj == null)
+            throw new NullPointerException("Null GetArchivedNodes query params");
+
+        // Get parameters
+        GetArchivedNodesCannedQueryParams paramBean = (GetArchivedNodesCannedQueryParams) paramBeanObj;
+
+        //        if (paramBean.getParentNodeId() == null || paramBean.getParentNodeId() < 0)
+        //        {
+        //            return Collections.emptyList();
+        //        }
+
+        long resultsRequired = cannedQueryDAO.executeCountQuery(QUERY_NAMESPACE, QUERY_SELECT_COUNT_ARCHIVED_NODES, paramBean);
+
+        int totalResults = Integer.valueOf((int) resultsRequired);
+
+        return new Pair<Integer, Integer>(totalResults, totalResults);
+    }
+
+    @Override protected boolean isApplyPostQueryPaging()
+    {
+        return false;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQueryParams.java
+++ b/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQueryParams.java
@@ -37,8 +37,6 @@ public class GetArchivedNodesCannedQueryParams extends ArchivedNodeEntity
 
     private int limit;
 
-    private int offset;
-
     /**
      *
      * @param parentNodeId Long
@@ -72,28 +70,6 @@ public class GetArchivedNodesCannedQueryParams extends ArchivedNodeEntity
         this(parentNodeId, assocTypeQNameId, filter, filterIgnoreCase, nameQNameId,
                 sortOrderAscending);
         this.setLimit(limit);
-        this.setOffset(0);
-    }
-
-    /**
-     *
-     * @param parentNodeId
-     * @param assocTypeQNameId
-     * @param filter
-     * @param filterIgnoreCase
-     * @param nameQNameId
-     * @param sortOrderAscending
-     * @param limit
-     * @param offset
-     */
-    public GetArchivedNodesCannedQueryParams(Long parentNodeId, Long assocTypeQNameId,
-        String filter, Boolean filterIgnoreCase, Long nameQNameId, Boolean sortOrderAscending,
-        int limit, int offset)
-    {
-        this(parentNodeId, assocTypeQNameId, filter, filterIgnoreCase, nameQNameId,
-            sortOrderAscending);
-        this.setLimit(limit);
-        this.setOffset(offset);
     }
 
     public int getLimit()
@@ -104,16 +80,6 @@ public class GetArchivedNodesCannedQueryParams extends ArchivedNodeEntity
     public void setLimit(int limit)
     {
         this.limit = limit;
-    }
-
-    public int getOffset()
-    {
-        return offset;
-    }
-
-    public void setOffset(int offset)
-    {
-        this.offset = offset;
     }
 
 }

--- a/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQueryParams.java
+++ b/repository/src/main/java/org/alfresco/repo/node/archive/GetArchivedNodesCannedQueryParams.java
@@ -37,6 +37,8 @@ public class GetArchivedNodesCannedQueryParams extends ArchivedNodeEntity
 
     private int limit;
 
+    private int offset;
+
     /**
      *
      * @param parentNodeId Long
@@ -70,6 +72,28 @@ public class GetArchivedNodesCannedQueryParams extends ArchivedNodeEntity
         this(parentNodeId, assocTypeQNameId, filter, filterIgnoreCase, nameQNameId,
                 sortOrderAscending);
         this.setLimit(limit);
+        this.setOffset(0);
+    }
+
+    /**
+     *
+     * @param parentNodeId
+     * @param assocTypeQNameId
+     * @param filter
+     * @param filterIgnoreCase
+     * @param nameQNameId
+     * @param sortOrderAscending
+     * @param limit
+     * @param offset
+     */
+    public GetArchivedNodesCannedQueryParams(Long parentNodeId, Long assocTypeQNameId,
+        String filter, Boolean filterIgnoreCase, Long nameQNameId, Boolean sortOrderAscending,
+        int limit, int offset)
+    {
+        this(parentNodeId, assocTypeQNameId, filter, filterIgnoreCase, nameQNameId,
+            sortOrderAscending);
+        this.setLimit(limit);
+        this.setOffset(offset);
     }
 
     public int getLimit()
@@ -80,6 +104,16 @@ public class GetArchivedNodesCannedQueryParams extends ArchivedNodeEntity
     public void setLimit(int limit)
     {
         this.limit = limit;
+    }
+
+    public int getOffset()
+    {
+        return offset;
+    }
+
+    public void setOffset(int offset)
+    {
+        this.offset = offset;
     }
 
 }

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-archived-nodes-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-archived-nodes-common-SqlMap.xml
@@ -8,6 +8,11 @@
     <select id="select_GetArchivedNodesCannedQuery" parameterType="ArchivedNodes" resultMap="alfresco.node.result_ArchivedNodes">
         select
         <include refid="alfresco.node.select_GetAllArchivedNodesCannedQuery"/>
+        <if test="offset != 0">offset ${offset}</if>
         <if test="limit != 0">limit ${limit}</if>
+    </select>
+
+    <select id="select_CountAllArchivedNodes" parameterType="ArchivedNodes" resultType="long">
+        select count(id) from alf_child_assoc where parent_node_id = #{parentNodeId} and type_qname_id = #{assocTypeQNameId}
     </select>
 </mapper>

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-archived-nodes-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-archived-nodes-common-SqlMap.xml
@@ -8,7 +8,6 @@
     <select id="select_GetArchivedNodesCannedQuery" parameterType="ArchivedNodes" resultMap="alfresco.node.result_ArchivedNodes">
         select
         <include refid="alfresco.node.select_GetAllArchivedNodesCannedQuery"/>
-        <if test="offset != 0">offset ${offset}</if>
         <if test="limit != 0">limit ${limit}</if>
     </select>
 


### PR DESCRIPTION
GetArchivedNodesCannedQuery now will return only the required results (page) based on offset(skipCount) and limit(maxItems).
Offset and limit are set as rowBounds for mybatis.
Added count query for GetArchivedNodesCannedQuery in order to preserve the totalItems.
Because GetArchivedNodesCannedQuery returns only the required results, an extra condition was added to establish `hasMoreItems` 