### PR TITLE
MNT-22040 Copying nodes that contain sys:pendingFixAcl aspect (#188)

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AccessControlListDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AccessControlListDAO.java
@@ -106,4 +106,6 @@ public interface AccessControlListDAO
     public void updateInheritance(Long childNodeId, Long oldParentAclId, Long newParentAclId);
     
     public void setFixedAcls(Long nodeId, Long inheritFrom, Long mergeFrom, Long sharedAclToReplace, List<AclChange> changes, boolean set);
+
+    public void removePendingAclAspect(Long nodeId);
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -53,7 +53,6 @@ import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.repo.transaction.TransactionListenerAdapter;
 import org.alfresco.service.cmr.repository.NodeRef;
-import org.alfresco.service.cmr.repository.NodeRef.Status;
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
@@ -93,8 +92,8 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
     private int maxItemBatchSize = 100;
     private int numThreads = 4;
 
-    private ClassPolicyDelegate<OnInheritPermissionsDisabled> onInheritPermissionsDisabledDelegate;    
-    private PolicyComponent policyComponent;    
+    private ClassPolicyDelegate<OnInheritPermissionsDisabled> onInheritPermissionsDisabledDelegate;
+    private PolicyComponent policyComponent;
     private PolicyIgnoreUtil policyIgnoreUtil;
 
     public void setNumThreads(int numThreads)
@@ -137,8 +136,8 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
     {
         this.lockTimeToLive = lockTimeToLive;
         this.lockRefreshTime = lockTimeToLive / 2;
-    }    
-    
+    }
+
     public void setPolicyComponent(PolicyComponent policyComponent)
     {
         this.policyComponent = policyComponent;
@@ -151,7 +150,8 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
 
     public void init()
     {
-        onInheritPermissionsDisabledDelegate = policyComponent.registerClassPolicy(PermissionServicePolicies.OnInheritPermissionsDisabled.class);
+        onInheritPermissionsDisabledDelegate = policyComponent
+                .registerClassPolicy(PermissionServicePolicies.OnInheritPermissionsDisabled.class);
     }
 
     private class GetNodesWithAspects
@@ -264,35 +264,34 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
                     {
                         log.debug(String.format("Processing node %s", nodeRef));
                     }
+
                     final Long nodeId = nodeDAO.getNodePair(nodeRef).getFirst();
 
                     // MNT-22009 - If node was deleted and in archive store, remove the aspect and properties and do not
                     // process
                     if (nodeRef.getStoreRef().equals(StoreRef.STORE_REF_ARCHIVE_SPACESSTORE))
                     {
-                        nodeDAO.removeNodeAspects(nodeId, aspects);
-                        nodeDAO.removeNodeProperties(nodeId, PENDING_FIX_ACL_ASPECT_PROPS);
+                        accessControlListDAO.removePendingAclAspect(nodeId);
                         return null;
                     }
 
                     // retrieve acl properties from node
-                    Long inheritFrom = (Long) nodeDAO.getNodeProperty(nodeId,
-                            ContentModel.PROP_INHERIT_FROM_ACL);
-                    Long sharedAclToReplace = (Long) nodeDAO.getNodeProperty(nodeId,
-                            ContentModel.PROP_SHARED_ACL_TO_REPLACE);
+                    Long inheritFrom = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_INHERIT_FROM_ACL);
+                    Long sharedAclToReplace = (Long) nodeDAO.getNodeProperty(nodeId, ContentModel.PROP_SHARED_ACL_TO_REPLACE);
 
                     // set inheritance using retrieved prop
-                    accessControlListDAO.setInheritanceForChildren(nodeRef, inheritFrom, sharedAclToReplace,
-                            true);
+                    accessControlListDAO.setInheritanceForChildren(nodeRef, inheritFrom, sharedAclToReplace, true);
 
-                    nodeDAO.removeNodeAspects(nodeId, aspects);
-                    nodeDAO.removeNodeProperties(nodeId, PENDING_FIX_ACL_ASPECT_PROPS);
-                    
+                    // Remove aspect
+                    accessControlListDAO.removePendingAclAspect(nodeId);
+
                     if (!policyIgnoreUtil.ignorePolicy(nodeRef))
                     {
-                        boolean transformedToAsyncOperation = toBoolean((Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY));
+                        boolean transformedToAsyncOperation = toBoolean(
+                                (Boolean) AlfrescoTransactionSupport.getResource(FixedAclUpdater.FIXED_ACL_ASYNC_REQUIRED_KEY));
 
-                        OnInheritPermissionsDisabled onInheritPermissionsDisabledPolicy = onInheritPermissionsDisabledDelegate.get(ContentModel.TYPE_BASE);
+                        OnInheritPermissionsDisabled onInheritPermissionsDisabledPolicy = onInheritPermissionsDisabledDelegate
+                                .get(ContentModel.TYPE_BASE);
                         onInheritPermissionsDisabledPolicy.onInheritPermissionsDisabled(nodeRef, transformedToAsyncOperation);
                     }
 
@@ -406,12 +405,8 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
 
             AclWorkProvider provider = new AclWorkProvider();
             AclWorker worker = new AclWorker();
-            BatchProcessor<NodeRef> bp = new BatchProcessor<>(
-                    "FixedAclUpdater",
-                    transactionService.getRetryingTransactionHelper(),
-                    provider,
-                    numThreads, maxItemBatchSize,
-                    applicationContext,
+            BatchProcessor<NodeRef> bp = new BatchProcessor<>("FixedAclUpdater",
+                    transactionService.getRetryingTransactionHelper(), provider, numThreads, maxItemBatchSize, applicationContext,
                     log, 100);
             int count = bp.process(worker, true);
             return count;
@@ -424,7 +419,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
         finally
         {
             jobLockRefreshCallback.isActive.set(false);
-            if(lockToken != null)
+            if (lockToken != null)
             {
                 jobLockService.releaseLock(lockToken, lockQName);
             }


### PR DESCRIPTION
* MNT-22040 - Copying nodes that contain sys:pendingFixAcl aspect
* Increased coverage of unit tests
* Added public method removePendingAclAspect
* Changed the job to use the removePendingAclAspect method instead of
repeating the same set of operations twice
* Changed method setFixedAcls to use sharedAclToReplace property of node
if it has the pendingFixAcl aspect applied instead of using the current
shared ACL to be replaced

* Added more tests and validations

* Fixed cuncurrency issues when updating parent and child at the same time, permissions triggered by a move on a node with a pending acl and permissions needeing to be reapplied on nodes that already have the pending acl aspect

* Increase the tree strcuture as sometimes we don't reach the timeout in tests

* code cleanup and formatting

(cherry picked from commit 1b2c5d4c3795e1e353a84c7b19d23df664658931)