### PR TITLE
SEARCH-2782 commit time as event time

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -563,6 +563,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             Long txnId = txn.getId();
             // Update it
             Long now = System.currentTimeMillis();
+            txn.setCommitTimeMs(now);
             updateTransaction(txnId, now);
         }
     }
@@ -602,6 +603,17 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         AlfrescoTransactionSupport.bindDaoService(updateTransactionListener);
         // Done
         return txn;
+    }
+    
+    public Long getCurrentTransactionCommitTime()
+    {
+        Long commitTime = null;
+        TransactionEntity resource = AlfrescoTransactionSupport.getResource(KEY_TRANSACTION);
+        if(resource != null)
+        {
+            commitTime = resource.getCommitTimeMs();
+        }
+        return commitTime;
     }
     
     public Long getCurrentTransactionId(boolean ensureNew)

--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
@@ -75,6 +75,13 @@ public interface NodeDAO extends NodeBulkLoader
     /*
      * Transaction
      */
+
+    /**
+     * @return                 the commit time of the current transaction entry or <tt>null</tt> if
+     *                         there have not been any modifications to nodes registered in the
+     *                         transaction.
+     */
+    Long getCurrentTransactionCommitTime();
     
     /**
      * @param ensureNew          <tt>true</tt> to ensure that a new transaction entry is created

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software.
- * If the software was purchased under a paid Alfresco license, the terms of
- * the paid license agreement will prevail.  Otherwise, the software is
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
  * provided under the following open source license terms:
- *
+ * 
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * 
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
@@ -186,7 +186,7 @@ public interface AclDAO
     /**
     * @return                 the commit time of the current ACL change set entry or <tt>null</tt> if
     *                         there have not been any modifications.
-    */ 
-    Long getCurrentChangeSetCommitTime();
+    */
+    public Long getCurrentChangeSetCommitTime();
 
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
@@ -182,4 +182,9 @@ public interface AclDAO
      * @return Long
      */
     public Long getMaxChangeSetIdByCommitTime(long maxCommitTime);
+
+    /**
+     * @return the current AclChangeSet created for the current ACL change 
+     */
+    AclChangeSet getCurrentACLChangeSet();
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAO.java
@@ -184,7 +184,9 @@ public interface AclDAO
     public Long getMaxChangeSetIdByCommitTime(long maxCommitTime);
 
     /**
-     * @return the current AclChangeSet created for the current ACL change 
-     */
-    AclChangeSet getCurrentACLChangeSet();
+    * @return                 the commit time of the current ACL change set entry or <tt>null</tt> if
+    *                         there have not been any modifications.
+    */ 
+    Long getCurrentChangeSetCommitTime();
+
 }

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software.
- * If the software was purchased under a paid Alfresco license, the terms of
- * the paid license agreement will prevail.  Otherwise, the software is
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
  * provided under the following open source license terms:
- *
+ * 
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * 
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
@@ -1668,22 +1668,10 @@ public class AclDAOImpl implements AclDAO
         }
     }
 
-    /**
-     * Retrieve the value from the current thread local, avoiding the access to the database.
-     * @return
-     */
     @Override
-    public AclChangeSet getCurrentACLChangeSet()
+    public Long getCurrentChangeSetCommitTime()
     {
-        AclChangeSetEntity aclChangeSetEntity = null;
-        Long id = AlfrescoTransactionSupport.getResource(RESOURCE_KEY_ACL_CHANGE_SET_ID);
-        if(id != null)
-        {
-            aclChangeSetEntity = new AclChangeSetEntity();
-            aclChangeSetEntity.setId(id);
-            aclChangeSetEntity.setCommitTimeMs(AlfrescoTransactionSupport.getResource(RESOURCE_KEY_ACL_CHANGE_SET_COMMIT_TIME_MS));    
-        }
-        return aclChangeSetEntity;
+        return AlfrescoTransactionSupport.getResource(RESOURCE_KEY_ACL_CHANGE_SET_COMMIT_TIME_MS);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AclDAOImpl.java
@@ -1636,8 +1636,8 @@ public class AclDAOImpl implements AclDAO
         return changes;
     }
 
