### PR TITLE
MNT-14308: CMIS - optionally request rendition(s) when uploading docs - part 2

### DIFF
--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -1081,6 +1081,7 @@
         <property name="authorityService"       ref="AuthorityService" />
         <property name="tenantAdminService"     ref="tenantAdminService"/>
         <property name="networksService"        ref="networksService"/>
+        <property name="cmisCreateDocRequestRenditionsSet" value="${cmis.create.doc.request.renditions.set}" />
     </bean>
 
     <bean   id="cmisDispatcherRegistry" class="org.alfresco.opencmis.CMISDispatcherRegistryImpl">

--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
@@ -174,6 +174,11 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
 //                cmisService,
 //                connector.getTypesDefaultMaxItems(), connector.getTypesDefaultDepth(),
 //                connector.getObjectsDefaultMaxItems(), connector.getObjectsDefaultDepth());
+
+        if (logger.isInfoEnabled())
+        {
+            logger.info("init: cmis.create.doc.request.renditions.set=" + cmisCreateDocRequestRenditionsSet);
+        }
     }
 
     @Override
@@ -205,17 +210,16 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
             AuthenticationUtil.clearCurrentSecurityContext();
         }
 
-        Set<String> stringSet = parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet());
-
         AlfrescoCmisService service = getCmisServiceTarget(connector);
         if (service instanceof AlfrescoCmisServiceImpl)
         {
-            logger.info("getService: cmis.create.doc.request.renditions.set=" + stringSet);
+            Set<String> stringSet = parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet());
             ((AlfrescoCmisServiceImpl)service).setCmisRequestRenditionsOnCreateDoc(stringSet);
-        }
-        else
-        {
-            logger.info("getService: ignored - cmis.create.doc.request.renditions.set=" + stringSet);
+
+            if (logger.isTraceEnabled())
+            {
+                logger.trace("getService: cmis.create.doc.request.renditions.set=" + stringSet);
+            }
         }
 
         // Wrap it

--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceFactory.java
@@ -205,8 +205,19 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
             AuthenticationUtil.clearCurrentSecurityContext();
         }
 
+        Set<String> stringSet = parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet());
+
         AlfrescoCmisService service = getCmisServiceTarget(connector);
-        
+        if (service instanceof AlfrescoCmisServiceImpl)
+        {
+            logger.info("getService: cmis.create.doc.request.renditions.set=" + stringSet);
+            ((AlfrescoCmisServiceImpl)service).setCmisRequestRenditionsOnCreateDoc(stringSet);
+        }
+        else
+        {
+            logger.info("getService: ignored - cmis.create.doc.request.renditions.set=" + stringSet);
+        }
+
         // Wrap it
         ProxyFactory proxyFactory = new ProxyFactory(service);
         proxyFactory.addInterface(AlfrescoCmisService.class);
@@ -227,16 +238,10 @@ public class AlfrescoCmisServiceFactory extends AbstractServiceFactory
 
         return wrapperService;
     }
-    
+
     protected AlfrescoCmisService getCmisServiceTarget(CMISConnector connector)
     {
-        AlfrescoCmisServiceImpl cmisService = new AlfrescoCmisServiceImpl(connector);
-
-        Set<String> stringSet = parseCommaSeparatedSet(getCmisCreateDocRequestRenditionsSet());
-        logger.info("getCmisServiceTarget: cmis.create.doc.request.renditions.set="+stringSet);
-        cmisService.setCmisRequestRenditionsOnCreateDoc(stringSet);
-
-        return cmisService;
+        return new AlfrescoCmisServiceImpl(connector);
     }
 
     private Set<String> parseCommaSeparatedSet(String str)


### PR DESCRIPTION
- note: PublicApiAlfrescoCmisServiceFactory extends AlfrescoCmisServiceFactory and overrides getCmisServiceTarget
- hence, also ensure property (cmis.create.doc.request.renditions.set) is set for public rest api spring context

- note: set following log4j.properties: log4j.logger.org.alfresco.opencmis=info