### PR TITLE
MNT-20791 : Smart Folder incorrect page number and item number

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/virtual/template/PagingRequestConstraint.java
+++ b/repository/src/main/java/org/alfresco/repo/virtual/template/PagingRequestConstraint.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -55,7 +55,17 @@ public class PagingRequestConstraint extends VirtualQueryConstraintDecorator
         if (pagingRequest != null)
         {
             searchParametersCopy.setSkipCount(pagingRequest.getSkipCount());
-            searchParametersCopy.setMaxItems(pagingRequest.getMaxItems());
+
+            // MNT-20791 : Smart folders will retrieve incorrect totalResults.
+            // Search query will return a set of size equal to searchParameters.maxItems
+            // For pagingRequest maxItems represents number of elements on the page and requestTotalCountMax the maximum number of elements to retrieve
+            // The Search query will retrieve elements starting from skipCount + 1, because of this in order to display pages consisten in share
+            // the numberOfElementsToRetrieve will be requestTotalCountMax - skipCount.
+            int numberOfElementsToRetrieve = pagingRequest.getRequestTotalCountMax() != 0
+                ? pagingRequest.getRequestTotalCountMax() - pagingRequest.getSkipCount()
+                : pagingRequest.getMaxItems();
+
+            searchParametersCopy.setMaxItems(numberOfElementsToRetrieve);
         }
 
         return searchParametersCopy;

