### PR TITLE
MNT-22135 Filter policy to only run on admin auth - Unit test

### DIFF
--- a/repository/src/test/java/org/alfresco/repo/security/authority/AuthorityServiceTest.java
+++ b/repository/src/test/java/org/alfresco/repo/security/authority/AuthorityServiceTest.java
@@ -1770,7 +1770,7 @@ public class AuthorityServiceTest extends TestCase
         pubAuthorityService.deleteAuthority(pubAuthorityService.getName(AuthorityType.GROUP, subGroup1));
         pubAuthorityService.deleteAuthority(pubAuthorityService.getName(AuthorityType.GROUP, subGroup2));
         pubAuthorityService.deleteAuthority(pubAuthorityService.getName(AuthorityType.GROUP, username));
-        pubAuthorityService.deleteAuthority(username);
+        personService.deletePerson(username);
     }
 
     private <T extends Policy> T createClassPolicy(Class<T> policyInterface, QName policyQName, QName triggerOnClass)


### PR DESCRIPTION
Created unit test testIfGroupIsAdminAuthority to check if public method isAdminAuthority correctly validates groups:
* Verify it can identify GROUP_ALFRESCO_ADMINISTRATORS as an admin group
* Verify created groups (non administrators) and users are not considered administrators
* Add a subgroup to the parent group and verify if its still identified as non admin
* Add the group to the administrators group and verify if both group and subgroup are identified correctly as admins
* Add the user to the subgroup and verify if he's an admin
* Create a group with the same name as an admin user, group should not be identified as admin