### PR TITLE
MNT-22186: propTablesCleanupJobDetail v2 can cause Out of Memory erro…

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/schema/script/ScriptExecutorImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/schema/script/ScriptExecutorImpl.java
@@ -350,7 +350,7 @@ public class ScriptExecutorImpl implements ScriptExecutor
                 }
                 else if (sql.startsWith("--DELETE_NOT_EXISTS"))
                 {
-                    DeleteNotExistsExecutor deleteNotExists = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, globalProperties);
+                    DeleteNotExistsExecutor deleteNotExists = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, globalProperties, dialect);
                     deleteNotExists.execute();
 
                     // Reset

--- a/repository/src/test/java/org/alfresco/repo/domain/schema/script/DeleteNotExistsExecutorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/schema/script/DeleteNotExistsExecutorTest.java
@@ -90,7 +90,7 @@ public class DeleteNotExistsExecutorTest
             {
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_READ_ONLY)).thenReturn("true");
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_TIMEOUT_SECONDS)).thenReturn("-1");
-                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties);
+                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties, null);
                 deleteNotExistsExecutor.execute();
 
                 List<String> res = jdbcTmpl.queryForList(select, String.class);
@@ -100,7 +100,7 @@ public class DeleteNotExistsExecutorTest
             {
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_READ_ONLY)).thenReturn("false");
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_TIMEOUT_SECONDS)).thenReturn("-1");
-                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties);
+                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties, null);
                 deleteNotExistsExecutor.execute();
 
                 List<String> res = jdbcTmpl.queryForList(select, String.class);
@@ -133,7 +133,7 @@ public class DeleteNotExistsExecutorTest
             {
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_DELETE_BATCH_SIZE)).thenReturn("1");
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_READ_ONLY)).thenReturn("false");
-                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties);
+                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties, null);
                 deleteNotExistsExecutor.execute();
 
                 List<String> res = jdbcTmpl.queryForList(select, String.class);
@@ -167,7 +167,7 @@ public class DeleteNotExistsExecutorTest
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_BATCH_SIZE)).thenReturn("2");
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_READ_ONLY)).thenReturn("false");
                 when(properties.getProperty(DeleteNotExistsExecutor.PROPERTY_TIMEOUT_SECONDS)).thenReturn("-1");
-                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties);
+                DeleteNotExistsExecutor deleteNotExistsExecutor = new DeleteNotExistsExecutor(connection, sql, line, scriptFile, properties, null);
                 deleteNotExistsExecutor.execute();
 
                 List<String> res = jdbcTmpl.queryForList(select, String.class);


### PR DESCRIPTION
…rs (CleanAlfPropTablesV2.sql )

- added dialect check to set MySQL specific fetch size limitation (Integer.MIN_VALUE). fetchSize activates result set streaming.
- updated tests