--- a/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -174,7 +174,7 @@ public class VirtualQueryImpl implements VirtualQuery
     private PagingResults<Reference> asPagingResults(ActualEnvironment environment, PagingRequest pagingRequest,
                 ResultSet result, Reference parentReference) throws ActualEnvironmentException
     {
-        final List<Reference> page = new LinkedList<Reference>();
+        final List<Reference> page = new LinkedList<>();
 
         for (ResultSetRow row : result)
         {
@@ -183,11 +183,10 @@ public class VirtualQueryImpl implements VirtualQuery
         }
 
         final boolean hasMore = result.hasMore();
-        final int totalFirst = (int) result.getNumberFound();
-        int start;
+        int skipCount;
         try
         {
-            start = result.getStart();
+            skipCount = result.getStart();
         }
         catch (UnsupportedOperationException e)
         {
@@ -195,18 +194,11 @@ public class VirtualQueryImpl implements VirtualQuery
             {
                 logger.debug("Unsupported ResultSet.getStart() when trying to create query paging result");
             }
-            if (pagingRequest != null)
-            {
-                start = pagingRequest.getSkipCount();
-            }
-            else
-            {
-                start = 0;
-            }
+            skipCount = pagingRequest != null ? pagingRequest.getSkipCount() : 0;
         }
-        final int totlaSecond = !hasMore ? (int) result.getNumberFound() : (int) (start + result.getNumberFound() + 1);
-        final Pair<Integer, Integer> total = new Pair<Integer, Integer>(totalFirst,
-                                                                        totlaSecond);
+        final int totalFirst = skipCount + (int) result.length();
+        final Pair<Integer, Integer> total = new Pair<>(totalFirst, totalFirst);
+
         return new PagingResults<Reference>()
         {
 

--- a/repository/src/test/java/org/alfresco/repo/virtual/template/VirtualQueryImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/virtual/template/VirtualQueryImplTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -32,6 +32,7 @@ import java.util.Collections;
 
 import junit.framework.TestCase;
 
+import org.alfresco.query.PagingRequest;
 import org.alfresco.repo.search.EmptyResultSet;
 import org.alfresco.repo.virtual.ActualEnvironment;
 import org.alfresco.repo.virtual.ref.Protocols;
@@ -150,6 +151,89 @@ public class VirtualQueryImplTest extends TestCase
 
         assertPerform2Results();
     }
+
+    public void testZeroSkipCountAndMaxItems()
+    {
+        // Case 1 skiCount=0, maxItems=50
+        PagingRequest pagingRequest = new PagingRequest(0,50);
+
+        VirtualQueryConstraint constraint = BasicConstraint.INSTANCE;
+        constraint = new PagingRequestConstraint(constraint, pagingRequest);
+
+        query.perform(mockitoActualEnvironment,
+            constraint,
+            null,
+            nodeOneReference);
+
+        ArgumentCaptor<SearchParameters> queryCaptor = ArgumentCaptor.forClass(SearchParameters.class);
+        Mockito.verify(mockitoActualEnvironment).query(queryCaptor.capture());
+
+        assertEquals(0, queryCaptor.getValue().getSkipCount());
+        assertEquals(50, queryCaptor.getValue().getMaxItems());
+    }
+
+    public void testSkipCountAndMaxItems()
+    {
+        // Case 2 skiCount=25, maxItems=50
+        PagingRequest pagingRequest = new PagingRequest(25,50);
+
+        VirtualQueryConstraint constraint = BasicConstraint.INSTANCE;
+        constraint = new PagingRequestConstraint(constraint, pagingRequest);
+
+        query.perform(mockitoActualEnvironment,
+            constraint,
+            null,
+            nodeOneReference);
+
+        ArgumentCaptor<SearchParameters> queryCaptor = ArgumentCaptor.forClass(SearchParameters.class);
+        Mockito.verify(mockitoActualEnvironment).query(queryCaptor.capture());
+
+        assertEquals(25, queryCaptor.getValue().getSkipCount());
+        assertEquals(50, queryCaptor.getValue().getMaxItems());
+    }
+
+    public void testZeroSkipCountAndTotalCountAndMaxItems()
+    {
+        // Case 3 skiCount=0, maxItems=50 requestTotalCountMax=100
+        PagingRequest pagingRequest = new PagingRequest(0,50);
+        pagingRequest.setRequestTotalCountMax(100);
+
+        VirtualQueryConstraint constraint = BasicConstraint.INSTANCE;
+        constraint = new PagingRequestConstraint(constraint, pagingRequest);
+
+        query.perform(mockitoActualEnvironment,
+            constraint,
+            null,
+            nodeOneReference);
+
+        ArgumentCaptor<SearchParameters> queryCaptor = ArgumentCaptor.forClass(SearchParameters.class);
+        Mockito.verify(mockitoActualEnvironment).query(queryCaptor.capture());
+
+        assertEquals(0, queryCaptor.getValue().getSkipCount());
+        assertEquals(100, queryCaptor.getValue().getMaxItems());
+    }
+
+    public void testSkipCountAndTotalCountAndMaxItems()
+    {
+        // Case 4 skiCount=25, maxItems=50
+        PagingRequest pagingRequest = new PagingRequest(25,50);
+        pagingRequest.setRequestTotalCountMax(100);
+
+        VirtualQueryConstraint constraint = BasicConstraint.INSTANCE;
+        constraint = new PagingRequestConstraint(constraint, pagingRequest);
+
+        query.perform(mockitoActualEnvironment,
+            constraint,
+            null,
+            nodeOneReference);
+
+        ArgumentCaptor<SearchParameters> queryCaptor = ArgumentCaptor.forClass(SearchParameters.class);
+        Mockito.verify(mockitoActualEnvironment).query(queryCaptor.capture());
+
+        assertEquals(25, queryCaptor.getValue().getSkipCount());
+        assertEquals(75, queryCaptor.getValue().getMaxItems());
+    }
+
 
     private void assertPerform1Results(Pair<QName, Boolean> withSortDefinitions)
     {


### PR DESCRIPTION
   PagingRequestConstraint now is aware of pagingRequest.requestTotalCountMax.
   Rename start to skipCount in VirtualQueryImpl#asPagingResults
   Added skipCount maxItems and requestTotalCountMax tests in VirtualQueryImplTest
   For consistency in the share pagination (normal folder vs smart folder) the following changes were done:
   When result.hasMore() is true inVirtualQueryImpl will now return a pair of identical values for totalItems instead of (value,value+1)
   When skipCount > 0 and requestTotalCountMax > 0 , searchParameter.maxItems will be requestTotalCountMax - skipCount because the skipped elements will not be part of the query ResultSet