-    public static final String RESOURCE_KEY_ACL_CHANGE_SET_ID = "acl.change.set.id";
-    public static final String RESOURCE_KEY_ACL_CHANGE_SET_COMMIT_TIME_MS = "acl.change.commit.set.time.ms";
+    private static final String RESOURCE_KEY_ACL_CHANGE_SET_ID = "acl.change.set.id";
+    private static final String RESOURCE_KEY_ACL_CHANGE_SET_COMMIT_TIME_MS = "acl.change.commit.set.time.ms";
 
     private UpdateChangeSetListener updateChangeSetListener = new UpdateChangeSetListener();
     /**

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -389,23 +389,8 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
     private ZonedDateTime getCurrentTransactionTimestamp()
     {
         Long currentTransactionCommitTime = nodeDAO.getCurrentTransactionCommitTime();
-        ZonedDateTime timestamp;
-        if(currentTransactionCommitTime != null)
-        {
-            Instant commitTimeMs = Instant.ofEpochMilli(currentTransactionCommitTime);
-            timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
-        }
-        else 
-        {
-            // Sometimes the transaction entry is not created because no nodes were added to the transaction, but we are producing events anywhere.
-            if(log.isDebugEnabled()){
-                log.debug("Unable to retrieve the commit time for transaction " + AlfrescoTransactionSupport.getTransactionId() + " the current timestamp will be used as event timestamp.");
-            }
-                
-            timestamp = ZonedDateTime.now();
-        }
-        
-        return timestamp;
+        Instant commitTimeMs = Instant.ofEpochMilli(currentTransactionCommitTime);
+        return ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
     }
 
     @Override
@@ -439,16 +424,14 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
                     }
 
                     // Child assoc events
-                    for (Map.Entry<ChildAssociationRef, ChildAssociationEventConsolidator> entry : consolidators.getChildAssocs()
-                                                                                                           .entrySet())
+                    for (Map.Entry<ChildAssociationRef, ChildAssociationEventConsolidator> entry : consolidators.getChildAssocs().entrySet())
                     {
                         ChildAssociationEventConsolidator eventConsolidator = entry.getValue();
                         sendEvent(entry.getKey(), eventConsolidator);
                     }
 
                     // Peer assoc events
-                    for (Map.Entry<AssociationRef, PeerAssociationEventConsolidator> entry : consolidators.getPeerAssocs()
-                                                                                                     .entrySet())
+                    for (Map.Entry<AssociationRef, PeerAssociationEventConsolidator> entry : consolidators.getPeerAssocs().entrySet())
                     {
                         PeerAssociationEventConsolidator eventConsolidator = entry.getValue();
                         sendEvent(entry.getKey(), eventConsolidator);

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -377,7 +377,7 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
         return (childAssociationTypeFilter.isExcluded(childAssocType) || (userFilter.isExcluded(user)));
     }
 
-    private EventInfo getEventInfo(String user)
+    protected EventInfo getEventInfo(String user)
     {
         return new EventInfo().setTimestamp(getCurrentTransactionTimestamp())
                               .setId(UUID.randomUUID().toString())

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -96,7 +96,7 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
     private TransactionService transactionService;
     private PersonService personService;
     protected NodeResourceHelper nodeResourceHelper;
-    private NodeDAO nodeDAO;
+    protected NodeDAO nodeDAO;
 
     private EventGeneratorQueue eventGeneratorQueue;
     private NodeTypeFilter nodeTypeFilter;
@@ -388,7 +388,7 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
 
     private ZonedDateTime getCurrentTransactionTimestamp()
     {
-        Long currentTransactionId = nodeDAO.getCurrentTransactionId(false);
+        Long currentTransactionId = nodeDAO.getCurrentTransactionId(true);
         Transaction transaction = nodeDAO.getTxnById(currentTransactionId);
         Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
         ZonedDateTime timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -388,12 +388,11 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
 
     private ZonedDateTime getCurrentTransactionTimestamp()
     {
-        Long currentTransactionId = nodeDAO.getCurrentTransactionId(false);
+        Long currentTransactionCommitTime = nodeDAO.getCurrentTransactionCommitTime();
         ZonedDateTime timestamp;
-        if(currentTransactionId != null)
+        if(currentTransactionCommitTime != null)
         {
-            Transaction transaction = nodeDAO.getTxnById(currentTransactionId);
-            Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
+            Instant commitTimeMs = Instant.ofEpochMilli(currentTransactionCommitTime);
             timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
         }
         else 

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -398,10 +398,11 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
         }
         else 
         {
-            /**
-             * Sometimes the transaction entry is not created because no nodes were added to the transaction, 
-             * but we need to produce some events anywhere.
-             */
+            // Sometimes the transaction entry is not created because no nodes were added to the transaction, but we are producing events anywhere.
+            if(log.isDebugEnabled()){
+                log.debug("Unable to retrieve the commit time for transaction " + AlfrescoTransactionSupport.getTransactionId() + " the current timestamp will be used as event timestamp.");
+            }
+                
             timestamp = ZonedDateTime.now();
         }
         

--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -388,10 +388,23 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
 
     private ZonedDateTime getCurrentTransactionTimestamp()
     {
-        Long currentTransactionId = nodeDAO.getCurrentTransactionId(true);
-        Transaction transaction = nodeDAO.getTxnById(currentTransactionId);
-        Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
-        ZonedDateTime timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
+        Long currentTransactionId = nodeDAO.getCurrentTransactionId(false);
+        ZonedDateTime timestamp;
+        if(currentTransactionId != null)
+        {
+            Transaction transaction = nodeDAO.getTxnById(currentTransactionId);
+            Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
+            timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
+        }
+        else 
+        {
+            /**
+             * Sometimes the transaction entry is not created because no nodes were added to the transaction, 
+             * but we need to produce some events anywhere.
+             */
+            timestamp = ZonedDateTime.now();
+        }
+        
         return timestamp;
     }
 

