### PR TITLE
MNT-20500 - Admin console breaks with serialised objects

### DIFF
--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/node-browser/node-browser.get.json.ftl
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/node-browser/node-browser.get.json.ftl
@@ -1,28 +1,75 @@
 <#macro dateFormat date>${date?string("dd MMM yyyy HH:mm:ss 'GMT'Z '('zzz')'")}</#macro>
 <#escape x as jsonUtils.encodeJSONString(x)>
+<#assign maxDepth=1000 />
 <#macro printPropertyValue p>
-   <#if p.value??>
-      <#if p.value?is_date>
+   <#attempt>
+      <#if p.value??>
+        <#if p.value?is_date>
          "<@dateFormat p.value />"
-      <#elseif p.value?is_boolean>
+        <#elseif p.value?is_boolean>
          ${p.value?string}
-      <#elseif p.value?is_number>
+        <#elseif p.value?is_number>
          ${p.value?c}
-      <#elseif p.value?is_string>
+        <#elseif p.value?is_string>
          "${p.value}"
-      <#elseif p.value?is_hash>
-         <#assign result = "{"/>
+        <#elseif p.value?is_hash || p.value?is_enumerable>
+            <#assign val>
+               <@convertToJSON p.value />
+            </#assign>
+            "${val}"
+        </#if>
+   	  <#else>
+   	     null
+      </#if>
+   <#recover>
+      "${.error}"
+   </#attempt>
+</#macro>
+<#macro convertToJSON v>
+   <#if v??>
+      <#if v?is_date>
+         "<@dateFormat v />"
+      <#elseif v?is_boolean>
+         ${v?string}
+      <#elseif v?is_number>
+         ${v?c}
+      <#elseif v?is_string>
+         "${v?string}"
+      <#elseif v?is_hash>
+         <#if v?keys?size gt maxDepth >
+            <#stop "Max depth of object achieved">
+         </#if>
+         <@compress single_line=true>
+            {
+            <#assign first = true />
+            <#list v?keys as key>
+               <#if first = false>,</#if>
+               "${key}":
+               <#if v[key]??>
+                  <@convertToJSON v[key] />
+               <#else>
+                  null
+               </#if>
+               <#assign first = false/>
+            </#list>
+            }
+         </@compress>
+      <#elseif v?is_enumerable>
+         <#if v?size gt maxDepth>
+            <#stop "Max depth of object achieved" >
+         </#if>
          <#assign first = true />
-         <#list p.value?keys as key>
-            <#if first = false>
-               <#assign result = result + ", "/>
-            </#if>
-            <#assign result = result + "${key} = ${p.value[key]}" />
-            <#assign first = false/>
-         </#list>
-         <#assign result = result + "}"/>
-         <#-- output the result -->
-         "${result}"
+            <@compress single_line=true>
+               [
+               <#list v as item>
+                  <#if first = false>,</#if>
+                  <@convertToJSON item />
+                  <#assign first = false/>
+               </#list>
+               ]
+            </@compress>
+      <#else>
+         ${v}
       </#if>
    <#else>
       null
@@ -70,7 +117,8 @@
                "isContent": ${val.content?string},
                "isNodeRef": ${val.nodeRef?string},
                "isNullValue": ${val.nullValue?string}
-            }<#if val_has_next>,</#if>
+            }
+            <#if val_has_next>,</#if>
             </#list>
          ],
          "type": {

--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/support-tools/admin-nodebrowser.get.html.ftl
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/support-tools/admin-nodebrowser.get.html.ftl
@@ -1,7 +1,7 @@
 <#assign null><span style="color:red">${msg("nodebrowser.null")?html}</span></#assign>
 <#assign none><span style="color:red">${msg("nodebrowser.none")?html}</span></#assign>
 <#assign collection>${msg("nodebrowser.collection")?html}</#assign>
-
+<#assign maxDepth=1000 />
 <#macro dateFormat date>${date?string("dd MMM yyyy HH:mm:ss 'GMT'Z '('zzz')'")}</#macro>
 <#macro propValue p>
    <#attempt>
@@ -25,50 +25,52 @@
    </#attempt>
 </#macro>
 <#macro convertToJSON v>
-   <#attempt>
-      <#if v??>
-         <#if v?is_date>
-            <@dateFormat v />
-         <#elseif v?is_boolean>
-            ${v?string}
-         <#elseif v?is_number>
-            ${v?c}
-         <#elseif v?is_string>
-            "${v?string}"
-         <#elseif v?is_hash>
-            <@compress single_line=true>
-               {
-               <#assign first = true />
-               <#list v?keys as key>
-               <#if first = false>,</#if>
-               "${key}":
-               <#if v[key]??>
-                  <@convertToJSON v[key] />
-               <#else>
-                  ${null}
-               </#if>
-               <#assign first = false/>
-               </#list>
-               }
-            </@compress>
-         <#elseif v?is_enumerable>
-            <#assign first = true />
-               <@compress single_line=true>
-                  [
-                  <#list v as item>
-                     <#if first = false>,</#if>
-                     <@convertToJSON item />
-                     <#assign first = false/>
-                  </#list>
-                  ]
-               </@compress>
+   <#if v??>
+      <#if v?is_date>
+         <@dateFormat v />
+      <#elseif v?is_boolean>
+         ${v?string}
+      <#elseif v?is_number>
+         ${v?c}
+      <#elseif v?is_string>
+         "${v?string}"
+      <#elseif v?is_hash>
+         <#if v?keys?size gt maxDepth >
+            <#stop "Max depth of object achieved">
          </#if>
-      <#else>
-         ${null}
+         <@compress single_line=true>
+            {
+            <#assign first = true />
+            <#list v?keys as key>
+            <#if first = false>,</#if>
+            "${key}":
+            <#if v[key]??>
+               <@convertToJSON v[key] />
+            <#else>
+               ${null}
+            </#if>
+            <#assign first = false/>
+            </#list>
+            }
+         </@compress>
+      <#elseif v?is_enumerable>
+         <#if v?size gt maxDepth>
+            <#stop "Max depth of object achieved" >
+         </#if>
+         <#assign first = true />
+            <@compress single_line=true>
+               [
+               <#list v as item>
+                  <#if first = false>,</#if>
+                  <@convertToJSON item />
+                  <#assign first = false/>
+               </#list>
+               ]
+            </@compress>
       </#if>
-   <#recover>
-      <span style="color:red">${.error}</span>
-   </#attempt>
+   <#else>
+      ${null}
+   </#if>
 </#macro>
 <#macro contentUrl nodeRef prop>
 ${url.serviceContext}/api/node/${nodeRef?replace("://","/")}/content;${prop?url}


### PR DESCRIPTION
In node browser:

- Added macro convertToJSON to recursively parse hashes and enumerables
- Added attempt/recover in macros to handle errors and not break the page
- Changed the output of serialized objects to JSON format

In both admin console and node browser:

- Adjusted consistency of the output between both pages when an error occurs
- Validate the depth of each hash. When we find a hash with over 1000 elements, we throw an error instead of displaying the object. Used the stop tag to effectively force an abort of the template processing preventing performance or security issues regarding very large objects.

Related PRs:
 - Original PR in repo that fixes the serialised objects: https://github.com/Alfresco/alfresco-community-repo/pull/291
 - Original PR in share (when share-services was still in there) where the depth problem was pointed out: https://github.com/Alfresco/share/pull/397