### PR TITLE
MNT-22425 : bump transform.model to 1.0.2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency.alfresco-log-sanitizer.version>0.2</dependency.alfresco-log-sanitizer.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.transform.model.version>1.0.2.8</dependency.transform.model.version>
+        <dependency.transform.model.version>1.0.2.10</dependency.transform.model.version>
         <dependency.alfresco-legacy-lucene.version>6.2</dependency.alfresco-legacy-lucene.version>
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
 


### PR DESCRIPTION
   Include fix for ATS-730 this will fix the selection of transformer based on priority.