### PR TITLE
RM-7171 Remove reference to http://swagger.io/v2/schema.json to avoid downloading schema.

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/unit-test/resources/rest/schema.json
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/resources/rest/schema.json
@@ -1,7 +1,7 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
-  "id": "http://swagger.io/v2/schema.json#",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "#",
+  "$schema": "#",
   "type": "object",
   "required": [
     "swagger",


### PR DESCRIPTION
This prevents the unit tests from failing when the webpage is unavailable. It has the side
effect of not picking up any updates to the schema.