### PR TITLE
SEARCH-2768 Add callback feature for asynchronous ACL updates.

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -306,7 +306,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
                         onInheritPermissionsDisabledPolicy.onInheritPermissionsDisabled(nodeRef, transformedToAsyncOperation);
                     }
 
-                    listeners.forEach(listener -> listener.permissionsUpdated(nodeRef));
+                    listeners.forEach(listener -> listener.permissionsUpdatedAsynchronously(nodeRef));
 
                     if (log.isDebugEnabled())
                     {

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -81,6 +81,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
 
     public static final String FIXED_ACL_ASYNC_REQUIRED_KEY = "FIXED_ACL_ASYNC_REQUIRED";
     public static final String FIXED_ACL_ASYNC_CALL_KEY = "FIXED_ACL_ASYNC_CALL";
+    protected static final QName LOCK_Q_NAME = QName.createQName(NamespaceService.SYSTEM_MODEL_1_0_URI, "FixedAclUpdater");
 
     /** A set of listeners to receive callback events whenever permissions are updated by this class. */
     private static Set<FixedAclUpdaterListener> listeners = Sets.newConcurrentHashSet();
@@ -90,7 +91,6 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
     private TransactionService transactionService;
     private AccessControlListDAO accessControlListDAO;
     private NodeDAO nodeDAO;
-    private QName lockQName = QName.createQName(NamespaceService.SYSTEM_MODEL_1_0_URI, "FixedAclUpdater");
     private long lockTimeToLive = 10000;
     private long lockRefreshTime = lockTimeToLive / 2;
 
@@ -242,7 +242,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
         }
     }
 
-    private class AclWorker implements BatchProcessor.BatchProcessWorker<NodeRef>
+    protected class AclWorker implements BatchProcessor.BatchProcessWorker<NodeRef>
     {
         private Set<QName> aspects = new HashSet<>(1);
 
@@ -322,7 +322,13 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
         }
     };
 
