### PR TITLE
REPO-5631 Investigate different types of results for optional patches difference detection

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/schema/SchemaBootstrap.java
@@ -85,7 +85,6 @@ import org.alfresco.util.DialectUtil;
 import org.alfresco.util.LogUtil;
 import org.alfresco.util.PropertyCheck;
 import org.alfresco.util.TempFileProvider;
-import org.alfresco.util.schemacomp.Difference;
 import org.alfresco.util.schemacomp.ExportDb;
 import org.alfresco.util.schemacomp.MultiFileDumper;
 import org.alfresco.util.schemacomp.MultiFileDumper.DbToXMLFactory;
@@ -2004,12 +2003,7 @@ public class SchemaBootstrap extends AbstractLifecycleBean
             return null;
         }
 
-        if (!(result instanceof Difference))
-        {
-            return null;
-        }
-
-        return differenceHelper.findPatchCausingDifference((Difference)result);
+        return differenceHelper.findPatchCausingDifference(result);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/util/schemacomp/Difference.java
+++ b/repository/src/main/java/org/alfresco/util/schemacomp/Difference.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -24,6 +24,8 @@
  * #L%
  */
 package org.alfresco.util.schemacomp;
+
+import java.util.Locale;
 
 import org.springframework.extensions.surf.util.I18NUtil;
 
