### PR TITLE
[MNT-21611] Removed HTML transformation pipelines (with LibreOffice). Added new HTML pipelines via TEXT.

### DIFF
--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -118,31 +118,6 @@
       ]
     },
     {
-      "transformerName": "htmlToPdfViaOdt",
-      "transformerPipeline" : [
-        {"transformerName": "libreoffice",                  "targetMediaType": "application/vnd.oasis.opendocument.text"},
-        {"transformerName": "libreoffice"}
-      ],
-      "supportedSourceAndTargetList": [
-        {"sourceMediaType": "text/html",                    "targetMediaType": "application/pdf" }
-      ],
-      "transformOptions": [
-      ]
-    },
-    {
-      "transformerName": "htmlToImageViaPdf",
-      "transformerPipeline" : [
-        {"transformerName": "htmlToPdfViaOdt",               "targetMediaType": "application/pdf"},
-        {"transformerName": "pdfToImageViaPng"}
-      ],
-      "supportedSourceAndTargetList": [
-      ],
-      "transformOptions": [
-        "pdfRendererOptions",
-        "imageMagickOptions"
-      ]
-    },
-    {
       "transformerName": "ooXmlToImageViaText",
       "transformerPipeline" : [
         {"transformerName": "OOXML",                                                                        "targetMediaType": "text/plain"},
@@ -199,20 +174,8 @@
       ]
     },
     {
-      "transformerName": "libreofficeHtmlToPdfViaOdt",
-      "transformerPipeline" : [
-        {"transformerName": "libreoffice", "targetMediaType": "application/vnd.oasis.opendocument.text"},
-        {"transformerName": "libreoffice"}
-      ],
-      "supportedSourceAndTargetList": [
-        {"sourceMediaType": "text/html",  "targetMediaType": "application/pdf" }
-      ],
-      "transformOptions": [
-      ]
-    },
-    {
       "transformerName": "libreofficeToPdf",
-      "transformerFailover" : [ "libreoffice", "libreofficeHtmlToPdfViaOdt" ],
+      "transformerFailover" : [ "libreoffice" ],
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/vnd.oasis.opendocument.graphics", "priority": 150, "targetMediaType": "application/pdf" },
         {"sourceMediaType": "application/vnd.sun.xml.calc.template",       "priority": 150, "targetMediaType": "application/pdf" },
@@ -262,6 +225,32 @@
       ],
       "transformOptions": [
         "tikaOptions"
+      ]
+    },
+    {
+      "transformerName": "htmlToPdfViaTXT",
+      "transformerPipeline" : [
+        {"transformerName": "string", "targetMediaType": "text/plain"},
+        {"transformerName": "libreoffice"}
+      ],
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "text/html",                             "targetMediaType": "application/pdf" }
+      ],
+      "transformOptions": [
+      ]
+    },
+    {
+      "transformerName": "htmlToImageViaTXT",
+      "transformerPipeline" : [
+        {"transformerName": "string", "targetMediaType": "text/plain"},
+        {"transformerName": "textToImageViaPdf"}
+      ],
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "text/html",                             "targetMediaType": "image/png" }
+      ],
+      "transformOptions": [
+        "pdfRendererOptions",
+        "imageMagickOptions"
       ]
     }
   ]


### PR DESCRIPTION
Removed HTML pipelines that use LibreOffice in order to prevent BSSRF attacks. New pipelines have been added so the transformations can be performed via TXT.

A PR has also been raised in alfresco-transform-service: https://github.com/Alfresco/alfresco-transform-service/pull/412

DOCS-6236 has been created containing a document that describes how to remove the LO pipelines on current installations and also how to restore them.

See also: https://github.com/Alfresco/alfresco-transform-service/pull/412 (enterprise / private repo)