### PR TITLE
MNT-21694 500 error on new logo upload with Legacy transforms

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/TransformationOptionsConverter.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 
 import static org.alfresco.repo.content.MimetypeMap.MIMETYPE_PDF;
+import static org.alfresco.repo.content.transform.magick.ImageTransformationOptions.OPT_COMMAND_OPTIONS;
 import static org.alfresco.repo.rendition2.RenditionDefinition2.ALLOW_ENLARGEMENT;
 import static org.alfresco.repo.rendition2.RenditionDefinition2.ALLOW_PDF_ENLARGEMENT;
 import static org.alfresco.repo.rendition2.RenditionDefinition2.ALPHA_REMOVE;
@@ -122,6 +123,7 @@ public class TransformationOptionsConverter implements InitializingBean
         IMAGE_OPTIONS.addAll(RESIZE_OPTIONS);
         IMAGE_OPTIONS.add(AUTO_ORIENT);
         IMAGE_OPTIONS.add(ALPHA_REMOVE);
+        IMAGE_OPTIONS.add(OPT_COMMAND_OPTIONS);
     }
 
     private static Set<String> PDF_OPTIONS = new HashSet<>(Arrays.asList(new String[]
@@ -284,6 +286,8 @@ public class TransformationOptionsConverter implements InitializingBean
                     }
                     opts.setSourceOptionsList(sourceOptionsList);
                 }
+
+                ifSet(options, OPT_COMMAND_OPTIONS, (v) -> opts.setCommandOptions(v));
             }
         }
         else
@@ -361,13 +365,11 @@ public class TransformationOptionsConverter implements InitializingBean
             {
                 ImageTransformationOptions opts = (ImageTransformationOptions) options;
 
-                // TODO We don't support this any more for security reasons, however it might be possible to
-                // extract some of the well know values and add them to the newer ImageMagick transform options.
+                // From a security viewpoint it would be better not to support the option of passing anything to
+                // ImageMagick. It might be possible to extract some of the well know values and add them to the
+                // T-Engine engine_config.
                 String commandOptions = opts.getCommandOptions();
-                if (commandOptions != null && !commandOptions.isBlank())
-                {
-                    logger.error("ImageMagick commandOptions are no longer supported for security reasons: " + commandOptions);
-                }
+                ifSet(commandOptions != null && !commandOptions.isBlank(), map, OPT_COMMAND_OPTIONS, commandOptions);
 
                 ImageResizeOptions imageResizeOptions = opts.getResizeOptions();
                 if (imageResizeOptions != null)

--- a/repository/src/test/java/org/alfresco/repo/rendition2/TransformationOptionsConverterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/TransformationOptionsConverterTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -582,6 +582,21 @@ public class TransformationOptionsConverterTest
                         "resizeHeight=30 " +
                         "resizeWidth=20 " +
                         "startPage=0 " +
+                        "timeout=-1 ",
+                true);
+    }
+
+    @Test
+    public void testCommandOptionsFromOldOptions()
+    {
+        ImageTransformationOptions oldOptions = new ImageTransformationOptions();
+        oldOptions.setCommandOptions("-resize 350x50> -background none -gravity center");
+
+        assertConverterToMapAndBack(oldOptions, MIMETYPE_IMAGE_JPEG, MIMETYPE_IMAGE_PNG,
+                "ImageTransformationOptions [commandOptions=-resize 350x50> -background none -gravity center, " +
+                        "resizeOptions=null, autoOrient=true]]",
+                "autoOrient=true " + // this is a default - so is also set when uploading a logo
+                        "commandOptions=-resize 350x50> -background none -gravity center " +
                         "timeout=-1 ",
                 true);
     }


### PR DESCRIPTION
The TransformationOptionsConverter class did not convert the newer transform option format a Map<String, String> to the legacy ImageTransformationOptions class that contains the commandOption (OPT_COMMAND_OPTIONS) property. As a result no legacy transformer is asked if it can do the transform.

There are no Legacy transformers in ACS 7, so this fix cannot be applied there as the class has been removed. Fixing on 6.2.N.