--- a/repository/src/main/resources/alfresco/events2-context.xml
+++ b/repository/src/main/resources/alfresco/events2-context.xml
@@ -42,6 +42,7 @@
         <property name="personService" ref="personService"/>
         <property name="nodeResourceHelper" ref="nodeResourceHelper"/>
         <property name="eventGeneratorQueue" ref="eventGeneratorQueue"/>
+        <property name="nodeDAO" ref="nodeDAO"/>
     </bean>
 
     <bean id="baseNodeResourceHelper" abstract="true">

--- a/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
@@ -26,9 +26,14 @@
 
 package org.alfresco.repo.event2;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.alfresco.model.ContentModel;
+import org.alfresco.repo.domain.node.NodeDAO;
+import org.alfresco.repo.domain.node.Transaction;
 import org.alfresco.repo.event.v1.model.EventData;
 import org.alfresco.repo.event.v1.model.EventType;
 import org.alfresco.repo.event.v1.model.NodeResource;
@@ -38,6 +43,7 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.PropertyMap;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Iulian Aftene
@@ -45,6 +51,9 @@ import org.junit.Test;
 public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
 {
 
+    @Autowired
+    private NodeDAO nodeDAO;
+    
     @Test
     public void testCreateEvent()
     {
@@ -149,9 +158,32 @@ public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
         assertTrue("isFile flag should be TRUE for nodeType=cm:content. ", resource.isFile());
         assertFalse("isFolder flag should be FALSE for nodeType=cm:content. ", resource.isFolder());
     }
+    
+    @Test
+    public void testEventTimestampEqualsToTransactionCommitTime()
+    {
+        String name = "TestFile-" + System.currentTimeMillis() + ".txt";
+        PropertyMap propertyMap = new PropertyMap();
+        propertyMap.put(ContentModel.PROP_NAME, name);
+        
+        //create a node and return the transaction id required later
+        Long transactionId = retryingTransactionHelper.doInTransaction(() -> {
+            nodeService.createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN,
+                    QName.createQName(TEST_NAMESPACE, GUID.generate()), ContentModel.TYPE_CONTENT, propertyMap).getChildRef();
+            return nodeDAO.getCurrentTransactionId(false);
+        });
+
+        RepoEvent<EventData<NodeResource>> resultRepoEvent = getRepoEvent(1);
+
+        Transaction transaction = nodeDAO.getTxnById(transactionId);
+        Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
+        ZonedDateTime timestamp = ZonedDateTime.ofInstant(commitTimeMs, ZoneOffset.UTC);
+        
+        assertEquals(timestamp, resultRepoEvent.getTime());
+    }
 
     @Test
-    public void testCteateMultipleNodesInTheSameTransaction()
+    public void testCreateMultipleNodesInTheSameTransaction()
     {
         retryingTransactionHelper.doInTransaction(() -> {
             for (int i = 0; i < 3; i++)

--- a/repository/src/test/java/org/alfresco/repo/security/permissions/impl/AclDaoComponentTest.java
+++ b/repository/src/test/java/org/alfresco/repo/security/permissions/impl/AclDaoComponentTest.java
@@ -273,16 +273,13 @@ public class AclDaoComponentTest extends TestCase
         assertEquals(aclProps.getAclVersion(), Long.valueOf(1l));
         assertEquals(aclProps.getInherits(), Boolean.TRUE);
 
-        assertNotNull(aclDaoComponent.getCurrentACLChangeSet());
-        assertNotNull(aclDaoComponent.getCurrentACLChangeSet().getId());
-
         AtomicBoolean afterCommit = new AtomicBoolean();
         AlfrescoTransactionSupport.bindListener(new TransactionListenerAdapter() {
             @Override
             public void afterCommit()
             {
                 //The commit time is available only after a transaction is committed
-                assertNotNull(aclDaoComponent.getCurrentACLChangeSet().getCommitTimeMs());
+                assertNotNull(aclDaoComponent.getCurrentChangeSetCommitTime());
                 afterCommit.set(true);
             }
         });


### PR DESCRIPTION
This PR is updated because we face an issue when the transaction entry object is not initialized and we cannot retrieve the commit time. This happens when no nodes were added to the transaction because there aren't changes to any node, but we need to produce some events (e.g. permission update).

Before I’m getting the commit time using the nodeDao:
```
Long currentTransactionId = nodeDAO.getCurrentTransactionId(true);
Transaction transaction = nodeDAO.getTxnById(currentTransactionId);
Instant commitTimeMs = Instant.ofEpochMilli(transaction.getCommitTimeMs());
```
The PermissionService does not invoke always NodeDAOImpl.getCurrentTransaction() method, so even if we are inside a transaction the Transaction entry will not be initialized and the method nodeDAO.getCurrentTransactionId() will return null or it will throw an exception, depends on the boolean parameter value. In this case, also the ACL transaction is null. For instance, if you remove an ACL from a node and that ACL type is shared the transaction entry is never initialized.

In this PR I'm purposing a solution checking if the current transaction id is null, and then using the current time.

I prefer the solution above because it avoids exceptions for a trivial reason. Otherwise, we can force the transaction entry initialization invoking nodeDAO.getCurrentTransactionId(true) in PermissionEventGenerator but in this case, we are creating empty transactions and we are relying on a side effect (the getter that inits an object).  
