### PR TITLE
MNT-14308: CMIS - optionally request rendition(s) when uploading docs

### DIFF
--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
@@ -231,7 +231,11 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
     protected AlfrescoCmisService getCmisServiceTarget(CMISConnector connector)
     {
         AlfrescoCmisServiceImpl cmisService = new AlfrescoCmisServiceImpl(connector);
-        cmisService.setCmisRequestRenditionsOnCreateDoc(parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet()));
+
+        Set<String> stringSet = parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet());
+        logger.info("getCmisServiceTarget: cmis.create.doc.request.renditions.set="+stringSet);
+        cmisService.setCmisRequestRenditionsOnCreateDoc(stringSet);
+
         return cmisService;
     }
 

--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -25,7 +25,10 @@
  */
 package org.alfresco.opencmis;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionInterceptor;
@@ -57,6 +60,8 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
     private AlfrescoCmisStreamInterceptor cmisStreams;
     private CMISTransactionAwareHolderInterceptor cmisHolder;
     private AuthorityService authorityService;
+
+    private String cmisCreateDocRequestRenditionsSet = null;
 
     /**
      *
@@ -139,6 +144,14 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
         this.cmisHolder = cmisHolder;
     }
 
+    public String getCmisCreateDocRequestRenditionsSet() {
+        return cmisCreateDocRequestRenditionsSet;
+    }
+
+    public void setCmisCreateDocRequestRenditionsSet(String cmisCreateDocRequestRenditionsSet) {
+        this.cmisCreateDocRequestRenditionsSet = cmisCreateDocRequestRenditionsSet;
+    }
+
     @Override
     public void init(Map<String, String> parameters)
     {
@@ -217,6 +230,26 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
     
     protected AlfrescoCmisService getCmisServiceTarget(CMISConnector connector)
     {
-        return new AlfrescoCmisServiceImpl(connector);
+        AlfrescoCmisServiceImpl cmisService = new AlfrescoCmisServiceImpl(connector);
+        cmisService.setCmisRequestRenditionsOnCreateDoc(parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet()));
+        return cmisService;
+    }
+
+    private Set<String> parseCommaSeparatedSet(String str)
+    {
+        Set<String> stringSet = new HashSet<>();
+        if (str != null)
+        {
+            StringTokenizer st = new StringTokenizer(str, ",");
+            while (st.hasMoreTokens())
+            {
+                String entry = st.nextToken().trim();
+                if (!entry.isEmpty())
+                {
+                    stringSet.add(entry);
+                }
+            }
+        }
+        return stringSet;
     }
 }

--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
@@ -1318,7 +1318,7 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
 
         // extract metadata and generate thumbnail asynchronously (if configured - see a-g.p)
         connector.extractMetadata(nodeRef);
-        connector.createThumbnails(nodeRef, cmisRequestRenditionsOnCreateDoc);
+        connector.createThumbnails(nodeRef, getCmisRequestRenditionsOnCreateDoc());
 
         connector.applyVersioningState(nodeRef, versioningState);
 
@@ -1396,7 +1396,7 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
 
             // extract metadata and generate thumbnail asynchronously (if configured - see a-g.p)
             connector.extractMetadata(nodeRef);
-            connector.createThumbnails(nodeRef, cmisRequestRenditionsOnCreateDoc);
+            connector.createThumbnails(nodeRef, getCmisRequestRenditionsOnCreateDoc());
 
             connector.applyVersioningState(nodeRef, versioningState);
             

--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -165,6 +165,16 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
     private Authentication authentication;
     private Map<String, CMISNodeInfo> nodeInfoMap;
     private Map<String, ObjectInfo> objectInfoMap;
+
+    private Set<String> cmisRequestRenditionsOnCreateDoc = null;
+
+    public Set<String> getCmisRequestRenditionsOnCreateDoc() {
+        return cmisRequestRenditionsOnCreateDoc;
+    }
+
+    public void setCmisRequestRenditionsOnCreateDoc(Set<String> cmisRequestRenditionsOnCreateDoc) {
+        this.cmisRequestRenditionsOnCreateDoc = cmisRequestRenditionsOnCreateDoc;
+    }
 
     public AlfrescoCmisServiceImpl(CMISConnector connector)
     {
@@ -1306,9 +1316,9 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
             writer.putContent(contentStream.getStream());
         }
 
-        // extract metadata and generate thumbnail asynchronously
+        // extract metadata and generate thumbnail asynchronously (if configured - see a-g.p)
         connector.extractMetadata(nodeRef);
-        connector.createThumbnails(nodeRef, Collections.singleton("doclib"));
+        connector.createThumbnails(nodeRef, cmisRequestRenditionsOnCreateDoc);
 
         connector.applyVersioningState(nodeRef, versioningState);
 
@@ -1384,9 +1394,9 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
             connector.applyPolicies(nodeRef, type, policies);
             connector.applyACL(nodeRef, type, addAces, removeAces);
 
-            // extract metadata and generate thumbnail asynchronously
+            // extract metadata and generate thumbnail asynchronously (if configured - see a-g.p)
             connector.extractMetadata(nodeRef);
-            connector.createThumbnails(nodeRef, Collections.singleton("doclib"));
+            connector.createThumbnails(nodeRef, cmisRequestRenditionsOnCreateDoc);
 
             connector.applyVersioningState(nodeRef, versioningState);
             

--- a/repository/src/main/resources/alfresco/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/opencmis-context.xml
@@ -86,6 +86,7 @@
         <property name="cmisStreams"            ref="CMISService_Streams" />
         <property name="cmisHolder"             ref="CMISTransactionAwareHolderInterceptor" />
         <property name="authorityService"       ref="AuthorityService" />
+        <property name="cmisCreateDocRequestRenditionsSet" value="${cmis.create.doc.request.renditions.set}" />
     </bean>
 
     <bean id="CMISTransactionAwareHolderInterceptor" class="org.alfresco.opencmis.CMISTransactionAwareHolderInterceptor" />

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -471,6 +471,9 @@ renditionService2.enabled=true
 # Thumbnail Service
 system.thumbnail.generate=true
 
+# when creating doc via CMIS - optionally configure set of renditions names to request async
+cmis.create.doc.request.renditions.set=
+
 # Default thumbnail limits
 # When creating thumbnails, only use the first pageLimit pages
 system.thumbnail.definition.default.timeoutMs=-1


### PR DESCRIPTION
- add new configurable option to request set of renditions when uploading via CMIS (none by default)
- note: in the (unlikely) event a customer *relied* on previous behaviour (rather than dynamic requests) they can override & set to "doclib"