### PR TITLE
REPO-5571

### DIFF
--- a/core/src/main/java/org/alfresco/util/TempFileProvider.java
+++ b/core/src/main/java/org/alfresco/util/TempFileProvider.java
@@ -493,7 +493,7 @@ public class TempFileProvider
                     int countRemoved = removeFiles(file,
                         isLongLifeTempDir(file) ? longLifeBefore : removeBefore, longLifeBefore,
                         true);
-                    logger.debug("Removed " + countRemoved + " files from temp directory: " + file);
+                    logger.debug("Removed " + countRemoved + " files from " + (isLongLifeTempDir(file) ? "temp " : "") + "directory: " + file);
                 }
                 else
                 {

--- a/core/src/main/java/org/alfresco/util/TempFileProvider.java
+++ b/core/src/main/java/org/alfresco/util/TempFileProvider.java
@@ -481,18 +481,19 @@ public class TempFileProvider
             int count = 0;
             for (File file : filesToIterate)
             {
+                if (shouldTheDeletionStop())
+                {
+                    break;
+                }
                 if (file.isDirectory())
                 {
                     // long life for this folder and its children
                     // OR
                     // enter subdirectory and clean it out and remove itsynetics
-                    if (!shouldTheDeletionStop())
-                    {
-                        int countRemoved = removeFiles(file,
-                            isLongLifeTempDir(file) ? longLifeBefore : removeBefore, longLifeBefore,
-                            true);
-                        logger.debug("Removed " + countRemoved + " files from temp directory: " + file);
-                    }
+                    int countRemoved = removeFiles(file,
+                        isLongLifeTempDir(file) ? longLifeBefore : removeBefore, longLifeBefore,
+                        true);
+                    logger.debug("Removed " + countRemoved + " files from temp directory: " + file);
                 }
                 else
                 {
@@ -505,12 +506,6 @@ public class TempFileProvider
                     // it is a file - attempt a delete
                     try
                     {
-                        // only delete if the limits allow
-                        if (shouldTheDeletionStop())
-                        {
-                            return count;
-                        }
-
                         logger.debug("Deleting temp file: " + file);
                         file.delete();
 

--- a/core/src/main/java/org/alfresco/util/TempFileProvider.java
+++ b/core/src/main/java/org/alfresco/util/TempFileProvider.java
@@ -491,7 +491,7 @@ public class TempFileProvider
                     {
                         // long life for this folder and its children
                         int countRemoved = removeFiles(file, longLifeBefore, longLifeBefore, true);  
-                        if (logger.isDebugEnabled())
+                        if (logger.isDebugEnabled() && countRemoved > 0)
                         {
                             logger.debug("Removed " + countRemoved + " files from temp directory: " + file);
                         }
@@ -500,7 +500,7 @@ public class TempFileProvider
                     {
                         // enter subdirectory and clean it out and remove itsynetics
                         int countRemoved = removeFiles(file, removeBefore, longLifeBefore, true);
-                        if (logger.isDebugEnabled())
+                        if (logger.isDebugEnabled() && countRemoved > 0)
                         {
                             logger.debug("Removed " + countRemoved + " files from directory: " + file);
                         }

--- a/core/src/main/java/org/alfresco/util/TempFileProvider.java
+++ b/core/src/main/java/org/alfresco/util/TempFileProvider.java
@@ -483,6 +483,7 @@ public class TempFileProvider
             {
                 if (shouldTheDeletionStop())
                 {
+                    logger.debug("Stopping, limit has been reached.");
                     break;
                 }
                 if (file.isDirectory())

--- a/core/src/main/java/org/alfresco/util/TempFileProvider.java
+++ b/core/src/main/java/org/alfresco/util/TempFileProvider.java
@@ -486,12 +486,13 @@ public class TempFileProvider
                     // long life for this folder and its children
                     // OR
                     // enter subdirectory and clean it out and remove itsynetics
-                    int countRemoved = removeFiles(
-                        file,
-                        isLongLifeTempDir(file) ? longLifeBefore : removeBefore,
-                        longLifeBefore,
-                        true);
-                    logger.debug("Removed " + countRemoved + " files from temp directory: " + file);
+                    if (!shouldTheDeletionStop())
+                    {
+                        int countRemoved = removeFiles(file,
+                            isLongLifeTempDir(file) ? longLifeBefore : removeBefore, longLifeBefore,
+                            true);
+                        logger.debug("Removed " + countRemoved + " files from temp directory: " + file);
+                    }
                 }
                 else
                 {
@@ -505,7 +506,7 @@ public class TempFileProvider
                     try
                     {
                         // only delete if the limits allow
-                        if (shouldTheDeletionContinue())
+                        if (shouldTheDeletionStop())
                         {
                             return count;
                         }
@@ -561,7 +562,7 @@ public class TempFileProvider
          *
          * @return true or false
          */
-        private static boolean shouldTheDeletionContinue()
+        private static boolean shouldTheDeletionStop()
         {
             return maxFilesToDelete != null && maxFilesToDelete.get() <= 0
                 || maxTimeToRun != null && ((jobStartTime + maxTimeToRun.toMillis()) < System

--- a/core/src/main/java/org/alfresco/util/TempFileProvider.java
+++ b/core/src/main/java/org/alfresco/util/TempFileProvider.java
@@ -493,7 +493,7 @@ public class TempFileProvider
                     int countRemoved = removeFiles(file,
                         isLongLifeTempDir(file) ? longLifeBefore : removeBefore, longLifeBefore,
                         true);
-                    logger.debug("Removed " + countRemoved + " files from " + (isLongLifeTempDir(file) ? "temp " : "") + "directory: " + file);
+                    logger.debug("Removed " + countRemoved + " files from " + (isLongLifeTempDir(file) ? "temp " : " ") + "directory: " + file);
                 }
                 else
                 {


### PR DESCRIPTION
## Fixed spammy logs

@rgherghelas found these logs while running the `TempFileCleaner`.
The cleaner had the same behaviour up until now. Now, we don't know whether or not the initial requirements were to display how many files were deleted per folder but if we don't like those logs this PR is ready to address the issue, by only logging when the poller actually deleted something in a folder.

![image](https://user-images.githubusercontent.com/10231850/109026073-04bd8c80-76c8-11eb-88e0-b5c83704e761.png)
