### PR TITLE
Bugfix/repo 5610 events are not actually sent to activemq

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
@@ -44,13 +44,13 @@ import org.springframework.beans.factory.InitializingBean;
  */
 public class EventGeneratorQueue implements InitializingBean
 {
-    private static final Log LOGGER = LogFactory.getLog(EventGeneratorQueue.class);
+	protected static final Log LOGGER = LogFactory.getLog(EventGeneratorQueue.class);
     
-    private Executor enqueueThreadPoolExecutor;
-    private Executor dequeueThreadPoolExecutor;
-    private Event2MessageProducer event2MessageProducer;
-    private BlockingQueue<EventInMaking> queue = new LinkedBlockingQueue<>();
-    private Runnable listener = createListener();
+    protected Executor enqueueThreadPoolExecutor;
+    protected Executor dequeueThreadPoolExecutor;
+    protected Event2MessageProducer event2MessageProducer;
+    protected BlockingQueue<EventInMaking> queue = new LinkedBlockingQueue<>();
+    protected Runnable listener = createListener();
 
     @Override
     public void afterPropertiesSet() throws Exception

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
@@ -37,14 +37,12 @@ import org.alfresco.util.PropertyCheck;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.extensions.surf.util.AbstractLifecycleBean;
 
 /*
  * This queue allows to create asynchronously the RepoEvent offloading the work to a ThreadPool but
  * at the same time it preserves the order of the events
  */
-public class EventGeneratorQueue extends AbstractLifecycleBean implements InitializingBean
+public class EventGeneratorQueue implements InitializingBean
 {
     private static final Log LOGGER = LogFactory.getLog(EventGeneratorQueue.class);
     
@@ -77,16 +75,6 @@ public class EventGeneratorQueue extends AbstractLifecycleBean implements Initia
         this.dequeueThreadPoolExecutor = dequeueThreadPoolExecutor;
         dequeueThreadPoolExecutor.execute(listener);
     }
-    @Override
-    protected void onBootstrap(ApplicationEvent event)
-    {
-    }
-    
-    @Override
-    protected void onShutdown(ApplicationEvent event)
-    {
-    }
-
 
     /**
      * Procedure to enqueue the callback functions that creates an event.

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
@@ -1,0 +1,191 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.event2;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.alfresco.repo.event.v1.model.RepoEvent;
+import org.alfresco.util.PropertyCheck;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.extensions.surf.util.AbstractLifecycleBean;
+
+/*
+ * This queue allows to create asynchronously the RepoEvent offloading the work to a ThreadPool but
+ * at the same time it preserves the order of the events
+ */
+public class EventGeneratorQueue extends AbstractLifecycleBean implements InitializingBean
+{
+    private static final Log LOGGER = LogFactory.getLog(EventGeneratorQueue.class);
+    
+    private Executor enqueueThreadPoolExecutor;
+    private Executor dequeueThreadPoolExecutor;
+    private Event2MessageProducer event2MessageProducer;
+    private BlockingQueue<EventInMaking> queue = new LinkedBlockingQueue<>();
+    private Runnable listener = createListener();
+
+    @Override
+    public void afterPropertiesSet() throws Exception
+    {
+        PropertyCheck.mandatory(this, "enqueueThreadPoolExecutor", enqueueThreadPoolExecutor);
+        PropertyCheck.mandatory(this, "dequeueThreadPoolExecutor", dequeueThreadPoolExecutor);
+        PropertyCheck.mandatory(this, "event2MessageProducer", event2MessageProducer);
+    }
+
+    public void setEvent2MessageProducer(Event2MessageProducer event2MessageProducer)
+    {
+        this.event2MessageProducer = event2MessageProducer;
+    }
+    
+    public void setEnqueueThreadPoolExecutor(Executor enqueueThreadPoolExecutor)
+    {
+        this.enqueueThreadPoolExecutor = enqueueThreadPoolExecutor;
+    }
+    
+    public void setDequeueThreadPoolExecutor(Executor dequeueThreadPoolExecutor)
+    {
+        this.dequeueThreadPoolExecutor = dequeueThreadPoolExecutor;
+        dequeueThreadPoolExecutor.execute(listener);
+    }
+    @Override
+    protected void onBootstrap(ApplicationEvent event)
+    {
+    }
+    
+    @Override
+    protected void onShutdown(ApplicationEvent event)
+    {
+    }
+
+
+    /**
+     * Procedure to enqueue the callback functions that create an event.
+     * @param maker Callback function that creates an event.
+     */
+    public void accept(Callable<RepoEvent<?>> maker)
+    {
+        EventInMaking eventInMaking = new EventInMaking(maker);
+        queue.offer(eventInMaking);
+        enqueueThreadPoolExecutor.execute(() -> {
+            try
+            {
+                eventInMaking.make();
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Unexpected error while enqueuing maker function for event" + e);
+            }
+        });
+    }
+
+    /**
+     * Create listener task in charge of dequeuing and sending events ready to be sent.
+     * @return The task in charge of dequeuing and sending events ready to be sent.
+     */
+    private Runnable createListener()
+    {
+        return new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                try 
+                {
+                    while (!Thread.interrupted())
+                    {
+                        try
+                        {
+                            EventInMaking eventInMaking = queue.take();
+                            RepoEvent<?> event = eventInMaking.getEventWhenReady();
+                            if (event != null)
+                            {
+                                event2MessageProducer.send(event);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            LOGGER.warn("Unexpected error while dequeuing and sending event" + e);
+                        }
+                    }
+                }
+                finally
+                {
+                    LOGGER.warn("Unexpected: rescheduling the listener thread.");
+                    dequeueThreadPoolExecutor.execute(listener);
+                }
+            }
+        };
+
+    }
+
+    /*
+     * Simple class that makes events and allows to retrieve them when ready
+     */
+    private static class EventInMaking
+    {
+        private Callable<RepoEvent<?>> maker;
+        private volatile RepoEvent<?> event;
+        private CountDownLatch latch;
+        
+        public EventInMaking(Callable<RepoEvent<?>> maker)
+        {
+            this.maker = maker;
+            this.latch = new CountDownLatch(1);
+        }
+        
+        public void make() throws Exception
+        {
+            try
+            {
+                event = maker.call();
+            }
+            finally 
+            {
+                latch.countDown();
+            }
+        }
+        
+        public RepoEvent<?> getEventWhenReady() throws InterruptedException
+        {
+            latch.await(30, TimeUnit.SECONDS);
+            return event;
+        }
+        
+        @Override
+        public String toString()
+        {
+            return maker.toString();
+        }
+    }
+
+}

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
@@ -89,7 +89,7 @@ public class EventGeneratorQueue extends AbstractLifecycleBean implements Initia
 
 
     /**
-     * Procedure to enqueue the callback functions that create an event.
+     * Procedure to enqueue the callback functions that creates an event.
      * @param maker Callback function that creates an event.
      */
     public void accept(Callable<RepoEvent<?>> maker)
