### PR TITLE
MNT-21898 Unexpected ACLs when job runs Fix

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -1483,7 +1483,17 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
 
             // Update ACLs for moved tree
             Long newParentAclId = newParentNode.getAclId();
-            accessControlListDAO.updateInheritance(newChildNodeId, oldParentAclId, newParentAclId);
+
+            // Verify if parent has aspect applied and ACL's are pending
+            if (hasNodeAspect(oldParentNodeId, ContentModel.ASPECT_PENDING_FIX_ACL))
+            {
+                Long oldParentSharedAclId = (Long) this.getNodeProperty(oldParentNodeId, ContentModel.PROP_SHARED_ACL_TO_REPLACE);
+                accessControlListDAO.updateInheritance(newChildNodeId, oldParentSharedAclId, newParentAclId);
+            }
+            else
+            {
+                accessControlListDAO.updateInheritance(newChildNodeId, oldParentAclId, newParentAclId);
+            }
         }
         
         // Done

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AccessControlListDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AccessControlListDAO.java
@@ -91,6 +91,11 @@ public interface AccessControlListDAO
      */
     public List<AclChange> setInheritanceForChildren(NodeRef parent, Long inheritFrom, Long sharedAclToReplace, boolean asyncCall);
 
+    /**
+     * Set the inheritance on a given node and it's children. If an unexpected ACL occurs in a child, it can be overriden by setting forceSharedACL
+     */
+    public List<AclChange> setInheritanceForChildren(NodeRef parent, Long inheritFrom, Long sharedAclToReplace, boolean asyncCall, boolean forceSharedACL);
+
     public Long getIndirectAcl(NodeRef nodeRef);
 
     public Long getInheritedAcl(NodeRef nodeRef);

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -92,7 +92,6 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
 
     private int maxItemBatchSize = 100;
     private int numThreads = 4;
-    private boolean forceSharedACL = false;
 
     private ClassPolicyDelegate<OnInheritPermissionsDisabled> onInheritPermissionsDisabledDelegate;
     private PolicyComponent policyComponent;
@@ -132,11 +131,6 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
     public void setMaxItemBatchSize(int maxItemBatchSize)
     {
         this.maxItemBatchSize = maxItemBatchSize;
-    }
-
-    public void setForceSharedACL(boolean forceSharedACL)
-    {
-        this.forceSharedACL = forceSharedACL;
     }
 
     public void setLockTimeToLive(long lockTimeToLive)
@@ -286,27 +280,20 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
                     Long inheritFrom = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_INHERIT_FROM_ACL);
                     Long sharedAclToReplace = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_SHARED_ACL_TO_REPLACE);
 
-                    try
+                    // set inheritance using retrieved prop
+                    accessControlListDAO.setInheritanceForChildren(nodeRef, inheritFrom, sharedAclToReplace, true, true);
+
+                    // Remove aspect
+                    accessControlListDAO.removePendingAclAspect(nodeId);
+
+                    if (!policyIgnoreUtil.ignorePolicy(nodeRef))
                     {
-                        // set inheritance using retrieved prop
-                        accessControlListDAO.setInheritanceForChildren(nodeRef, inheritFrom, sharedAclToReplace, true, forceSharedACL);
+                        boolean transformedToAsyncOperation = toBoolean(
+                                (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY));
 
-                        // Remove aspect
-                        accessControlListDAO.removePendingAclAspect(nodeId);
-
-                        if (!policyIgnoreUtil.ignorePolicy(nodeRef))
-                        {
-                            boolean transformedToAsyncOperation = toBoolean(
-                                    (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY));
-
-                            OnInheritPermissionsDisabled onInheritPermissionsDisabledPolicy = onInheritPermissionsDisabledDelegate
-                                    .get(ContentModel.TYPE_BASE);
-                            onInheritPermissionsDisabledPolicy.onInheritPermissionsDisabled(nodeRef, transformedToAsyncOperation);
-                        }
-                    }
-                    catch (ConcurrencyFailureException e)
-                    {
-                        log.error(e);
+                        OnInheritPermissionsDisabled onInheritPermissionsDisabledPolicy = onInheritPermissionsDisabledDelegate
+                                .get(ContentModel.TYPE_BASE);
+                        onInheritPermissionsDisabledPolicy.onInheritPermissionsDisabled(nodeRef, transformedToAsyncOperation);
                     }
 
                     if (log.isDebugEnabled())

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.batch.BatchProcessWorkProvider;
 import org.alfresco.repo.batch.BatchProcessor;
