### PR TITLE
[MNT-22419] Allow to save null leading values in a multiValued property

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodePropertyHelper.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodePropertyHelper.java
@@ -463,6 +463,7 @@ public class NodePropertyHelper
             PropertyDefinition propertyDef,
             SortedMap<NodePropertyKey, NodePropertyValue> sortedPropertyValues)
     {
+    	boolean first = true;
         Serializable result = null;
         Collection<Serializable> collectionResult = null;
         // A working map. Ordering is not important for this map.
@@ -489,9 +490,10 @@ public class NodePropertyHelper
                 // We have added something to the scratch properties but the index has just changed
                 Serializable collapsedValue = collapsePropertiesWithSameQNameAndListIndex(propertyDef, scratch);
                 // Store. If there is a value already, then we must build a collection.
-                if (result == null)
+                if (result == null && first)
                 {
                     result = collapsedValue;
+                    first = false;
                 }
                 else if (collectionResult != null)
                 {


### PR DESCRIPTION
Usecase:

1. Create a model content property (e.g., d:date or d:text) as multi-value property
2. Upload a document, e.g., through REST api and add the previous property with [null, null, "2021-05-24", null, null]
3. The value ["2021-05-24", null, null] is assigned to document property, excluding the null values at the beginning

This PR has a proposal which change the behavior described above, storing all the supplied values: [null, null, "2021-05-24", null, null]