@@ -103,7 +103,7 @@ public class EventGeneratorQueue extends AbstractLifecycleBean implements Initia
             }
             catch (Exception e)
             {
-                LOGGER.warn("Unexpected error while enqueuing maker function for event" + e);
+                LOGGER.error("Unexpected error while enqueuing maker function for repository event" + e);
             }
         });
     }
@@ -134,7 +134,7 @@ public class EventGeneratorQueue extends AbstractLifecycleBean implements Initia
                         }
                         catch (Exception e)
                         {
-                            LOGGER.warn("Unexpected error while dequeuing and sending event" + e);
+                            LOGGER.error("Unexpected error while dequeuing and sending repository event" + e);
                         }
                     }
                 }

--- a/repository/src/main/resources/alfresco/events2-context.xml
+++ b/repository/src/main/resources/alfresco/events2-context.xml
@@ -38,7 +38,6 @@
         <property name="dictionaryService" ref="dictionaryService"/>
         <property name="descriptorService" ref="descriptorComponent"/>
         <property name="eventFilterRegistry" ref="event2FilterRegistry"/>
-        <property name="event2MessageProducer" ref="event2MessageProducer"/>
         <property name="transactionService" ref="transactionService"/>
         <property name="personService" ref="personService"/>
     </bean>
@@ -56,23 +55,46 @@
 
     <bean id="eventGeneratorV2" class="org.alfresco.repo.event2.EventGenerator" parent="baseEventGeneratorV2">
         <property name="nodeResourceHelper" ref="nodeResourceHelper"/>