+import org.alfresco.repo.batch.BatchProcessor.BatchProcessWorker;
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.node.NodeDAO.NodeRefQueryCallback;
 import org.alfresco.repo.lock.JobLockService;
@@ -50,6 +51,7 @@ import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.security.permissions.PermissionServicePolicies;
 import org.alfresco.repo.security.permissions.PermissionServicePolicies.OnInheritPermissionsDisabled;
 import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.repo.transaction.TransactionListenerAdapter;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -64,6 +66,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.ConcurrencyFailureException;
 
 /**
@@ -260,7 +263,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
         {
         }
 
-        public void process(final NodeRef nodeRef) throws Throwable
+        public void process(final NodeRef nodeRef) 
         {
             RunAsWork<Void> findAndUpdateAclRunAsWork = new RunAsWork<Void>()
             {
@@ -272,39 +275,41 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
                         log.debug(String.format("Processing node %s", nodeRef));
                     }
 
-                    final Long nodeId = nodeDAO.getNodePair(nodeRef).getFirst();
-
-                    // MNT-22009 - If node was deleted and in archive store, remove the aspect and properties and do not
-                    // process
-                    if (nodeRef.getStoreRef().equals(StoreRef.STORE_REF_ARCHIVE_SPACESSTORE))
-                    {
-                        accessControlListDAO.removePendingAclAspect(nodeId);
-                        return null;
-                    }
-
-                    // retrieve acl properties from node
-                    Long inheritFrom = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_INHERIT_FROM_ACL);
-                    Long sharedAclToReplace = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_SHARED_ACL_TO_REPLACE);
-
                     try
                     {
+                        final Long nodeId = nodeDAO.getNodePair(nodeRef).getFirst();
+
+                        // MNT-22009 - If node was deleted and in archive store, remove the aspect and properties and do
+                        // not
+                        // process
+                        if (nodeRef.getStoreRef().equals(StoreRef.STORE_REF_ARCHIVE_SPACESSTORE))
+                        {
+                            accessControlListDAO.removePendingAclAspect(nodeId);
+                            return null;
+                        }
+
+                        // retrieve acl properties from node
+                        Long inheritFrom = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_INHERIT_FROM_ACL);
+                        Long sharedAclToReplace = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_SHARED_ACL_TO_REPLACE);
+
                         // set inheritance using retrieved prop
-                        accessControlListDAO.setInheritanceForChildren(nodeRef, inheritFrom, sharedAclToReplace, true, forceSharedACL);
+                        accessControlListDAO.setInheritanceForChildren(nodeRef, inheritFrom, sharedAclToReplace, true,
+                                forceSharedACL);
 
                         // Remove aspect
                         accessControlListDAO.removePendingAclAspect(nodeId);
 
                         if (!policyIgnoreUtil.ignorePolicy(nodeRef))
                         {
-                            boolean transformedToAsyncOperation = toBoolean(
-                                    (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY));
+                            boolean transformedToAsyncOperation = toBoolean((Boolean) AlfrescoTransactionSupport
+                                    .getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY));
 
                             OnInheritPermissionsDisabled onInheritPermissionsDisabledPolicy = onInheritPermissionsDisabledDelegate
                                     .get(ContentModel.TYPE_BASE);
                             onInheritPermissionsDisabledPolicy.onInheritPermissionsDisabled(nodeRef, transformedToAsyncOperation);
                         }
                     }
-                    catch (ConcurrencyFailureException e)
+                    catch (Exception e)
                     {
                         log.error(e);
                     }
@@ -322,6 +327,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
             AuthenticationUtil.runAs(findAndUpdateAclRunAsWork, AuthenticationUtil.getSystemUserName());
         }
     };
+    
 
     private class GetNodesWithAspectCallback implements NodeRefQueryCallback
     {

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -311,7 +311,8 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
                     }
                     catch (Exception e)
                     {
-                        log.error(e);
+                        log.error("Job could not process pending ACL node " + nodeRef + ": " + e);
+                        e.printStackTrace();
                     }
 
                     if (log.isDebugEnabled())

--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -117,6 +117,7 @@
         <property name="nodeDAO" ref="nodeDAO"/>
         <property name="maxItemBatchSize" value="${system.fixedACLsUpdater.maxItemBatchSize}"/>
         <property name="numThreads" value="${system.fixedACLsUpdater.numThreads}"/>
+        <property name="forceSharedACL" value="${system.fixedACLsUpdater.forceSharedACL}"/>
         <property name="lockTimeToLive" value="${system.fixedACLsUpdater.lockTTL}"/>
         <property name="policyComponent" ref="policyComponent"/>
         <property name="policyIgnoreUtil" ref="policyIgnoreUtil"/>

--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -117,7 +117,6 @@
         <property name="nodeDAO" ref="nodeDAO"/>
         <property name="maxItemBatchSize" value="${system.fixedACLsUpdater.maxItemBatchSize}"/>
         <property name="numThreads" value="${system.fixedACLsUpdater.numThreads}"/>
-        <property name="forceSharedACL" value="${system.fixedACLsUpdater.forceSharedACL}"/>
         <property name="lockTimeToLive" value="${system.fixedACLsUpdater.lockTTL}"/>
         <property name="policyComponent" ref="policyComponent"/>
         <property name="policyIgnoreUtil" ref="policyIgnoreUtil"/>

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1082,8 +1082,6 @@ system.fixedACLsUpdater.lockTTL=10000
 system.fixedACLsUpdater.maxItemBatchSize=100
 # fixedACLsUpdater - the number of threads to use
 system.fixedACLsUpdater.numThreads=4
-# fixedACLsUpdater - Force shared ACL to propagate through children even if there is an unexpected ACL
-system.fixedACLsUpdater.forceSharedACL=false
 # fixedACLsUpdater cron expression - fire at midnight every day
 system.fixedACLsUpdater.cronExpression=0 0 0 * * ? 
 

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1082,6 +1082,8 @@ system.fixedACLsUpdater.lockTTL=10000
 system.fixedACLsUpdater.maxItemBatchSize=100
 # fixedACLsUpdater - the number of threads to use
 system.fixedACLsUpdater.numThreads=4
+# fixedACLsUpdater - Force shared ACL to propagate through children even if there is an unexpected ACL
+system.fixedACLsUpdater.forceSharedACL=false
 # fixedACLsUpdater cron expression - fire at midnight every day
 system.fixedACLsUpdater.cronExpression=0 0 0 * * ? 
 

--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -90,8 +90,8 @@ public class FixedAclUpdaterTest extends TestCase
     private CheckOutCheckInService checkOutCheckInService;
     private ContentService contentService;
     private AuthorityService authorityService;
-    private static final long MAX_TRANSACTION_TIME_DEFAULT = 50;
-    private static final int[] filesPerLevelMoreFolders = { 5, 5, 5, 5, 1, 1, 1 };
+    private static final long MAX_TRANSACTION_TIME_DEFAULT = 10;
+    private static final int[] filesPerLevelMoreFolders = { 5, 1, 1, 1, 1, 1, 1 };
     private static final int[] filesPerLevelMoreFiles = { 5, 100 };
     private long maxTransactionTime;
     private static HashMap<Integer, Class<?>> errors;
@@ -765,7 +765,7 @@ public class FixedAclUpdaterTest extends TestCase
 
             ACLComparator aclComparator = new ACLComparator(originFolderWithPendingAclChild);
 
-            // Trigger job without forcing the shared ACL, 1 error is expected
+            // Trigger job without forcing the shared ACL, only 1 error is expected
             triggerFixedACLJob(false);
             assertEquals("Unexpected number of errors", 1, getNodesCountWithPendingFixedAclAspect());
 

--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -91,7 +91,7 @@ public class FixedAclUpdaterTest extends TestCase
     private ContentService contentService;
     private AuthorityService authorityService;
     private static final long MAX_TRANSACTION_TIME_DEFAULT = 50;
-    private static final int[] filesPerLevelMoreFolders = { 5, 3, 1, 50 };
+    private static final int[] filesPerLevelMoreFolders = { 5, 5, 5, 5, 1, 1, 1 };
     private static final int[] filesPerLevelMoreFiles = { 5, 100 };
     private long maxTransactionTime;
     private static HashMap<Integer, Class<?>> errors;
@@ -306,7 +306,7 @@ public class FixedAclUpdaterTest extends TestCase
     public void testSyncCopyNoTimeOut() throws FileExistsException, FileNotFoundException
     {
         NodeRef originalRef = createFolderHierarchyInRootForFolderTests("originFolder");
-        NodeRef targetRef = createFolderHierarchyInRootForFolderTests("targetFolder");
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("targetFolder");
 
         // Get ACLS for later comparison
         ACLComparator aclComparatorOrigin = new ACLComparator(originalRef);
@@ -315,6 +315,19 @@ public class FixedAclUpdaterTest extends TestCase
         {
             maxTransactionTime = 86400000;
             setFixedAclMaxTransactionTime(permissionsDaoComponent, homeFolderNodeRef, maxTransactionTime);
+
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
 
             // Set Shared permissions on origin
             permissionService.setInheritParentPermissions(originalRef, true, false);
@@ -343,7 +356,7 @@ public class FixedAclUpdaterTest extends TestCase
         finally
         {
             deleteNodes(originalRef);
-            deleteNodes(targetRef);
+            deleteNodes(targetRefBase);
         }
     }
 
@@ -354,14 +367,26 @@ public class FixedAclUpdaterTest extends TestCase
     public void testAsyncWithNodeCopy()
     {
         NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyOriginFolder");
-        NodeRef targetRef = createFile(fileFolderService, homeFolderNodeRef, "testAsyncWithNodeCopyTargetFolder",
-                ContentModel.TYPE_FOLDER);
-
-        // Get ACLS for later comparison
-        ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyTargetFolder");
 
         try
         {
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+
             // Set permissions on target folder
             txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
                 permissionService.setInheritParentPermissions(targetRef, false, false);
@@ -410,7 +435,7 @@ public class FixedAclUpdaterTest extends TestCase
         finally
         {
             deleteNodes(folderRef);
-            deleteNodes(targetRef);
+            deleteNodes(targetRefBase);
         }
     }
 
@@ -421,13 +446,26 @@ public class FixedAclUpdaterTest extends TestCase
     public void testAsyncWithNodeCopyToPendingFolder()
     {
         NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyOriginFolder");
-        NodeRef targetRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyTargetFolder");
-
-        // Get ACLS for later comparison
-        ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyTargetFolder");
 
         try
         {
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+
             // Set permissions on target folder
             txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
                 permissionService.setInheritParentPermissions(targetRef, false, false);
@@ -487,7 +525,7 @@ public class FixedAclUpdaterTest extends TestCase
         finally
         {
             deleteNodes(folderRef);
-            deleteNodes(targetRef);
+            deleteNodes(targetRefBase);
         }
     }
 
@@ -499,13 +537,26 @@ public class FixedAclUpdaterTest extends TestCase
     public void testAsyncWithNodeCopyParentToChildPendingFolder()
     {
         NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyOriginFolder");
-        NodeRef targetRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyTargetFolder");
-
-        // Get ACLS for later comparison
-        ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeCopyTargetFolder");
 
         try
         {
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+
             // Set permissions on target folder
             txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
                 permissionService.setInheritParentPermissions(targetRef, false, false);
@@ -585,7 +636,151 @@ public class FixedAclUpdaterTest extends TestCase
         finally
         {
             deleteNodes(folderRef);
-            deleteNodes(targetRef);
+            deleteNodes(targetRefBase);
+        }
+    }
+
+    /*
+     * Move child of node that has the aspect to a child folder of a folder that also has the aspect applied before job
+     * runs
+     */
+    @Test
+    public void testAsyncWithNodeMoveChildToChildPendingFolder()
+    {
+        NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveChildToChildPendingFolderOrigin");
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveChildToChildPendingFolderTarget");
+
+        try
+        {
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
+
+            // Set permissions on a child to get a new shared ACL with pending acl nodes
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRef, true, false);
+                permissionService.setPermission(targetRef, TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR, true);
+                return null;
+            }, false, true);
+
+            // Get target Folder with a pending ACL
+            NodeRef targetFolderWithPendingAcl = getFirstNodeWithAclPending(ContentModel.TYPE_FOLDER, targetRef);
+            assertNotNull("No children folders were found with pendingFixACl aspect", targetFolderWithPendingAcl);
+            NodeRef targetFolderWithPendingAclChild = nodeDAO
+                    .getNodePair(getChild(nodeDAO.getNodePair(targetFolderWithPendingAcl).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorTarget = new ACLComparator(targetFolderWithPendingAcl);
+            aclComparatorTarget.setOriginalPermission(TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR);
+
+            // Set permissions on origin folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(folderRef, true, false);
+                permissionService.setPermission(folderRef, TEST_GROUP_NAME_FULL, DEFAULT_PERMISSION, true);
+                return null;
+            }, false, true);
+
+            // Find a pending ACL folder
+            NodeRef originFolderWithPendingAcl = getFirstNodeWithAclPending(ContentModel.TYPE_FOLDER, folderRef);
+            assertNotNull("No children folders were found with pendingFixACl aspect", originFolderWithPendingAcl);
+            NodeRef originFolderWithPendingAclChild = nodeDAO
+                    .getNodePair(getChild(nodeDAO.getNodePair(originFolderWithPendingAcl).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorMovedNode = new ACLComparator(originFolderWithPendingAclChild);
+            aclComparatorMovedNode.setOriginalPermission(TEST_GROUP_NAME_FULL, DEFAULT_PERMISSION);
+
+            // Move one pending folder into the other
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                fileFolderService.move(originFolderWithPendingAclChild, targetFolderWithPendingAclChild, "movedFolder");
+                return null;
+            }, false, true);
+
+            // Trigger job
+            triggerFixedACLJob();
+
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+            assertTrue("Moved node did not inherit permissions from target",
+                    aclComparatorMovedNode.hasPermission(TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR));
+            assertTrue("Child of Pending Moved node did not inherit permissions from target",
+                    aclComparatorMovedNode.firstChildHasPermission(TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR));
+            assertFalse("Moved node kept original permissions", aclComparatorMovedNode.parentHasOriginalPermission());
+            assertFalse("Child of Moved node kept original permissions",
+                    aclComparatorMovedNode.firstChildHasOriginalPermission());
+        }
+        finally
+        {
+            deleteNodes(folderRef);
+            deleteNodes(targetRefBase);
+        }
+    }
+
+    /*
+     * Create a conflicting ACL on a node and then try to run the job normally, without forcing the ACL to get the
+     * expected error and then run it again with the forcedShareACL property as true so it can override the problematic
+     * ACL
+     */
+    @Test
+    public void testAsyncWithErrorsForceSharedACL()
+    {
+        NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithErrorsForceSharedACL");
+
+        try
+        {
+            // Set permissions on origin folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(folderRef, true, false);
+                permissionService.setPermission(folderRef, TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR, true);
+                return null;
+            }, false, true);
+
+            // Find a pending ACL folder
+            NodeRef originFolderWithPendingAcl = getFirstNodeWithAclPending(ContentModel.TYPE_FOLDER, folderRef);
+            assertNotNull("No children folders were found with pendingFixACl aspect", originFolderWithPendingAcl);
+            NodeRef originFolderWithPendingAclChild = nodeDAO
+                    .getNodePair(getChild(nodeDAO.getNodePair(originFolderWithPendingAcl).getFirst())).getSecond();
+
+            // Create a new ACL elsewhere and put the shared ACL (from a child) on the pending node child to simulate
+            // conflict
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                NodeRef tempNode = createFile(fileFolderService, folderRef, "testAsyncWithErrorsForceSharedACLTemp",
+                        ContentModel.TYPE_FOLDER);
+                permissionService.setInheritParentPermissions(tempNode, false, false);
+                permissionService.setPermission(tempNode, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                NodeRef tempNodeChild = createFile(fileFolderService, tempNode, "testAsyncWithErrorsForceSharedACLTempChild",
+                        ContentModel.TYPE_FOLDER);
+                setACL(permissionsDaoComponent, originFolderWithPendingAclChild,
+                        nodeDAO.getNodeAclId(nodeDAO.getNodePair(tempNodeChild).getFirst()));
+                return null;
+            }, false, true);
+
+            ACLComparator aclComparator = new ACLComparator(originFolderWithPendingAclChild);
+
+            // Trigger job without forcing the shared ACL, 1 error is expected
+            triggerFixedACLJob(false);
+            assertEquals("Unexpected number of errors", 1, getNodesCountWithPendingFixedAclAspect());
+
+            // Trigger job forcing the shared ACL
+            triggerFixedACLJob(true);
+
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+            assertTrue("Child of node with conflict does not have correct permissions",
+                    aclComparator.firstChildHasPermission(TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR));
+            assertTrue("Node with conflict does not have correct permissions",
+                    aclComparator.hasPermission(TEST_GROUP_NAME_FULL, PermissionService.COORDINATOR));
+        }
+        finally
+        {
+            deleteNodes(folderRef);
         }
     }
 
