### PR TITLE
ACS-895 User email should not be necessary for joining a site

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/invitation/InvitationServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/invitation/InvitationServiceImpl.java
@@ -2003,23 +2003,15 @@ public class InvitationServiceImpl implements InvitationService, NodeServicePoli
             return;
         }
 
-        // send email to the invitee if possible - but don't fail the invitation if email cannot be sent
-        try
-        {
-            Map<String, String> properties = makePropertiesFromContextVariables(executionVariables, invitePropNames);
+        // send email to the invitee
+        Map<String, String> properties = makePropertiesFromContextVariables(executionVariables, invitePropNames);
 
-            String packageRef = getPackageRef(executionVariables);
-            properties.put(InviteNominatedSender.WF_PACKAGE, packageRef);
+        String packageRef = getPackageRef(executionVariables);
+        properties.put(InviteNominatedSender.WF_PACKAGE, packageRef);
 
-            properties.put(InviteNominatedSender.WF_INSTANCE_ID, inviteId);
+        properties.put(InviteNominatedSender.WF_INSTANCE_ID, inviteId);
 
-            inviteSender.sendMail(emailTemplateXpath, emailSubjectKey, properties);
-        }
-        catch (Exception e)
-        {
-            // Swallow exception
-            logger.error("unable to send invite email", e);
-        }
+        inviteSender.sendMail(emailTemplateXpath, emailSubjectKey, properties);
     }
     
 

--- a/repository/src/main/java/org/alfresco/repo/invitation/site/InviteNominatedSender.java
+++ b/repository/src/main/java/org/alfresco/repo/invitation/site/InviteNominatedSender.java
@@ -53,6 +53,9 @@ import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.TemplateService;
 import org.alfresco.util.ModelUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.surf.util.ParameterCheck;
 import org.springframework.extensions.surf.util.URLEncoder;
 
@@ -64,6 +67,7 @@ import org.springframework.extensions.surf.util.URLEncoder;
  */
 public class InviteNominatedSender extends InviteSender
 {
+    private static final Log logger = LogFactory.getLog(InviteNominatedSender.class);
     public static final String WF_INSTANCE_ID = "wf_instanceId";
     public static final String WF_PACKAGE = "wf_package";
     public static final String SITE_LEAVE_HASH = "#leavesite";
@@ -109,7 +113,13 @@ public class InviteNominatedSender extends InviteSender
         NodeRef invitee = personService.getPerson(inviteeName);
         Action mail = actionService.createAction(MailActionExecuter.NAME);
         mail.setParameterValue(MailActionExecuter.PARAM_FROM, getEmail(inviter));
-        mail.setParameterValue(MailActionExecuter.PARAM_TO, getEmail(invitee));
+        String recipient = getEmail(invitee);
+        if(StringUtils.isEmpty(recipient))
+        {
+            logger.warn("Cannot send invitation: Invitee user account does not have email");
+            return;
+        }
+        mail.setParameterValue(MailActionExecuter.PARAM_TO, recipient);
         mail.setParameterValue(MailActionExecuter.PARAM_SUBJECT, emailSubjectKey);
         mail.setParameterValue(MailActionExecuter.PARAM_SUBJECT_PARAMS, new Object[] { ModelUtil.getProductName(repoAdminService), getSiteName(properties) });
         mail.setParameterValue(MailActionExecuter.PARAM_TEMPLATE, getEmailTemplateNodeRef(emailTemplateXpath));


### PR DESCRIPTION
Fixed the first approach. No longer catching the Exception and instead preventing to invoke the email action if the invited user does not have an email address