-        <property name="threadPoolExecutor">
-             <ref bean="eventAsyncThreadPool"/>
+        <property name="eventGeneratorQueue" ref="eventGeneratorQueue"/>
+    </bean>
+
+    <bean id="eventGeneratorQueue" class="org.alfresco.repo.event2.EventGeneratorQueue" >
+        <property name="enqueueThreadPoolExecutor">
+            <ref bean="eventAsyncEnqueueThreadPool" />
+        </property>
+        <property name="dequeueThreadPoolExecutor">
+            <ref bean="eventAsyncDequeueThreadPool" />
+        </property>
+       <property name="event2MessageProducer" ref="event2MessageProducer"/>
+    </bean>
+
+    <bean id="eventAsyncEnqueueThreadPool" class="org.alfresco.util.ThreadPoolExecutorFactoryBean">
+        <property name="poolName">
+            <value>eventAsyncEnqueueThreadPool</value>
+        </property>
+        <property name="corePoolSize">
+            <value>${repo.event2.queue.enqueueThreadPool.coreSize}</value>
+        </property>
+        <property name="maximumPoolSize">
+            <value>${repo.event2.queue.enqueueThreadPool.maximumSize}</value>
+        </property>
+        <property name="threadPriority">
+            <value>${repo.event2.queue.enqueueThreadPool.priority}</value>
         </property>
     </bean>
 
-    <bean id="eventAsyncThreadPool" class="org.alfresco.util.ThreadPoolExecutorFactoryBean">
+    <bean id="eventAsyncDequeueThreadPool" class="org.alfresco.util.ThreadPoolExecutorFactoryBean">
         <property name="poolName">
-            <value>eventAsyncThreadPool</value>
+            <value>eventAsyncDequeueThreadPool</value>
         </property>
         <property name="corePoolSize">
-            <value>${repo.event2.threadPool.coreSize}</value>
+            <value>${repo.event2.queue.dequeueThreadPool.coreSize}</value>
         </property>
         <property name="maximumPoolSize">
-            <value>${repo.event2.threadPool.maximumSize}</value>
+            <value>${repo.event2.queue.dequeueThreadPool.maximumSize}</value>
         </property>
         <property name="threadPriority">
-            <value>${repo.event2.threadPool.priority}</value>
+            <value>${repo.event2.queue.dequeueThreadPool.priority}</value>
         </property>
     </bean>
 </beans>

--- a/repository/src/main/resources/alfresco/events2-context.xml
+++ b/repository/src/main/resources/alfresco/events2-context.xml
@@ -56,5 +56,23 @@
 
     <bean id="eventGeneratorV2" class="org.alfresco.repo.event2.EventGenerator" parent="baseEventGeneratorV2">
         <property name="nodeResourceHelper" ref="nodeResourceHelper"/>
+        <property name="threadPoolExecutor">
+             <ref bean="eventAsyncThreadPool"/>
+        </property>
+    </bean>
+
+    <bean id="eventAsyncThreadPool" class="org.alfresco.util.ThreadPoolExecutorFactoryBean">
+        <property name="poolName">
+            <value>eventAsyncThreadPool</value>
+        </property>
+        <property name="corePoolSize">
+            <value>${repo.event2.threadPool.coreSize}</value>
+        </property>
+        <property name="maximumPoolSize">
+            <value>${repo.event2.threadPool.maximumSize}</value>
+        </property>
+        <property name="threadPriority">
+            <value>${repo.event2.threadPool.priority}</value>
+        </property>
     </bean>
 </beans>

--- a/repository/src/main/resources/alfresco/events2-context.xml
+++ b/repository/src/main/resources/alfresco/events2-context.xml
@@ -40,6 +40,8 @@
         <property name="eventFilterRegistry" ref="event2FilterRegistry"/>
         <property name="transactionService" ref="transactionService"/>
         <property name="personService" ref="personService"/>
+        <property name="nodeResourceHelper" ref="nodeResourceHelper"/>
+        <property name="eventGeneratorQueue" ref="eventGeneratorQueue"/>
     </bean>
 
     <bean id="baseNodeResourceHelper" abstract="true">
@@ -53,10 +55,7 @@
 
     <bean id="nodeResourceHelper" class="org.alfresco.repo.event2.NodeResourceHelper" parent="baseNodeResourceHelper"/>
 
-    <bean id="eventGeneratorV2" class="org.alfresco.repo.event2.EventGenerator" parent="baseEventGeneratorV2">
-        <property name="nodeResourceHelper" ref="nodeResourceHelper"/>
-        <property name="eventGeneratorQueue" ref="eventGeneratorQueue"/>
-    </bean>
+    <bean id="eventGeneratorV2" class="org.alfresco.repo.event2.EventGenerator" parent="baseEventGeneratorV2"/>
 
     <bean id="eventGeneratorQueue" class="org.alfresco.repo.event2.EventGeneratorQueue" >
         <property name="enqueueThreadPoolExecutor">

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1211,6 +1211,10 @@ repo.event2.filter.childAssocTypes=rn:rendition
 repo.event2.filter.users=
 # Topic name
 repo.event2.topic.endpoint=amqp:topic:alfresco.repo.event2