@@ -596,14 +791,26 @@ public class FixedAclUpdaterTest extends TestCase
     public void testAsyncWithNodeMove()
     {
         NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveOriginFolder");
-        NodeRef targetRef = createFile(fileFolderService, homeFolderNodeRef, "testAsyncWithNodeMoveTargetFolder",
-                ContentModel.TYPE_FOLDER);
-
-        // Get ACLS for later comparison
-        ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveTargetFolder");
 
         try
         {
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+
             // Set permissions on target folder
             txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
                 permissionService.setInheritParentPermissions(targetRef, false, false);
@@ -649,7 +856,7 @@ public class FixedAclUpdaterTest extends TestCase
         finally
         {
             deleteNodes(folderRef);
-            deleteNodes(targetRef);
+            deleteNodes(targetRefBase);
         }
     }
 
@@ -660,13 +867,27 @@ public class FixedAclUpdaterTest extends TestCase
     public void testAsyncWithNodeMoveToPendingFolder()
     {
         NodeRef folderRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveOriginFolder");
-        NodeRef targetRef = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveTargetFolder");
-
-        // Get ACLS for later comparison
-        ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+        NodeRef targetRefBase = createFolderHierarchyInRootForFolderTests("testAsyncWithNodeMoveTargetFolder");
 
         try
         {
+
+            // Set permissions on target folder
+            txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                permissionService.setInheritParentPermissions(targetRefBase, true, false);
+                permissionService.setPermission(targetRefBase, TEST_GROUP_NAME_FULL, PermissionService.CONSUMER, true);
+                return null;
+            }, false, true);
+
+            // Trigger the job so the target folder structure has a different base ACL
+            triggerFixedACLJob();
+            assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
+
+            NodeRef targetRef = nodeDAO.getNodePair(getChild(nodeDAO.getNodePair(targetRefBase).getFirst())).getSecond();
+
+            // Get ACLS for later comparison
+            ACLComparator aclComparatorTarget = new ACLComparator(targetRef);
+
             // Set permissions on target folder
             txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
                 permissionService.setInheritParentPermissions(targetRef, false, false);
@@ -723,7 +944,7 @@ public class FixedAclUpdaterTest extends TestCase
         finally
         {
             deleteNodes(folderRef);
-            deleteNodes(targetRef);
+            deleteNodes(targetRefBase);
         }
     }
 
