### PR TITLE
ACS-1201: Model integrity violation saving properties

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/forms/processor/node/ContentModelFormProcessor.java
+++ b/repository/src/main/java/org/alfresco/repo/forms/processor/node/ContentModelFormProcessor.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -634,9 +634,12 @@ public abstract class ContentModelFormProcessor<ItemType, PersistType> extends
         {
             try
             {
-                // if the name property changes the rename method of the file folder
-                // service should be called rather than updating the property directly
-                this.fileFolderService.rename(nodeRef, (String) fieldData.getValue());
+                if (!fileInfo.getName().equals(fieldData.getValue()))
+                {
+                    // if the name property changes, the rename method of the file folder
+                    // service should be called rather than updating the property directly
+                    this.fileFolderService.rename(nodeRef, (String) fieldData.getValue());
+                }
             }
             catch (FileExistsException fee)
             {


### PR DESCRIPTION
- Fix the name property persistence in ContentModelFormProcessor to only save when the property value is actually changed. This prevents the FilenameFilteringInterceptor to be called when there are no changes to the file name.