+# Thread pool for async delivery
+repo.event2.threadPool.priority=1
+repo.event2.threadPool.coreSize=8
+repo.event2.threadPool.maximumSize=10
 
 # MNT-21083
 # --DELETE_NOT_EXISTS - default settings

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1211,10 +1211,15 @@ repo.event2.filter.childAssocTypes=rn:rendition
 repo.event2.filter.users=
 # Topic name
 repo.event2.topic.endpoint=amqp:topic:alfresco.repo.event2
-# Thread pool for async delivery
-repo.event2.threadPool.priority=1
-repo.event2.threadPool.coreSize=8
-repo.event2.threadPool.maximumSize=10
+# Thread pool for async enqueue of repo events
+repo.event2.queue.enqueueThreadPool.priority=1
+repo.event2.queue.enqueueThreadPool.coreSize=8
+repo.event2.queue.enqueueThreadPool.maximumSize=10
+# Thread pool for async dequeue and delivery of repo events
+repo.event2.queue.dequeueThreadPool.priority=1
+repo.event2.queue.dequeueThreadPool.coreSize=1
+repo.event2.queue.dequeueThreadPool.maximumSize=1
+
 
 # MNT-21083
 # --DELETE_NOT_EXISTS - default settings

--- a/repository/src/test/java/org/alfresco/repo/event2/AbstractContextAwareRepoEvent.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/AbstractContextAwareRepoEvent.java
@@ -31,6 +31,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import javax.jms.ConnectionFactory;
 
@@ -104,6 +105,10 @@ public abstract class AbstractContextAwareRepoEvent extends BaseSpringTest
     @Autowired
     protected ObjectMapper event2ObjectMapper;
 
+    @Autowired @Qualifier("eventGeneratorV2")
+    protected EventGenerator eventGenerator;
+
+
     protected NodeRef rootNodeRef;
 
     @BeforeClass
@@ -140,6 +145,18 @@ public abstract class AbstractContextAwareRepoEvent extends BaseSpringTest
                     storeRef.getIdentifier());
             }
             return nodeService.getRootNode(storeRef);
