### PR TITLE
REPO-5391 : [cmis webservices] isPrivateWorkingCopy throws NullPointerException

### DIFF
--- a/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CancelCheckOutTests.java
+++ b/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CancelCheckOutTests.java
@@ -32,7 +32,7 @@ public class CancelCheckOutTests extends CmisTest
         usersWithRoles = dataUser.addUsersWithRolesToSite(testSite, UserRole.SiteContributor, UserRole.SiteCollaborator);
     }
 
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.SANITY, TestGroup.CMIS})
+    @Test(groups = { TestGroup.SANITY, TestGroup.CMIS})
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.SANITY,
             description = "Verify cancel check out on a pwc")
     public void cancelCheckOutOnPWC() throws Exception
@@ -74,7 +74,7 @@ public class CancelCheckOutTests extends CmisTest
                 .then().cancelCheckOut();
     }
 
-    @Test(groups = { "bug-atom-REPO-5383", "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS }, expectedExceptions=CmisRuntimeException.class)
+    @Test(groups = { "bug-atom-REPO-5383", TestGroup.REGRESSION, TestGroup.CMIS }, expectedExceptions=CmisRuntimeException.class)
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify cancel check out on a pwc twice")
     public void cancelCheckOutTwice() throws Exception

--- a/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CheckInTests.java
+++ b/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CheckInTests.java
@@ -58,7 +58,7 @@ public class CheckInTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.SANITY,
             description = "Verify check in document with minor version and with content")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.SANITY, TestGroup.CMIS})
+    @Test(groups = { TestGroup.SANITY, TestGroup.CMIS})
     public void checkInDocumentWithMinorVersionAndWithContent() throws Exception
     {
         String newContent = "new minor content";

--- a/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CheckOutTests.java
+++ b/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CheckOutTests.java
@@ -33,7 +33,7 @@ public class CheckOutTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.SANITY,
             description = "Verify check out valid document")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.SANITY, TestGroup.CMIS})
+    @Test(groups = { TestGroup.SANITY, TestGroup.CMIS})
     public void verifyCheckOutValidDocument() throws Exception
     {
         testFile = FileModel.getRandomFileModel(FileType.TEXT_PLAIN, fileContent);

--- a/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CreateDocumentTests.java
+++ b/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CreateDocumentTests.java
@@ -191,7 +191,7 @@ public class CreateDocumentTests extends CmisTest
     
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify site manager is able to create file with CHECKEDOUT versioning state")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
     public void siteManagerShouldCreateDocumentWithCheckedOutVersioningState() throws Exception
     {
         testFile = FileModel.getRandomFileModel(FileType.TEXT_PLAIN);

--- a/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/IsPrivateWorkingCopyTests.java
+++ b/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/IsPrivateWorkingCopyTests.java
@@ -41,7 +41,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.SANITY,
             description = "Verify site manager is able to verify if checked out document is private working copy")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.SANITY, TestGroup.CMIS})
+    @Test(groups = { TestGroup.SANITY, TestGroup.CMIS})
     public void siteManagerCanVerifyIsPrivateWorkingCopy() throws Exception
     {
         cmisApi.authenticateUser(managerUser).usingResource(checkedOutDoc)
@@ -51,7 +51,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.SANITY,
             description = "Verify site manager is able to verify if pwc document is private working copy")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.SANITY, TestGroup.CMIS})
+    @Test(groups = { TestGroup.SANITY, TestGroup.CMIS})
     public void siteManagerCanVerifyIsPrivateWorkingCopyOnPwc() throws Exception
     {
         cmisApi.authenticateUser(managerUser).usingResource(checkedOutDoc)
@@ -73,7 +73,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify site collaborator is able to verify if checked out document is private working copy")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
     public void collaboratorCanVerifyIsPrivateWorkingCopy() throws Exception
     {
         cmisApi.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteCollaborator))
@@ -84,7 +84,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify site contributor is able to verify if checked out document is private working copy")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
     public void contributorCanVerifyIsPrivateWorkingCopy() throws Exception
     {
         cmisApi.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteContributor))
@@ -95,7 +95,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify site consumer is able to verify if checked out document is private working copy")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
     public void consumerCanVerifyIsPrivateWorkingCopy() throws Exception
     {
         cmisApi.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteConsumer))
@@ -106,7 +106,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify non invited user is able to verify if checked out document is private working copy in public site")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
     public void nonInvitedUserCanVerifyIsPrivateWorkingCopyInPublicSite() throws Exception
     {
         cmisApi.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteConsumer))
@@ -143,7 +143,7 @@ public class IsPrivateWorkingCopyTests extends CmisTest
 
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify site manager is able to verify if document created with CHECKEDOUT versioning state is private working copy")
-    @Test(groups = { "bug-ws-REPO-5391", TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
     public void verifyIsPrivateWorkingCopyForDocumentWithCheckedOutVersioningState() throws Exception
     {
         FileModel checkedDoc = FileModel.getRandomFileModel(FileType.TEXT_PLAIN, documentContent);

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency.tas-utility.version>3.0.44</dependency.tas-utility.version>
         <dependency.rest-assured.version>3.3.0</dependency.rest-assured.version>
         <dependency.tas-restapi.version>1.58</dependency.tas-restapi.version>
-        <dependency.tas-cmis.version>1.29</dependency.tas-cmis.version>
+        <dependency.tas-cmis.version>1.30</dependency.tas-cmis.version>
         <dependency.tas-email.version>1.8</dependency.tas-email.version>
         <dependency.tas-webdav.version>1.6</dependency.tas-webdav.version>
         <dependency.tas-ftp.version>1.5</dependency.tas-ftp.version>


### PR DESCRIPTION
   - upgrade tas-cmis (see fix in https://github.com/Alfresco/alfresco-tas-cmis/pull/56)
   - remove `bug-ws-REPO-5391` flag on checkout tests