### PR TITLE
MNT-20775 : deleted-nodes with maxitems parameter take longer

### DIFF
--- a/core/src/main/java/org/alfresco/query/AbstractCannedQuery.java
+++ b/core/src/main/java/org/alfresco/query/AbstractCannedQuery.java
@@ -113,7 +113,7 @@ public abstract class AbstractCannedQuery<R> implements CannedQuery<R>
         final List<List<R>> finalPages = pages;
         
         // Has more items beyond requested pages ? ... ie. at least one more page (with at least one result)
-        final boolean hasMoreItems = (rawResults.size() > pagingDetails.getResultsRequiredForPaging());
+        final boolean hasMoreItems = (rawResults.size() > pagingDetails.getResultsRequiredForPaging()) || (totalCount.getFirst() > pagingDetails.getResultsRequiredForPaging());
         
         results = new CannedQueryResults<R>()
         {

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-archived-nodes-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/query-archived-nodes-common-SqlMap.xml
@@ -10,4 +10,8 @@
         <include refid="alfresco.node.select_GetAllArchivedNodesCannedQuery"/>
         <if test="limit != 0">limit ${limit}</if>
     </select>
+
+    <select id="select_CountAllArchivedNodes" parameterType="ArchivedNodes" resultType="long">
+        select count(id) from alf_child_assoc where parent_node_id = #{parentNodeId} and type_qname_id = #{assocTypeQNameId}
+    </select>
 </mapper>


### PR DESCRIPTION
* MNT-20775 : rest api /deleted-nodes with maxitems parameter take longer when there are more items in the trash can
  Based on offset and limit, returns only the required results from database
  Added count query for ArchivedNodes

(cherry picked from commit 14ca5bb726db2be3cecb732e19625bbb6e6d7ce1)