@@ -84,10 +86,22 @@ public final class Difference extends Result
     @Override
     public String describe()
     {
+        return doDescribe(I18NUtil.getLocale());
+    }
+
+    @Override
+    public String describe(Locale locale)
+    {
+        return doDescribe(locale);
+    }
+
+    private String doDescribe(Locale locale)
+    {
         if (getLeft() == null)
         {
             return I18NUtil.getMessage(
                         "system.schema_comp.diff.target_only",
+                        locale,
                         getRight().getDbObject().getTypeName(),
                         getRight().getPath(),
                         getRight().getPropertyValue());
@@ -96,6 +110,7 @@ public final class Difference extends Result
         {
             return I18NUtil.getMessage(
                         "system.schema_comp.diff.ref_only",
+                        locale,
                         getLeft().getDbObject().getTypeName(),
                         getLeft().getPath(),
                         getLeft().getPropertyValue());
@@ -103,6 +118,7 @@ public final class Difference extends Result
         
         return I18NUtil.getMessage(
                     "system.schema_comp.diff",
+                    locale,
                     getLeft().getDbObject().getTypeName(),
                     getLeft().getPath(),
                     getLeft().getPropertyValue(),
@@ -115,4 +131,5 @@ public final class Difference extends Result
     {
         return "Difference [where=" + this.where + ", left=" + this.left + ", right=" + this.right + "]";
     }
+
 }

--- a/repository/src/main/java/org/alfresco/util/schemacomp/RedundantDbObject.java
+++ b/repository/src/main/java/org/alfresco/util/schemacomp/RedundantDbObject.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -26,6 +26,7 @@
 package org.alfresco.util.schemacomp;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.alfresco.util.schemacomp.model.DbObject;
 import org.springframework.extensions.surf.util.I18NUtil;
@@ -50,6 +51,17 @@ public class RedundantDbObject extends Result
 
     @Override
     public String describe()
+    {
+        return doDescribe(I18NUtil.getLocale());
+    }
+
+    @Override
+    public String describe(Locale locale)
+    {
+        return doDescribe(locale);
+    }
+
+    private String doDescribe(Locale locale)
     {
         if (matches.size() > SHOW_MAX_MATCHES)
         {

--- a/repository/src/main/java/org/alfresco/util/schemacomp/Result.java
+++ b/repository/src/main/java/org/alfresco/util/schemacomp/Result.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -25,6 +25,8 @@
  */
 package org.alfresco.util.schemacomp;
 
+import java.util.Locale;
+
 /**
  * Base class for the result of a differencing or validation operation.
  *  
@@ -43,4 +45,13 @@ public abstract class Result
     {
         return toString();
     }
+
+    /**
+     * An overload of the {@link #describe()} that allows you to specify what locale
+     * to use for the loggable message that describes the comparison result.
+     *
+     * @param locale The locale to use for comparison description.
+     * @return String
+     */
+    public abstract String describe(Locale locale);
 }

--- a/repository/src/main/java/org/alfresco/util/schemacomp/SchemaDifferenceHelper.java
+++ b/repository/src/main/java/org/alfresco/util/schemacomp/SchemaDifferenceHelper.java
@@ -42,7 +42,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.extensions.surf.util.I18NUtil;
 
 public class SchemaDifferenceHelper
 {
@@ -76,9 +75,9 @@ public class SchemaDifferenceHelper
         }
     }
 
-    public String findPatchCausingDifference(Difference difference)
+    public String findPatchCausingDifference(Result result)
     {
-        String differenceText = describe(difference);
+        String problemText = describe(result);
         for (SchemaUpgradeScriptPatch patch : optionalUpgradePatches)
         {
             if (!isPatchApplied(patch))
@@ -86,7 +85,7 @@ public class SchemaDifferenceHelper
                 List<String> problemPatterns = getProblemsPatterns(patch);
                 for (String problemPattern : problemPatterns)
                 {
-                    if (differenceText.matches(problemPattern))
+                    if (problemText.matches(problemPattern))
                     { 
                         return patch.getId(); 
                     }
@@ -138,34 +137,14 @@ public class SchemaDifferenceHelper
         return optionalProblems;
     }
 
-    protected String describe(Difference difference)
+    /**
+     * Retrieves the comparison result description message in the default system language.
+     *
+     * @param result The result of a differencing or validation operation.
+     * @return Comparison result description message in the default system language.
+     */
+    protected String describe(Result result)
     {
-        if (difference.getLeft() == null)
-        {
-            return I18NUtil.getMessage(
-                        "system.schema_comp.diff.target_only",
-                        ENGLISH,
-                        difference.getRight().getDbObject().getTypeName(),
-                        difference.getRight().getPath(),
-                        difference.getRight().getPropertyValue());
-        }
-        if (difference.getRight() == null)
-        {
-            return I18NUtil.getMessage(
-                        "system.schema_comp.diff.ref_only",
-                        ENGLISH,
-                        difference.getLeft().getDbObject().getTypeName(),
-                        difference.getLeft().getPath(),
-                        difference.getLeft().getPropertyValue());
-        }
-
-        return I18NUtil.getMessage(
-                    "system.schema_comp.diff",
-                    ENGLISH,
-                    difference.getLeft().getDbObject().getTypeName(),
-                    difference.getLeft().getPath(),
-                    difference.getLeft().getPropertyValue(),
-                    difference.getRight().getPath(),
-                    difference.getRight().getPropertyValue());
+        return result.describe(ENGLISH);
     }
 }

--- a/repository/src/main/java/org/alfresco/util/schemacomp/ValidationResult.java
+++ b/repository/src/main/java/org/alfresco/util/schemacomp/ValidationResult.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -24,6 +24,8 @@
  * #L%
  */
 package org.alfresco.util.schemacomp;
+
+import java.util.Locale;
 
 import org.springframework.extensions.surf.util.I18NUtil;
 
@@ -65,8 +67,20 @@ public class ValidationResult extends Result
     @Override
     public String describe()
     {
+        return doDescribe(I18NUtil.getLocale());
+    }
+
+    @Override
+    public String describe(Locale locale)
+    {
+        return doDescribe(locale);
+    }
+
+    private String doDescribe(Locale locale)
+    {
         return I18NUtil.getMessage(
                     "system.schema_comp.validation",
+                    locale,
                     getDbProperty().getDbObject().getTypeName(),
                     getDbProperty().getPath(),
                     getValue(),

--- a/repository/src/test/java/org/alfresco/util/schemacomp/SchemaBootstrapTest.java
+++ b/repository/src/test/java/org/alfresco/util/schemacomp/SchemaBootstrapTest.java
@@ -108,8 +108,8 @@ public class SchemaBootstrapTest
         int numProblems = schemaBootstrap.validateSchema(null, out);
         out.flush();
 
-        assertEquals(1, numProblems);
         String problems = buff.toString();
+        assertEquals("Expected 1 problem; but these problems were found instead: \n" + problems + "\n", 1, numProblems);
         assertTrue("Missing optional patch-specific problems report: \n" + problems,
                 problems.contains("The following problems will be resolved once the long running patch "
                         + optionalPatch.getId() + " has been run"));

--- a/repository/src/test/java/org/alfresco/util/schemacomp/SchemaDifferenceHelperUnitTest.java
+++ b/repository/src/test/java/org/alfresco/util/schemacomp/SchemaDifferenceHelperUnitTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.extensions.surf.util.I18NUtil;
 
 public class SchemaDifferenceHelperUnitTest
 {
@@ -71,6 +72,7 @@ public class SchemaDifferenceHelperUnitTest
     {
         dialect = mock(Dialect.class);
         patchService = mock(PatchService.class);
+        I18NUtil.registerResourceBundle("alfresco.messages.system-messages");
     }
 
     @Test
@@ -164,32 +166,8 @@ public class SchemaDifferenceHelperUnitTest
 
     private SchemaDifferenceHelper createHelper(List<SchemaUpgradeScriptPatch> upgradePatches)
     {
-        return new SchemaDifferenceHelper(dialect, patchService, upgradePatches) {
-            @Override
-            protected String describe(Difference difference)
-            {
-                if (difference.getLeft() == null)
-                {
-                    return String.format("Difference: unexpected %s found in database with path: %s",
-
-                            difference.getRight().getDbObject().getTypeName(),
-                            difference.getRight().getPath());
-                }
-                if(difference.getRight() == null)
-                {
-                    return String.format("Difference: missing %s from database, expected at path: %s",
-                            difference.getLeft().getDbObject().getTypeName(),
-                            difference.getLeft().getPath());
-                }
-
-                return String.format("Difference: expected %s %s=\"%s\", but was %s=\"%s\"",
-                        difference.getLeft().getDbObject().getTypeName(),
-                        difference.getLeft().getPath(),
-                        difference.getLeft().getPropertyValue(),
-                        difference.getRight().getPath(),
-                        difference.getRight().getPropertyValue());
-            }
-
+        return new SchemaDifferenceHelper(dialect, patchService, upgradePatches)
+        {
             @Override
             protected Resource getDialectResource(String resourceUrl)
             {


### PR DESCRIPTION
Changes made to support other `Result` implementations when detecting optional patches problems descriptions.