@@ -1250,6 +1471,19 @@ public class FixedAclUpdaterTest extends TestCase
         }
     }
 
+    private static void setACL(PermissionsDaoComponent permissionsDaoComponent, NodeRef nodeRef, long aclId)
+    {
+        if (permissionsDaoComponent instanceof ADMPermissionsDaoComponentImpl)
+        {
+            AccessControlListDAO acldao = ((ADMPermissionsDaoComponentImpl) permissionsDaoComponent).getACLDAO(nodeRef);
+            if (acldao instanceof ADMAccessControlListDAO)
+            {
+                ADMAccessControlListDAO admAcLDao = (ADMAccessControlListDAO) acldao;
+                admAcLDao.setAccessControlList(nodeRef, aclId);
+            }
+        }
+    }
+
     private NodeRef createFolderHierarchyInRoot(String folderName, int[] filesPerLevel)
     {
         return txnHelper.doInTransaction((RetryingTransactionCallback<NodeRef>) () -> {
@@ -1319,12 +1553,18 @@ public class FixedAclUpdaterTest extends TestCase
 
     private void triggerFixedACLJob()
     {
+        triggerFixedACLJob(false);
+    }
+
+    private void triggerFixedACLJob(boolean forceSharedACL)
+    {
         // run the fixedAclUpdater until there is nothing more to fix (running the updater may create more to fix up) or
         // the count doesn't change for 3 cycles, meaning we have a problem.
         txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
             int count = 0;
             int previousCount = 0;
             int rounds = 0;
+            fixedAclUpdater.setForceSharedACL(forceSharedACL);
             do
             {
                 previousCount = count;

--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -1596,8 +1596,13 @@ public class FixedAclUpdaterTest extends TestCase
                         isDescendent = true;
                     }
                 }
+
                 if (isDescendent && nodeDAO.getNodeType(nodeDAO.getNodePair(nodeRef).getFirst()).equals(nodeType))
                 {
+                    // If folder, the tests will need a child and a grandchild to verify permissions
+                    if (nodeType.equals(ContentModel.TYPE_FOLDER) && !hasGrandChilden(nodeRef)) {
+                        continue;
+                    }
                     return nodeRef;
                 }
             }
@@ -1617,12 +1622,28 @@ public class FixedAclUpdaterTest extends TestCase
                 NodeRef nodeRef = nodesWithAclPendingAspect.get(i);
                 if (nodeDAO.getNodeType(nodeDAO.getNodePair(nodeRef).getFirst()).equals(nodeType))
                 {
+                    // If folder, the tests will need a child and a grandchild to verify permissions
+                    if (nodeType.equals(ContentModel.TYPE_FOLDER) && !hasGrandChilden(nodeRef)) {
+                        continue;
+                    }
                     return nodeRef;
                 }
             }
             return null;
         }, false, true);
 
