### PR TITLE
[ACS-1291] Asynchronous mechanism to send events

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -32,7 +32,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.Executor;
 
 import org.alfresco.repo.event.v1.model.EventType;
 import org.alfresco.repo.event.v1.model.RepoEvent;
@@ -96,7 +96,7 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
     private PersonService personService;
     protected NodeResourceHelper nodeResourceHelper;
 
-    private ThreadPoolExecutor threadPoolExecutor;
+    private Executor threadPoolExecutor;
     private NodeTypeFilter nodeTypeFilter;
     private ChildAssociationTypeFilter childAssociationTypeFilter;
     private EventUserFilter userFilter;
@@ -201,7 +201,7 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
         this.nodeResourceHelper = nodeResourceHelper;
     }
 
-    public void setThreadPoolExecutor(ThreadPoolExecutor threadPoolExecutor)
+    public void setThreadPoolExecutor(Executor threadPoolExecutor)
     {
         this.threadPoolExecutor = threadPoolExecutor;
     }

--- a/repository/src/main/resources/alfresco/events2-context.xml
+++ b/repository/src/main/resources/alfresco/events2-context.xml
@@ -56,5 +56,23 @@
 
     <bean id="eventGeneratorV2" class="org.alfresco.repo.event2.EventGenerator" parent="baseEventGeneratorV2">
         <property name="nodeResourceHelper" ref="nodeResourceHelper"/>
+        <property name="threadPoolExecutor">
+             <ref bean="eventAsyncThreadPool"/>
+        </property>
+    </bean>
+    
+    <bean id="eventAsyncThreadPool" class="org.alfresco.util.ThreadPoolExecutorFactoryBean">
+        <property name="poolName">
+            <value>eventAsyncThreadPool</value>
+        </property>
+        <property name="corePoolSize">
+            <value>${repo.event2.threadPool.coreSize}</value>
+        </property>
+        <property name="maximumPoolSize">
+            <value>${repo.event2.threadPool.maximumSize}</value>
+        </property>        
+        <property name="threadPriority">
+            <value>${repo.event2.threadPool.priority}</value>
+        </property>
     </bean>
 </beans>

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1209,6 +1209,10 @@ repo.event2.filter.childAssocTypes=rn:rendition
 repo.event2.filter.users=System, null
 # Topic name
 repo.event2.topic.endpoint=amqp:topic:alfresco.repo.event2
+# Thread pool for async delivery
+repo.event2.threadPool.priority=1
+repo.event2.threadPool.coreSize=8
+repo.event2.threadPool.maximumSize=10
 
 # MNT-21083
 # --DELETE_NOT_EXISTS - default settings

--- a/repository/src/test/java/org/alfresco/repo/event2/AbstractContextAwareRepoEvent.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/AbstractContextAwareRepoEvent.java
@@ -31,6 +31,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import javax.jms.ConnectionFactory;
 
@@ -104,6 +105,10 @@ public abstract class AbstractContextAwareRepoEvent extends BaseSpringTest
     @Autowired
     protected ObjectMapper event2ObjectMapper;
 
+    @Autowired
+    protected EventGenerator eventGenerator;
+
+
     protected NodeRef rootNodeRef;
 
     @BeforeClass
@@ -140,6 +145,15 @@ public abstract class AbstractContextAwareRepoEvent extends BaseSpringTest
                     storeRef.getIdentifier());
             }
             return nodeService.getRootNode(storeRef);
+        });
+        
+        eventGenerator.setThreadPoolExecutor(new Executor()
+        {
+            @Override
+            public void execute(Runnable command)
+            {
+                command.run();
+            }
         });
     }
 

--- a/repository/src/test/java/org/alfresco/repo/event2/AbstractContextAwareRepoEvent.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/AbstractContextAwareRepoEvent.java
@@ -105,7 +105,7 @@ public abstract class AbstractContextAwareRepoEvent extends BaseSpringTest
     @Autowired
     protected ObjectMapper event2ObjectMapper;
 
-    @Autowired
+    @Autowired @Qualifier("eventGeneratorV2")
     protected EventGenerator eventGenerator;
 
 
@@ -146,7 +146,10 @@ public abstract class AbstractContextAwareRepoEvent extends BaseSpringTest
             }
             return nodeService.getRootNode(storeRef);
         });
-        
+    }
+
+    @Before
+    public void forceEventGeneratorToBeSynchronous() {
         eventGenerator.setThreadPoolExecutor(new Executor()
         {
             @Override


### PR DESCRIPTION
In order to not suffer from a drop in performance caused by the introduction of the new events system, the sendEvent calls (and related code) are now executed asynchronously using a thread pool.

The pool is controlled by these properties:
repo.event2.threadPool.priority=1
repo.event2.threadPool.coreSize=8
repo.event2.threadPool.maximumSize=10