### PR TITLE
REPO-5632 Investigate intermittent failing tests in AppContext05TestSuite

### DIFF
--- a/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/domain/permissions/FixedAclUpdaterTest.java
@@ -91,7 +91,7 @@ public class FixedAclUpdaterTest extends TestCase
     private ContentService contentService;
     private AuthorityService authorityService;
     private static final long MAX_TRANSACTION_TIME_DEFAULT = 10;
-    private static final int[] filesPerLevelMoreFolders = { 5, 1, 1, 1, 1, 1, 1 };
+    private static final int[] filesPerLevelMoreFolders = { 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
     private static final int[] filesPerLevelMoreFiles = { 5, 100 };
     private long maxTransactionTime;
     private static HashMap<Integer, Class<?>> errors;


### PR DESCRIPTION
As a result of the fixedACL job finish off right before a few assertions take place, some tests that call `FixedAclUpdaterTest::getFirstNodeWithAclPending(QName nodeType, NodeRef parentRef)` occasionally fail as a sought after node with the `ASPECT_PENDING_FIX_ACL` aspect and grandchildren nodes is not always found after setting new permissions on the test data (a set of subfolders and files). An increase of the test data solves this issue.