### PR TITLE
MNT-22295 - FixedACLJob not processing all nodes due to unordered results

### DIFF
--- a/repository/src/main/java/org/alfresco/ibatis/IdsEntity.java
+++ b/repository/src/main/java/org/alfresco/ibatis/IdsEntity.java
@@ -40,6 +40,7 @@ public class IdsEntity
     private Long idThree;
     private Long idFour;
     private List<Long> ids;
+    private boolean ordered;
     public Long getIdOne()
     {
         return idOne;
@@ -79,5 +80,13 @@ public class IdsEntity
     public void setIds(List<Long> ids)
     {
         this.ids = ids;
+    }
+    public boolean isOrdered()
+    {
+        return ordered;
+    }
+    public void setOrdered(boolean ordered)
+    {
+        this.ordered = ordered;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -2756,6 +2756,22 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         selectNodesWithAspects(qnameIds, minNodeId, maxNodeId, resultsCallback);
     }
 
+    @Override
+    public void getNodesWithAspects(
+            Set<QName> aspectQNames,
+            Long minNodeId, Long maxNodeId, boolean ordered,
+            NodeRefQueryCallback resultsCallback)
+    {
+        Set<Long> qnameIdsSet = qnameDAO.convertQNamesToIds(aspectQNames, false);
+        if (qnameIdsSet.size() == 0)
+        {
+            // No point running a query
+            return;
+        }
+        List<Long> qnameIds = new ArrayList<Long>(qnameIdsSet);
+        selectNodesWithAspects(qnameIds, minNodeId, maxNodeId, ordered, resultsCallback);
+    }
+
     /**
      * @return              Returns a writable copy of the cached aspects set
      */
@@ -4926,6 +4942,10 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
     protected abstract void selectNodesWithAspects(
             List<Long> qnameIds,
             Long minNodeId, Long maxNodeId,
+            NodeRefQueryCallback resultsCallback);
+    protected abstract void selectNodesWithAspects(
+            List<Long> qnameIds,
+            Long minNodeId, Long maxNodeId, boolean ordered,
             NodeRefQueryCallback resultsCallback);
     protected abstract Long insertNodeAssoc(Long sourceNodeId, Long targetNodeId, Long assocTypeQNameId, int assocIndex);
     protected abstract int updateNodeAssoc(Long id, int assocIndex);

--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
@@ -405,6 +405,20 @@ public interface NodeDAO extends NodeBulkLoader
             Long minNodeId, Long maxNodeId,
             NodeRefQueryCallback resultsCallback);
 
+    /**
+     * Get nodes with aspects between the given ranges, ordering the results optionally
+     * 
+     * @param aspectQNames              the aspects that must be on the nodes
+     * @param minNodeId                 the minimum node ID (inclusive)
+     * @param maxNodeId                 the maximum node ID (exclusive)
+     * @param ordered                   if the results are to be ordered by nodeID
+     * @param resultsCallback           callback to process results
+     */
+    public void getNodesWithAspects(
+            Set<QName> aspectQNames,
+            Long minNodeId, Long maxNodeId, boolean ordered,
+            NodeRefQueryCallback resultsCallback);
+
     /*
      * Node Assocs
      */
@@ -922,5 +936,6 @@ public interface NodeDAO extends NodeBulkLoader
      * @return next commit time
      */
     public Long getNextTxCommitTime(Long fromCommitTime);
+
 
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
@@ -937,5 +937,4 @@ public interface NodeDAO extends NodeBulkLoader
      */
     public Long getNextTxCommitTime(Long fromCommitTime);
 
-
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -765,6 +765,31 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
     }
 
     @Override
+    protected void selectNodesWithAspects(
+            List<Long> qnameIds,
+            Long minNodeId, Long maxNodeId, boolean ordered,
+            final NodeRefQueryCallback resultsCallback)
+    {
+        @SuppressWarnings("rawtypes")
+        ResultHandler resultHandler = new ResultHandler()
+        {
+            public void handleResult(ResultContext context)
+            {
+                NodeEntity entity = (NodeEntity) context.getResultObject();
+                Pair<Long, NodeRef> nodePair = new Pair<Long, NodeRef>(entity.getId(), entity.getNodeRef());
+                resultsCallback.handle(nodePair);
+            }
+        };
+
+        IdsEntity parameters = new IdsEntity();
+        parameters.setIdOne(minNodeId);
+        parameters.setIdTwo(maxNodeId);
+        parameters.setIds(qnameIds);
+        parameters.setOrdered(ordered);
+        template.select(SELECT_NODES_WITH_ASPECT_IDS, parameters, resultHandler);
+    }
+
+    @Override
     protected Long insertNodeAssoc(Long sourceNodeId, Long targetNodeId, Long assocTypeQNameId, int assocIndex)
     {
         NodeAssocEntity assoc = new NodeAssocEntity();

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -192,7 +192,7 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
                         public List<NodeRef> execute() throws Throwable
                         {
                             getNodesCallback.init();
-                            nodeDAO.getNodesWithAspects(aspects, getNodesCallback.getMinNodeId(), null, getNodesCallback);
+                            nodeDAO.getNodesWithAspects(aspects, getNodesCallback.getMinNodeId(), null, true, getNodesCallback);
                             getNodesCallback.done();
 
                             return getNodesCallback.getNodes();

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
@@ -779,6 +779,7 @@
             <if test="idTwo != null"><![CDATA[and na.node_id < #{idTwo}]]></if>
             and na.qname_id in
                 <foreach item="item" index="i" collection="ids" open="(" separator="," close=")">#{item}</foreach>
+        <if test="ordered == true">order by node.id ASC</if>
     </select>
 
     <!-- Common results for result_NodeAssoc -->


### PR DESCRIPTION
* Added method selectNodesWithAspects that accepts a boolean as param to order values
* Added param ordered to IdsEntity class
* Added optional ordered param to the query template that orders the results by node id in asc order
* Added method getNodesWithAspects that accepts a boolean as param to order values in nodeDAO
* FixedACLUpdater Job calls the new getNodesWithAspects, with the ordered param as true