+        });
+    }
+
+    @Before
+    public void forceEventGeneratorToBeSynchronous() {
+        eventGenerator.setThreadPoolExecutor(new Executor()
+        {
+            @Override
+            public void execute(Runnable command)
+            {
+                command.run();
+            }
         });
     }
 

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorQueueUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorQueueUnitTest.java
@@ -1,3 +1,28 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.repo.event2;
 
 import static java.lang.Thread.sleep;

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorQueueUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorQueueUnitTest.java
@@ -1,0 +1,265 @@
+package org.alfresco.repo.event2;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.alfresco.repo.event.v1.model.RepoEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class EventGeneratorQueueUnitTest
+{
+    private EventGeneratorQueue queue;
+
+    private Event2MessageProducer bus;
+    private ExecutorService enqueuePool;
+    private ExecutorService dequeuePool;
+    private List<RepoEvent<?>> recordedEvents;
+    private Map<String, RepoEvent<?>> events;
+
+    @Before
+    public void setup() 
+    {
+        queue = new EventGeneratorQueue();
+
+        enqueuePool = newThreadPool();
+        queue.setEnqueueThreadPoolExecutor(enqueuePool);
+        dequeuePool = newThreadPool();
+        queue.setDequeueThreadPoolExecutor(dequeuePool);
+
+        bus = mock(Event2MessageProducer.class);
+        queue.setEvent2MessageProducer(bus);
+
+        events = new HashMap<>();
+
+        setupEventsRecorder();
+    }
+
+    @After
+    public void teardown() 
+    {
+        enqueuePool.shutdown();
+    }
+
+    private void setupEventsRecorder()
+    {
+        recordedEvents = new CopyOnWriteArrayList<>();
+
+        Mockito.doAnswer(new Answer<Void>()
+        {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable
+            {
+                RepoEvent<?> event = invocation.getArgument(0, RepoEvent.class);
+                recordedEvents.add(event);
+                return null;
+            }
+        }).when(bus).send(any());
+    }
+
+    @Test
+    public void shouldReceiveSingleQuickMessage() throws Exception 
+    {
+        queue.accept(messageWithDelay("A", 55l));
+
+        sleep(150l);
+
+        assertEquals(1, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+    }
+
+    @Test
+    public void shouldNotReceiveEventsWhenMessageIsNull() throws Exception 
+    {
+        queue.accept(() -> { return null; });
+
+        sleep(150l);
+
+        assertEquals(0, recordedEvents.size());
+    }
+
+    @Test
+    public void shouldReceiveMultipleMessagesPreservingOrderScenarioOne() throws Exception {
+        queue.accept(messageWithDelay("A", 0l));
+        queue.accept(messageWithDelay("B", 100l));
+        queue.accept(messageWithDelay("C", 200l));
+
+        sleep(450l);
+
+        assertEquals(3, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+        assertEquals("B", recordedEvents.get(1).getId());
+        assertEquals("C", recordedEvents.get(2).getId());
+    }
+
+    @Test
+    public void shouldReceiveMultipleMessagesPreservingOrderScenarioTwo() throws Exception
+    {
+        queue.accept(messageWithDelay("A", 300l));
+        queue.accept(messageWithDelay("B", 150l));
+        queue.accept(messageWithDelay("C", 0l));
+
+        sleep(950l);
+
+        assertEquals(3, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+        assertEquals("B", recordedEvents.get(1).getId());
+        assertEquals("C", recordedEvents.get(2).getId());
+    }
+
+    @Test
+    public void shouldReceiveMultipleMessagesPreservingOrderEvenWhenMakerPoisoned() throws Exception
+    {
+        queue.accept(messageWithDelay("A", 300l));
+        queue.accept(() -> {throw new RuntimeException("Boom! (not to worry, this is a test)");});
+        queue.accept(messageWithDelay("B", 55l));
+        queue.accept(messageWithDelay("C", 0l));
+
+        sleep(950l);
+
+        assertEquals(3, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+        assertEquals("B", recordedEvents.get(1).getId());
+        assertEquals("C", recordedEvents.get(2).getId());
+    }
+    
+    @Test
+    public void shouldReceiveMultipleMessagesPreservingOrderEvenWhenSenderPoisoned() throws Exception
+    {
+        Callable<RepoEvent<?>> makerB = messageWithDelay("B", 55l);
+        RepoEvent<?> messageB = makerB.call();
+        doThrow(new RuntimeException("Boom! (not to worry, this is a test)")).when(bus).send(messageB);
+        queue.accept(messageWithDelay("A", 300l));
+        queue.accept(makerB);
+        queue.accept(messageWithDelay("C", 0l));
+
+        sleep(950l);
+
+        assertEquals(2, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+        assertEquals("C", recordedEvents.get(1).getId());
+    }
+
+    @Test
+    public void shouldReceiveMultipleMessagesPreservingOrderEvenWhenMakerPoisonedWithError() throws Exception
+    {
+        queue.accept(messageWithDelay("A", 300l));
+        queue.accept(() -> {throw new OutOfMemoryError("Boom! (not to worry, this is a test)");});
+        queue.accept(messageWithDelay("B", 55l));
+        queue.accept(messageWithDelay("C", 0l));
+
+        sleep(950l);
+
+        assertEquals(3, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+        assertEquals("B", recordedEvents.get(1).getId());
+        assertEquals("C", recordedEvents.get(2).getId());
+    }
+    
+    @Test
+    public void shouldReceiveMultipleMessagesPreservingOrderEvenWhenSenderPoisonedWithError() throws Exception
+    {
+        Callable<RepoEvent<?>> makerB = messageWithDelay("B", 55l);
+        RepoEvent<?> messageB = makerB.call();
+        doThrow(new OutOfMemoryError("Boom! (not to worry, this is a test)")).when(bus).send(messageB);
+        queue.accept(messageWithDelay("A", 300l));
+        queue.accept(makerB);
+        queue.accept(messageWithDelay("C", 0l));
+
+        sleep(950l);
+
+        assertEquals(2, recordedEvents.size());
+        assertEquals("A", recordedEvents.get(0).getId());
+        assertEquals("C", recordedEvents.get(1).getId());
+    }
+
+    private Callable<RepoEvent<?>> messageWithDelay(String id, long delay)
+    {
+        Callable<RepoEvent<?>> res = new Callable<RepoEvent<?>>() {
+
+            @Override
+            public RepoEvent<?> call() throws Exception
+            {
+                if(delay != 0)
+                {
+                    sleep(delay); 
+                }
+                return newRepoEvent(id);
+            } 
+            
+            @Override
+            public String toString()
+            {
+                return id;
+            }
+        };
+        return res;
+    }
+    
+    private RepoEvent<?> newRepoEvent(String id)
+    {
+        RepoEvent<?> ev = events.get(id);
+        if (ev!=null)
+            return ev;
+        
+        ev = mock(RepoEvent.class);
+        when(ev.getId()).thenReturn(id);
+        when(ev.toString()).thenReturn(id);
+        events.put(id, ev);
+
+        return ev;
+    }
+
+    public static ExecutorService newThreadPool() 
+    {
+        return new ThreadPoolExecutor(2, Integer.MAX_VALUE,
+                                      60L, TimeUnit.SECONDS,
+                                      new SynchronousQueue<Runnable>());
+    }
+
+    public static final Executor SYNC_EXECUTOR_SAME_THREAD = new Executor()
+    {
+        @Override
+        public void execute(Runnable command)
+        {
+            command.run();
+        }
+    };
+
+    public static final Executor SYNC_EXECUTOR_NEW_THREAD = new Executor()
+    {
+        @Override
+        public void execute(Runnable command)
+        {
+            Thread t = new Thread(command);
+            t.start();
+            try
+            {
+                t.join();
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+        }
+    };
+}

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
@@ -1,0 +1,70 @@
+package org.alfresco.repo.event2;
+
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.Test;
+
+public class EventGeneratorTest extends AbstractContextAwareRepoEvent implements ExceptionListener
+{
+
+    @Test
+    public void shouldReceiveEvent2Events() throws Exception
+    {
+        NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT);
+        System.out.println(nodeRef);
+        
+        try
+        {
+            listen();
+        }
+        catch (Exception ex)
+        {
+            ex.printStackTrace();
+        }
+    }
+    
+    public void listen() throws Exception
+    {
+        // Create a ConnectionFactory
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost");
+
+        // Create a Connection
+        Connection connection = connectionFactory.createConnection();
+        connection.start();
+
+        connection.setExceptionListener(this);
+
+        // Create a Session
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+        // Create the destination (Topic or Queue)
+        Destination destination = session.createQueue("alfresco.repo.event2");
+
+        // Create a MessageConsumer from the Session to the Topic or Queue
+        MessageConsumer consumer = session.createConsumer(destination);
+
+        // Wait for a message
+        Message message = consumer.receive(60000);
+
+        System.out.println("Received: " + message);
+
+        consumer.close();
+        session.close();
+        connection.close();
+    }
+
+    public synchronized void onException(JMSException ex)
+    {
+        System.out.println("JMS Exception occured.  Shutting down client.");
+        ex.printStackTrace();
+    }
+}

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
@@ -1,3 +1,28 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.repo.event2;
 
 import java.util.ArrayList;
@@ -78,19 +103,6 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
                     return null;
                 }
             }
-
-            private String getText(Message message)
-            {
-                try
-                {
-                    ActiveMQTextMessage am = (ActiveMQTextMessage) message;
-                    return am.getText();
-                }
-                catch (JMSException e)
-                {
-                    return null;
-                }
-            }
         });
 
         if (DEBUG) System.err.println("Now actively listening on topic " + EVENT2_TOPIC_NAME);
@@ -124,6 +136,19 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
         assertEquals("Events are different!", sent, received);
     }
 
+    private static String getText(Message message)
+    {
+        try
+        {
+            ActiveMQTextMessage am = (ActiveMQTextMessage) message;
+            return am.getText();
+        }
+        catch (JMSException e)
+        {
+            return null;
+        }
+    }
+
     // a simple main to investigate he contents of the local broker
     public static void main(String[] args) throws Exception
     {
@@ -131,7 +156,7 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
         System.exit(0);
     }
 
-    private static void dumpBroker(String url) throws JMSException
+    private static void dumpBroker(String url) throws Exception
     {
         System.out.println("Broker at url: '" + url + "'");
 
@@ -170,6 +195,23 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
                     e.printStackTrace();
                 }
             }
