### PR TITLE
MNT-21898 Unexpected ACLs when job runs Fix (#344)

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -1553,7 +1553,17 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
 
             // Update ACLs for moved tree
             Long newParentAclId = newParentNode.getAclId();
+
+            // Verify if parent has aspect applied and ACL's are pending
+            if (hasNodeAspect(oldParentNodeId, ContentModel.ASPECT_PENDING_FIX_ACL))
+            {
+                Long oldParentSharedAclId = (Long) this.getNodeProperty(oldParentNodeId, ContentModel.PROP_SHARED_ACL_TO_REPLACE);
+                accessControlListDAO.updateInheritance(newChildNodeId, oldParentSharedAclId, newParentAclId);
+            }
+            else
+            {
             accessControlListDAO.updateInheritance(newChildNodeId, oldParentAclId, newParentAclId);
+        }
         }
         
         // Done

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AccessControlListDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AccessControlListDAO.java
@@ -91,6 +91,11 @@ public interface AccessControlListDAO
      */
     public List<AclChange> setInheritanceForChildren(NodeRef parent, Long inheritFrom, Long sharedAclToReplace, boolean asyncCall);
 
+    /**
+     * Set the inheritance on a given node and it's children. If an unexpected ACL occurs in a child, it can be overriden by setting forceSharedACL
+     */
+    public List<AclChange> setInheritanceForChildren(NodeRef parent, Long inheritFrom, Long sharedAclToReplace, boolean asyncCall, boolean forceSharedACL);
+
     public Long getIndirectAcl(NodeRef nodeRef);
 
     public Long getInheritedAcl(NodeRef nodeRef);

--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -117,6 +117,7 @@
         <property name="nodeDAO" ref="nodeDAO"/>
         <property name="maxItemBatchSize" value="${system.fixedACLsUpdater.maxItemBatchSize}"/>
         <property name="numThreads" value="${system.fixedACLsUpdater.numThreads}"/>
+        <property name="forceSharedACL" value="${system.fixedACLsUpdater.forceSharedACL}"/>
         <property name="lockTimeToLive" value="${system.fixedACLsUpdater.lockTTL}"/>
         <property name="policyComponent" ref="policyComponent"/>
         <property name="policyIgnoreUtil" ref="policyIgnoreUtil"/>

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1192,6 +1192,8 @@ system.fixedACLsUpdater.lockTTL=10000
 system.fixedACLsUpdater.maxItemBatchSize=100
 # fixedACLsUpdater - the number of threads to use
 system.fixedACLsUpdater.numThreads=4
+# fixedACLsUpdater - Force shared ACL to propagate through children even if there is an unexpected ACL
+system.fixedACLsUpdater.forceSharedACL=false
 # fixedACLsUpdater cron expression - fire at midnight every day
 system.fixedACLsUpdater.cronExpression=0 0 0 * * ? 
 


### PR DESCRIPTION
* On move node, verify if parent has pending acl aspect applied and consider the pending shared ACL to update inheritance to avoid ending up with mixed permissions as children of pending acl nodes do not have the correct acls and when moved, keep their wrong acl.
* Add public method setInheritanceForChildren that receives an additional param: forceSharedACL. If an unexpected ACL occurs in a child, it can be overridden by setting it.
* Implement method setInheritanceForChildren that receives an additional parameter: forceSharedACL
* Add method setFixedAcls that receives an additional parameter: forceSharedACL - When a child node has an unexpected ACL, setting this parameter to true will force it to assume the new shared ACL instead of throwing a concurrency exception. When the shared ACL is forces, a warning is thrown in the log informing on what node exactly are we forcing the ACL. This is only possible when the child ACL is type SHARED and when it has an unexpected ACL
* All methods that called setFixedAcls without the new parameter will continue to operate as normal, as having forceSharedACL=false
* Added property forceSharedACL to the FixedACLUpdaterJob. If set to true it will force shared ACL to propagate through children even if there is an unexpected ACL
* When there is a exception detected when doing setInheritanceForChildren on the job, catch and log the error, but do not rollback the entire batch
* On copy/move unit tests I changed the ACL of the target folders on copy and move tests so that the old shared ACL accessed was never the same for origin and target folders as happens when performing these operations between sites
* Added unit test to verify fix for MNT-21898 - testAsyncWithNodeMoveChildToChildPendingFolder
* Added unit test to verify system property for the job: forceSharedACL - testAsyncWithErrorsForceSharedACL

(cherry picked from commit ace87c9c3be098b5f438ab415c6c04095f3be674)