### PR TITLE
Revert "SEARCH-2782 use current transaction timestamp instead of current time as event time"

### DIFF
--- a/repository/src/main/resources/alfresco/events2-context.xml
+++ b/repository/src/main/resources/alfresco/events2-context.xml
@@ -41,7 +41,6 @@
         <property name="event2MessageProducer" ref="event2MessageProducer"/>
         <property name="transactionService" ref="transactionService"/>
         <property name="personService" ref="personService"/>
-        <property name="nodeDAO" ref="nodeDAO"/>
     </bean>
 
     <bean id="baseNodeResourceHelper" abstract="true">

--- a/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
@@ -26,14 +26,9 @@
 
 package org.alfresco.repo.event2;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.alfresco.model.ContentModel;
-import org.alfresco.repo.domain.node.NodeDAO;
-import org.alfresco.repo.domain.node.Transaction;
 import org.alfresco.repo.event.v1.model.EventData;
 import org.alfresco.repo.event.v1.model.EventType;
 import org.alfresco.repo.event.v1.model.NodeResource;
@@ -43,7 +38,6 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.PropertyMap;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Iulian Aftene
@@ -51,9 +45,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
 {
 
-    @Autowired
-    private NodeDAO nodeDAO;
-    
     @Test
     public void testCreateEvent()
     {
@@ -158,32 +149,9 @@ public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
         assertTrue("isFile flag should be TRUE for nodeType=cm:content. ", resource.isFile());
         assertFalse("isFolder flag should be FALSE for nodeType=cm:content. ", resource.isFolder());
     }
-    
-    @Test
-    public void testEventTimestampEqualsToTransactionCommitTime()
-    {
-        String name = "TestFile-" + System.currentTimeMillis() + ".txt";
-        PropertyMap propertyMap = new PropertyMap();
-        propertyMap.put(ContentModel.PROP_NAME, name);
-        
-        //create a node and return the transaction id required later
-        Long transactionId = retryingTransactionHelper.doInTransaction(() -> {
-            nodeService.createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN,
-                    QName.createQName(TEST_NAMESPACE, GUID.generate()), ContentModel.TYPE_CONTENT, propertyMap).getChildRef();
-            return nodeDAO.getCurrentTransactionId(false);
-        });
-
-        RepoEvent<EventData<NodeResource>> resultRepoEvent = getRepoEvent(1);
-
-        Transaction transaction = nodeDAO.getTxnById(transactionId);
-        Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
-        ZonedDateTime timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
-        
-        assertEquals(timestamp, resultRepoEvent.getTime());
-    }
 
     @Test
-    public void testCreateMultipleNodesInTheSameTransaction()
+    public void testCteateMultipleNodesInTheSameTransaction()
     {
         retryingTransactionHelper.doInTransaction(() -> {
             for (int i = 0; i < 3; i++)


### PR DESCRIPTION
This reverts commit 28f1429a, PR #371