+            
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Destination destination = session.createTopic(EVENT2_TOPIC_NAME);
+            MessageConsumer consumer = session.createConsumer(destination);
+
+            System.out.println("\nListening to topic "+EVENT2_TOPIC_NAME+"...");
+            consumer.setMessageListener(new MessageListener()
+            {
+                @Override
+                public void onMessage(Message message)
+                {
+                    String text = getText(message);
+                    System.out.println("Received message " + message + "\n" + text+"\n");
+                }
+            });
+            
+            Thread.sleep(50000000l);
         }
         finally
         {

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
@@ -1,70 +1,179 @@
 package org.alfresco.repo.event2;
 
-import javax.jms.Connection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import javax.jms.Destination;
-import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
 import javax.jms.Session;
 
 import org.alfresco.model.ContentModel;
-import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.repo.event.databind.ObjectMapperFactory;
+import org.alfresco.repo.event.v1.model.RepoEvent;
+import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.advisory.DestinationSource;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.activemq.command.ActiveMQTopic;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-public class EventGeneratorTest extends AbstractContextAwareRepoEvent implements ExceptionListener
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class EventGeneratorTest extends AbstractContextAwareRepoEvent
 {
+    private static final boolean DEBUG = true;
 
-    @Test
-    public void shouldReceiveEvent2Events() throws Exception
-    {
-        NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT);
-        System.out.println(nodeRef);
-        
-        try
-        {
-            listen();
-        }
-        catch (Exception ex)
-        {
-            ex.printStackTrace();
-        }
-    }
-    
-    public void listen() throws Exception
-    {
-        // Create a ConnectionFactory
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost");
+    private static final String EVENT2_TOPIC_NAME = "alfresco.repo.event2";
 
-        // Create a Connection
-        Connection connection = connectionFactory.createConnection();
+    private ActiveMQConnection connection;
+    private ObjectMapper objectMapper;
+    private List<RepoEvent<?>> receivedEvents;
+
+    @Before
+    public void startupTopicListener() throws Exception
+    {
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
+        connection = (ActiveMQConnection) connectionFactory.createConnection();
         connection.start();
 
-        connection.setExceptionListener(this);
-
-        // Create a Session
         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-
-        // Create the destination (Topic or Queue)
-        Destination destination = session.createQueue("alfresco.repo.event2");
-
-        // Create a MessageConsumer from the Session to the Topic or Queue
+        Destination destination = session.createTopic(EVENT2_TOPIC_NAME);
         MessageConsumer consumer = session.createConsumer(destination);
 
-        // Wait for a message
-        Message message = consumer.receive(60000);
+        objectMapper = ObjectMapperFactory.createInstance();
+        receivedEvents = Collections.synchronizedList(new ArrayList<>());
+        consumer.setMessageListener(new MessageListener()
+        {
+            @Override
+            public void onMessage(Message message)
+            {
+                String text = getText(message);
+                RepoEvent<?> event = toRepoEvent(text);
 
-        System.out.println("Received: " + message);
+                if (DEBUG)
+                {
+                    System.err.println("Received message " + message + "\n" + text + "\n" + event);
+                }
 
-        consumer.close();
-        session.close();
-        connection.close();
+                receivedEvents.add(event);
+            }
+
+            private RepoEvent<?> toRepoEvent(String json)
+            {
+                try
+                {
+                    return objectMapper.readValue(json, RepoEvent.class);
+                }
+                catch (Exception e)
+                {
+                    e.printStackTrace();
+                    return null;
+                }
+            }
+
+            private String getText(Message message)
+            {
+                try
+                {
+                    ActiveMQTextMessage am = (ActiveMQTextMessage) message;
+                    return am.getText();
+                }
+                catch (JMSException e)
+                {
+                    return null;
+                }
+            }
+        });
+
+        if (DEBUG) System.err.println("Now actively listening on topic " + EVENT2_TOPIC_NAME);
     }
 
-    public synchronized void onException(JMSException ex)
+    @After
+    public void shutdownTopicListener() throws Exception
     {
-        System.out.println("JMS Exception occured.  Shutting down client.");
-        ex.printStackTrace();
+        connection.close();
+        connection = null;
+    }
+
+    @Test
+    public void shouldReceiveEvent2EventsOnNodeCreation() throws Exception
+    {
+        createNode(ContentModel.TYPE_CONTENT);
+
+        int i = 100;
+        while (--i > 0)
+        {
+            Thread.sleep(55l);
+            if (receivedEvents.size() == 1)
+                break;
+        }
+
+        assertFalse("No messages were received!", receivedEvents.isEmpty());
+
+        RepoEvent<?> sent = getRepoEvent(1);
+        RepoEvent<?> received = receivedEvents.get(0);
+
+        assertEquals("Events are different!", sent, received);
+    }
+
+    // a simple main to investigate he contents of the local broker
+    public static void main(String[] args) throws Exception
+    {
+        dumpBroker("tcp://localhost:61616");
+        System.exit(0);
+    }
+
+    private static void dumpBroker(String url) throws JMSException
+    {
+        System.out.println("Broker at url: '" + url + "'");
+
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(url);
+        ActiveMQConnection connection = (ActiveMQConnection) connectionFactory.createConnection();
+        try
+        {
+            connection.start();
+
+            DestinationSource ds = connection.getDestinationSource();
+
+            Set<ActiveMQQueue> queues = ds.getQueues();
+            System.out.println("\nFound " + queues.size() + " queues:");
+            for (ActiveMQQueue queue : queues)
+            {
+                try
+                {
+                    System.out.println("- " + queue.getQueueName());
+                }
+                catch (JMSException e)
+                {
+                    e.printStackTrace();
+                }
+            }
+
+            Set<ActiveMQTopic> topics = ds.getTopics();
+            System.out.println("\nFound " + topics.size() + " topics:");
+            for (ActiveMQTopic topic : topics)
+            {
+                try
+                {
+                    System.out.println("- " + topic.getTopicName());
+                }
+                catch (JMSException e)
+                {
+                    e.printStackTrace();
+                }
+            }
+        }
+        finally
+        {
+            connection.close();
+        }
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
@@ -60,7 +60,7 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
 
     private ActiveMQConnection connection;
     private ObjectMapper objectMapper;
-    private List<RepoEvent<?>> receivedEvents;
+    protected List<RepoEvent<?>> receivedEvents;
 
     @Before
     public void startupTopicListener() throws Exception

--- a/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/EventGeneratorTest.java
@@ -58,6 +58,8 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
 
     private static final String EVENT2_TOPIC_NAME = "alfresco.repo.event2";
 
+    private static final long DUMP_BROKER_TIMEOUT = 50000000l;
+
     private ActiveMQConnection connection;
     private ObjectMapper objectMapper;
     protected List<RepoEvent<?>> receivedEvents;
@@ -149,14 +151,14 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
         }
     }
 
-    // a simple main to investigate he contents of the local broker
+    // a simple main to investigate the contents of the local broker
     public static void main(String[] args) throws Exception
     {
-        dumpBroker("tcp://localhost:61616");
+        dumpBroker("tcp://localhost:61616", DUMP_BROKER_TIMEOUT);
         System.exit(0);
     }
 
-    private static void dumpBroker(String url) throws Exception
+    private static void dumpBroker(String url, long timeout) throws Exception
     {
         System.out.println("Broker at url: '" + url + "'");
 
@@ -210,8 +212,8 @@ public class EventGeneratorTest extends AbstractContextAwareRepoEvent
                     System.out.println("Received message " + message + "\n" + text+"\n");
                 }
             });