+    }
+
+    private boolean hasGrandChilden(NodeRef nodeRef)
+    {
+        Long nodeId = nodeDAO.getNodePair(nodeRef).getFirst();
+        Long childId = getChild(nodeId);
+        Long grandChild = null;
+        if (childId != null)
+        {
+            grandChild = getChild(childId);
+        }
+        return (grandChild != null);
     }
 
     private void deleteNodes(NodeRef folder)

--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -120,6 +120,8 @@ public class FixedAclUpdaterTest extends TestCase
         homeFolderNodeRef = repository.getCompanyHome();
         maxTransactionTime = MAX_TRANSACTION_TIME_DEFAULT;
         setFixedAclMaxTransactionTime(permissionsDaoComponent, homeFolderNodeRef, maxTransactionTime);
+        
+        txnHelper.setMaxRetries(1);
     }
 
     @Override
@@ -765,12 +767,8 @@ public class FixedAclUpdaterTest extends TestCase
 
             ACLComparator aclComparator = new ACLComparator(originFolderWithPendingAclChild);
 
-            // Trigger job without forcing the shared ACL, 1 error is expected
-            triggerFixedACLJob(false);
-            assertEquals("Unexpected number of errors", 1, getNodesCountWithPendingFixedAclAspect());
-
             // Trigger job forcing the shared ACL
