### PR TITLE
APPS-986: [AGS] Export of records with size> 4 MB fails

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
@@ -109,7 +109,8 @@ public class RepositoryContainer extends AbstractRuntimeContainer
     {
         File tempDirectory = TempFileProvider.getTempDir(tempDirectoryName);
         this.streamFactory = new TempOutputStreamFactory(tempDirectory, memoryThreshold, maxContentSize, encryptTempFiles, false);
-        this.responseStreamFactory = new TempOutputStreamFactory(tempDirectory, memoryThreshold, maxContentSize, encryptTempFiles, true);
+        this.responseStreamFactory = new TempOutputStreamFactory(tempDirectory, memoryThreshold, maxContentSize,
+                encryptTempFiles, false);
     }
 
     public void setEncryptTempFiles(Boolean encryptTempFiles)


### PR DESCRIPTION
    - Changed deleteTempFileOnClose