-            
-            Thread.sleep(50000000l);
+
+            Thread.sleep(timeout);
         }
         finally
         {

--- a/repository/src/test/java/org/alfresco/repo/event2/RepoEvent2ITSuite.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/RepoEvent2ITSuite.java
@@ -34,7 +34,8 @@ import org.junit.runners.Suite.SuiteClasses;
                 UpdateRepoEventIT.class,
                 DeleteRepoEventIT.class,
                 ChildAssociationRepoEventIT.class,
-                PeerAssociationRepoEventIT.class
+                PeerAssociationRepoEventIT.class,
+                EventGeneratorTest.class
 })
 public class RepoEvent2ITSuite
 {

--- a/repository/src/test/java/org/alfresco/repo/event2/RepoEvent2UnitSuite.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/RepoEvent2UnitSuite.java
@@ -33,7 +33,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ EventFilterUnitTest.class,
                 EventConsolidatorUnitTest.class,
-                EventJSONSchemaUnitTest.class
+                EventJSONSchemaUnitTest.class,
+                EventGeneratorQueueUnitTest.class
 })
 public class RepoEvent2UnitSuite
 {


### PR DESCRIPTION
A fix is applied to collect the user name in the calling thread in `EventGenerator::sendEvent` so that it doesn't silently fail.
As part of detecting this issue, changes were made to verify the reception of events on the `alfresco.repo.event2` event topic through end-to-end tests. Please see enterprise companion PR [here](https://github.com/Alfresco/alfresco-enterprise-repo/pull/344).