### PR TITLE
ACS-1253 Enable Camel JMX management

### DIFF
--- a/packaging/tests/environment/docker-compose-minimal+transforms.yml
+++ b/packaging/tests/environment/docker-compose-minimal+transforms.yml
@@ -38,7 +38,7 @@ services:
         -Dftp.dataPortTo=30099
         -Dshare.host=localhost
         -Daos.baseUrlOverwrite=http://localhost:8082/alfresco/aos
-        -Dmessaging.broker.url=\"failover:(tcp://activemq:61616)?timeout=3000&jms.useCompression=true\"
+        -Dmessaging.broker.url=\"failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true\"
         -DlocalTransform.core-aio.url=http://transform-core-aio:8090/
         -Dimap.server.port=1143
         -Dftp.port=1221

--- a/packaging/tests/environment/docker-compose-minimal.yml
+++ b/packaging/tests/environment/docker-compose-minimal.yml
@@ -38,7 +38,7 @@ services:
         -Dftp.dataPortTo=30099
         -Dshare.host=localhost
         -Daos.baseUrlOverwrite=http://localhost:8082/alfresco/aos
-        -Dmessaging.broker.url=\"failover:(tcp://activemq:61616)?timeout=3000&jms.useCompression=true\"
+        -Dmessaging.broker.url=\"failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true\"
         -Dlocal.transform.service.enabled=false
         -Dlegacy.transform.service.enabled=false
         -Dimap.server.port=1143

--- a/pom.xml
+++ b/pom.xml
@@ -779,6 +779,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-management</artifactId>
+                <version>${dependency.camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-mock</artifactId>
                 <version>${dependency.camel.version}</version>
                 <scope>test</scope>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -689,6 +689,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-mock</artifactId>
             <scope>test</scope>
         </dependency>

--- a/repository/src/main/resources/alfresco/subsystems/Messaging/default/messaging-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Messaging/default/messaging-context.xml
@@ -22,6 +22,7 @@
     <bean id="pooledConnectionFactory" class="org.apache.activemq.pool.PooledConnectionFactory"
         init-method="start" destroy-method="stop">
         <property name="maxConnections" value="${messaging.broker.connections.max}" />
+        <property name="createConnectionOnStartup" value="false"/>
         <property name="connectionFactory" ref="activeMqConnectionFactory" />
     </bean>
     
@@ -85,7 +86,7 @@
 
     <camelContext id="alfrescoCamelContext" xmlns="http://camel.apache.org/schema/spring" useBreadcrumb="true">
         <contextScan/>
-        <camel:jmxAgent id="agent" mbeanObjectDomainName="Alfresco.Camel" />
+        <jmxAgent id="agent" mbeanServerDefaultDomain="Alfresco.Camel" />
         <template id="camelProducerTemplate" defaultEndpoint="direct:alfresco.default" />
     </camelContext>
 

--- a/repository/src/main/resources/alfresco/subsystems/Messaging/default/messaging-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Messaging/default/messaging-context.xml
@@ -86,7 +86,7 @@
 
     <camelContext id="alfrescoCamelContext" xmlns="http://camel.apache.org/schema/spring" useBreadcrumb="true">
         <contextScan/>
-        <jmxAgent id="agent" mbeanServerDefaultDomain="Alfresco.Camel" />
+        <jmxAgent id="agent" mbeanObjectDomainName="Alfresco.Camel" />
         <template id="camelProducerTemplate" defaultEndpoint="direct:alfresco.default" />
     </camelContext>
 

--- a/repository/src/main/resources/alfresco/subsystems/Messaging/default/messaging.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Messaging/default/messaging.properties
@@ -1,5 +1,5 @@
-# External failover broker at tcp://localhost
-messaging.broker.url=failover:(tcp://localhost:61616)?timeout=3000&jms.useCompression=true
+# External failover broker at nio://localhost ("nio" = "tcp" through the java.nio API)
+messaging.broker.url=failover:(nio://localhost:61616)?timeout=3000&jms.useCompression=true
 messaging.broker.ssl=false
 messaging.broker.username=
 messaging.broker.password=


### PR DESCRIPTION
- enable camel JMX management
- add `camel-management` dependency
- disable JMS connection-pool warm-up
- update ActiveMQ URLs to force clients to connect through the `java.nio` APIs