### PR TITLE
SEARCH-2748 Bump restapi from 1.57 to 1.58

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency.mariadb.version>2.7.2</dependency.mariadb.version>
         <dependency.tas-utility.version>3.0.44</dependency.tas-utility.version>
         <dependency.rest-assured.version>3.3.0</dependency.rest-assured.version>
-        <dependency.tas-restapi.version>1.57</dependency.tas-restapi.version>
+        <dependency.tas-restapi.version>1.58</dependency.tas-restapi.version>
         <dependency.tas-cmis.version>1.29</dependency.tas-cmis.version>
         <dependency.tas-email.version>1.8</dependency.tas-email.version>
         <dependency.tas-webdav.version>1.6</dependency.tas-webdav.version>


### PR DESCRIPTION
Dependabot is failing because of a weird issue, I guess from their side, so I created the bump PR manually:
```
fetcher | ERROR <job_77448412> Error during file fetching; aborting
fetcher | ERROR <job_77448412> key not found: :security_updates_only
```