### PR TITLE
ACS-1264: Content Model changes dynamically updated to node caches ac…

### DIFF
--- a/core/src/main/java/org/alfresco/util/cache/AbstractAsynchronouslyRefreshedCache.java
+++ b/core/src/main/java/org/alfresco/util/cache/AbstractAsynchronouslyRefreshedCache.java
@@ -424,6 +424,7 @@ public abstract class AbstractAsynchronouslyRefreshedCache<T>
         @Override
         public Void call()
         {
+            liveLock.writeLock().lock();
             try
             {
                 doCall();
@@ -443,6 +444,10 @@ public abstract class AbstractAsynchronouslyRefreshedCache<T>
                     runLock.writeLock().unlock();
                 }
                 return null;
+            }
+            finally
+            {
+                liveLock.writeLock().unlock();
             }
         }
 

--- a/repository/src/main/java/org/alfresco/repo/cache/DefaultSimpleCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/DefaultSimpleCache.java
@@ -153,7 +153,7 @@ public final class DefaultSimpleCache<K extends Serializable, V extends Object>
     {
         AbstractMap.SimpleImmutableEntry<K, V> kvp = new AbstractMap.SimpleImmutableEntry<K, V>(key, value);
         AbstractMap.SimpleImmutableEntry<K, V> priorKVP = cache.asMap().put(key, kvp);
-        return priorKVP != null && (! priorKVP.equals(kvp));
+        return (priorKVP != null && (!priorKVP.equals(kvp)));
     }
     
     @Override


### PR DESCRIPTION
…ross a cluster deadlock (#289)

Re enabling changes disabled in ACS-936 we can see deadlock in asynchronouslyRefreshedCacheThreadPool (AbstractAsynchronouslyRefreshedCache).

There should be no reason to be calling the dictionary destroy method before the doCall() finishes...and it is the use of the destroy method that carries the risk of deadlock.

Proposed fix: the liveLock is used for the doCall() method, this will stop deadlock from external calls to dictionary destroy() while doCall is in progress.

Removed invalidating cache fix (e.g. fix the issue where cluster nodes could have null values and other nodes had default value… so no properly invalidated on node startup). This fix was moved in ClusteringBootstrap as the initial one was causing issues.

(cherry picked from commit cee63b31f6d98c08eabc3f51461ae137bd9f8a32)