-            triggerFixedACLJob(true);
+            triggerFixedACLJob();
 
             assertEquals("Not all nodes were processed", 0, getNodesCountWithPendingFixedAclAspect());
             assertTrue("Child of node with conflict does not have correct permissions",
@@ -1553,18 +1551,12 @@ public class FixedAclUpdaterTest extends TestCase
 
     private void triggerFixedACLJob()
     {
-        triggerFixedACLJob(false);
-    }
-
-    private void triggerFixedACLJob(boolean forceSharedACL)
-    {
         // run the fixedAclUpdater until there is nothing more to fix (running the updater may create more to fix up) or
         // the count doesn't change for 3 cycles, meaning we have a problem.
         txnHelper.doInTransaction((RetryingTransactionCallback<Void>) () -> {
             int count = 0;
             int previousCount = 0;
             int rounds = 0;
-            fixedAclUpdater.setForceSharedACL(forceSharedACL);
             do
             {
                 previousCount = count;


### PR DESCRIPTION
 - On move node, verify if parent has pending acl aspect applied and consider the pending shared ACL to update inheritance to avoid ending up with mixed permissions as children of pending acl nodes do not have the correct acls and when moved, keep their wrong acl.
 - Add public method setInheritanceForChildren that receives an additional param: forceSharedACL. If an unexpected ACL occurs in a child, it can be overridden by setting it.
 - Implement method setInheritanceForChildren that receives an additional parameter: forceSharedACL
 - Add method setFixedAcls that receives an additional parameter: forceSharedACL - When a child node has an unexpected ACL, setting this parameter to true will force it to assume the new shared ACL instead of throwing a concurrency exception. When the shared ACL is forces, a warning is thrown in the log informing on what node exactly are we forcing the ACL. This is only possible when the child ACL is type SHARED and when it has an unexpected ACL
- All methods that called setFixedAcls without the new parameter will continue to operate as normal, as having forceSharedACL=false
- Added property forceSharedACL to the FixedACLUpdaterJob. If set to true it will force shared ACL to propagate through children even if there is an unexpected ACL
 - When there is a exception detected when doing setInheritanceForChildren on the job, catch and log the error, but do not rollback the entire batch
 - On copy/move unit tests I changed the ACL of the target folders on copy and move tests so that the old shared ACL accessed was never the same for origin and target folders as happens when performing these operations between sites
- Added unit test to verify fix for MNT-21898 - testAsyncWithNodeMoveChildToChildPendingFolder
- Added unit test to verify system property for the job: forceSharedACL - testAsyncWithErrorsForceSharedACL

Builds:
https://travis-ci.com/github/Alfresco/alfresco-community-repo/builds/219794392
https://travis-ci.com/github/Alfresco/alfresco-enterprise-repo/builds/219805926
https://travis-ci.com/github/Alfresco/acs-packaging/builds/219851627