-    private class GetNodesWithAspectCallback implements NodeRefQueryCallback
+    /** Create a new AclWorker. */
+    protected AclWorker createAclWorker()
+    {
+        return new AclWorker();
+    }
+
+    class GetNodesWithAspectCallback implements NodeRefQueryCallback
     {
         private List<NodeRef> nodes = new ArrayList<>();
         private long minNodeId;
@@ -413,11 +419,11 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
 
         try
         {
-            lockToken = jobLockService.getLock(lockQName, lockTimeToLive, 0, 1);
-            jobLockService.refreshLock(lockToken, lockQName, lockRefreshTime, jobLockRefreshCallback);
+            lockToken = jobLockService.getLock(LOCK_Q_NAME, lockTimeToLive, 0, 1);
+            jobLockService.refreshLock(lockToken, LOCK_Q_NAME, lockRefreshTime, jobLockRefreshCallback);
 
             AclWorkProvider provider = new AclWorkProvider();
-            AclWorker worker = new AclWorker();
+            AclWorker worker = createAclWorker();
             BatchProcessor<NodeRef> bp = new BatchProcessor<>("FixedAclUpdater",
                     transactionService.getRetryingTransactionHelper(), provider, numThreads, maxItemBatchSize, applicationContext,
                     log, 100);
@@ -434,7 +440,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
             jobLockRefreshCallback.isActive.set(false);
             if (lockToken != null)
             {
-                jobLockService.releaseLock(lockToken, lockQName);
+                jobLockService.releaseLock(lockToken, LOCK_Q_NAME);
             }
         }
     }

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterListener.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterListener.java
@@ -31,5 +31,5 @@ import org.alfresco.service.cmr.repository.NodeRef;
 public interface FixedAclUpdaterListener
 {
     /** Callback method for when permissions have been updated by the FixedAclUpdater. */
-    void permissionsUpdated(NodeRef nodeRef);
+    void permissionsUpdatedAsynchronously(NodeRef nodeRef);
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterListener.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterListener.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.domain.permissions;
+
+import org.alfresco.service.cmr.repository.NodeRef;
+
+/** Listener to receive callback events when permissions are asynchronously updated with the {@link FixedAclUpdater}. */
+public interface FixedAclUpdaterListener
+{
+    /** Callback method for when permissions have been updated by the FixedAclUpdater. */
+    void permissionsUpdated(NodeRef nodeRef);
+}

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1202,7 +1202,7 @@ repo.event2.filter.nodeAspects=sys:*
 repo.event2.filter.childAssocTypes=rn:rendition
 # Comma separated list of users which should be excluded
 # Note: username's case-sensitivity depends on the {user.name.caseSensitive} setting
-repo.event2.filter.users=System, null
+repo.event2.filter.users=
 # Topic name
 repo.event2.topic.endpoint=amqp:topic:alfresco.repo.event2
 

--- a/repository/src/test/java/org/alfresco/AllUnitTestsSuite.java
+++ b/repository/src/test/java/org/alfresco/AllUnitTestsSuite.java
@@ -170,6 +170,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.content.caching.quota.UnlimitedQuotaStrategyTest.class,
     org.alfresco.repo.content.caching.CachingContentStoreTest.class,
     org.alfresco.repo.content.caching.ContentCacheImplTest.class,
+    org.alfresco.repo.domain.permissions.FixedAclUpdaterUnitTest.class,
     org.alfresco.repo.domain.propval.PropertyTypeConverterTest.class,
     org.alfresco.repo.search.MLAnaysisModeExpansionTest.class,
     org.alfresco.repo.search.DocumentNavigatorTest.class,

--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterUnitTest.java
@@ -1,0 +1,108 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.domain.permissions;
+
+import static org.alfresco.model.ContentModel.TYPE_BASE;
+import static org.alfresco.service.cmr.repository.StoreRef.STORE_REF_ARCHIVE_SPACESSTORE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import org.alfresco.repo.domain.node.NodeDAO;
+import org.alfresco.repo.domain.permissions.FixedAclUpdater.AclWorker;
+import org.alfresco.repo.policy.ClassPolicyDelegate;
+import org.alfresco.repo.security.permissions.PermissionServicePolicies.OnInheritPermissionsDisabled;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.util.Pair;
+import org.alfresco.util.PolicyIgnoreUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+/** Mock-based unit tests for {@link FixedAclUpdater}. */
+public class FixedAclUpdaterUnitTest
+{
+    private static final NodeRef NODE_REF = new NodeRef("test://node/ref");
+    private static final long NODE_ID = 123L;
+    private static final NodeRef ARCHIVED_NODE = new NodeRef(STORE_REF_ARCHIVE_SPACESSTORE, "archived");
+
+    @InjectMocks
+    private FixedAclUpdater fixedAclUpdater = new FixedAclUpdater();
+    /** The inner class under test. */
+    private AclWorker aclWorker = fixedAclUpdater.createAclWorker();
+    @Mock
+    private NodeDAO nodeDAO;
+    @Mock
+    private AccessControlListDAO accessControlListDAO;
+    @Mock
+    private PolicyIgnoreUtil policyIgnoreUtil;
+    @Mock
+    private ClassPolicyDelegate<OnInheritPermissionsDisabled> onInheritPermissionsDisabledDelegate;
+    @Mock
+    private OnInheritPermissionsDisabled onInheritPermissionsDisabled;
+    /** A pair of mock listeners. */
+    @Mock
+    private FixedAclUpdaterListener listenerA, listenerB;
+
+    @Before
+    public void setUp()
+    {
+        openMocks(this);
+
+        fixedAclUpdater.registerListener(listenerA);
+        fixedAclUpdater.registerListener(listenerB);
+    }
+
+    /** Check that when the AclWorker successfully processes a node then the listeners are notified. */
+    @Test
+    public void testListenersNotifiedAboutUpdate() throws Throwable
+    {
+        when(nodeDAO.getNodePair(NODE_REF)).thenReturn(new Pair<>(NODE_ID, NODE_REF));
+        when(onInheritPermissionsDisabledDelegate.get(TYPE_BASE)).thenReturn(onInheritPermissionsDisabled);
+
+        aclWorker.process(NODE_REF);
+
+        verify(listenerA).permissionsUpdated(NODE_REF);
+        verify(listenerB).permissionsUpdated(NODE_REF);
+    }
+
+    /** Check that archived nodes get the "Pending ACL" aspect removed without further updates, and the listeners are not notified. */
+    @Test
+    public void testListenersNotNotifiedAboutArchivedNode() throws Throwable
+    {
+        when(nodeDAO.getNodePair(ARCHIVED_NODE)).thenReturn(new Pair<>(NODE_ID, ARCHIVED_NODE));
+        when(onInheritPermissionsDisabledDelegate.get(TYPE_BASE)).thenReturn(onInheritPermissionsDisabled);
+
+        aclWorker.process(ARCHIVED_NODE);
+
+        verify(accessControlListDAO).removePendingAclAspect(NODE_ID);
+        verify(listenerA, never()).permissionsUpdated(any(NodeRef.class));
+        verify(listenerB, never()).permissionsUpdated(any(NodeRef.class));
+    }
+}

--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterUnitTest.java
@@ -88,8 +88,8 @@ public class FixedAclUpdaterUnitTest
 
         aclWorker.process(NODE_REF);
 
-        verify(listenerA).permissionsUpdated(NODE_REF);
-        verify(listenerB).permissionsUpdated(NODE_REF);
+        verify(listenerA).permissionsUpdatedAsynchronously(NODE_REF);
+        verify(listenerB).permissionsUpdatedAsynchronously(NODE_REF);
     }
 
     /** Check that archived nodes get the "Pending ACL" aspect removed without further updates, and the listeners are not notified. */
@@ -102,7 +102,7 @@ public class FixedAclUpdaterUnitTest
         aclWorker.process(ARCHIVED_NODE);
 
         verify(accessControlListDAO).removePendingAclAspect(NODE_ID);
-        verify(listenerA, never()).permissionsUpdated(any(NodeRef.class));
-        verify(listenerB, never()).permissionsUpdated(any(NodeRef.class));
+        verify(listenerA, never()).permissionsUpdatedAsynchronously(any(NodeRef.class));
+        verify(listenerB, never()).permissionsUpdatedAsynchronously(any(NodeRef.class));
     }
 }


### PR DESCRIPTION
Change default for user filter to empty, as changes from all users could affect metadata
or permissions which might need to be indexing by the enterprise Elasticsearch Connector.