### PR TITLE
MNT-20500 - Admin console breaks with serialised objects

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/support-tools/admin-nodebrowser.get.html.ftl
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/support-tools/admin-nodebrowser.get.html.ftl
@@ -1,7 +1,7 @@
 <#assign null><span style="color:red">${msg("nodebrowser.null")?html}</span></#assign>
 <#assign none><span style="color:red">${msg("nodebrowser.none")?html}</span></#assign>
 <#assign collection>${msg("nodebrowser.collection")?html}</#assign>
-
+<#assign maxDepth=1000 />
 <#macro dateFormat date>${date?string("dd MMM yyyy HH:mm:ss 'GMT'Z '('zzz')'")}</#macro>
 <#macro propValue p>
    <#attempt>
@@ -25,50 +25,52 @@
    </#attempt>
 </#macro>
 <#macro convertToJSON v>
-   <#attempt>
-      <#if v??>
-         <#if v?is_date>
-            <@dateFormat v />
-         <#elseif v?is_boolean>
-            ${v?string}
-         <#elseif v?is_number>
-            ${v?c}
-         <#elseif v?is_string>
-            "${v?string}"
-         <#elseif v?is_hash>
-            <@compress single_line=true>
-               {
-               <#assign first = true />
-               <#list v?keys as key>
-               <#if first = false>,</#if>
-               "${key}":
-               <#if v[key]??>
-                  <@convertToJSON v[key] />
-               <#else>
-                  ${null}
-               </#if>
-               <#assign first = false/>
-               </#list>
-               }
-            </@compress>
-         <#elseif v?is_enumerable>
-            <#assign first = true />
-               <@compress single_line=true>
-                  [
-                  <#list v as item>
-                     <#if first = false>,</#if>
-                     <@convertToJSON item />
-                     <#assign first = false/>
-                  </#list>
-                  ]
-               </@compress>
+   <#if v??>
+      <#if v?is_date>
+         <@dateFormat v />
+      <#elseif v?is_boolean>
+         ${v?string}
+      <#elseif v?is_number>
+         ${v?c}
+      <#elseif v?is_string>
+         "${v?string}"
+      <#elseif v?is_hash>
+         <#if v?keys?size gt maxDepth >
+            <#stop "Max depth of object achieved">
          </#if>
-      <#else>
-         ${null}
+         <@compress single_line=true>
+            {
+            <#assign first = true />
+            <#list v?keys as key>
+            <#if first = false>,</#if>
+            "${key}":
+            <#if v[key]??>
+               <@convertToJSON v[key] />
+            <#else>
+               ${null}
+            </#if>
+            <#assign first = false/>
+            </#list>
+            }
+         </@compress>
+      <#elseif v?is_enumerable>
+         <#if v?size gt maxDepth>
+            <#stop "Max depth of object achieved" >
+         </#if>
+         <#assign first = true />
+            <@compress single_line=true>
+               [
+               <#list v as item>
+                  <#if first = false>,</#if>
+                  <@convertToJSON item />
+                  <#assign first = false/>
+               </#list>
+               ]
+            </@compress>
       </#if>
-   <#recover>
-      <span style="color:red">${.error}</span>
-   </#attempt>
+   <#else>
+      ${null}
+   </#if>
 </#macro>
 <#macro contentUrl nodeRef prop>
 ${url.serviceContext}/api/node/${nodeRef?replace("://","/")}/content;${prop?url}


### PR DESCRIPTION
In node browser and admin console:
** Added macro convertToJSON to recursively parse hashes and enumerables
** Added attempt/recover in macros to handle errors and not break the page
** Changed the output of serialized objects to JSON format
** Adjusted consistency of the ouput when an error occurs
** Validate the depth of each hash. When we find a hash with over 1000 elements, we throw an error instead of displaying the object. Used the stop tag to effectively force an abort of the template processing preventing performance or security issues regarding very large objects.

(cherry picked from commit d7ec130)