### PR TITLE
MNT-21837 License expires 23h earlier  (#541)

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/usage/RepoUsageComponentImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/usage/RepoUsageComponentImpl.java
@@ -456,12 +456,16 @@ public class RepoUsageComponentImpl implements RepoUsageComponent
             }
         }
         
-        // Check the license expiry
+        // Check the license expiration
         Long licenseExpiryDate = restrictions.getLicenseExpiryDate();
         if (licenseExpiryDate != null)
         {
-            int remainingDays = DateUtil.calculateDays(System.currentTimeMillis(), licenseExpiryDate);
-            if (remainingDays <= 0)
+            //For informational purposes, get the remaining number of days, counting from the beginning of the day of each date (now and expiration date)
+            long remainingDays = DateUtil.calculateDays(System.currentTimeMillis(), licenseExpiryDate);
+            
+            //Get exact number of milliseconds between license expiration time and now to see if is expired
+            long remainingMills = DateUtil.calculateMs(System.currentTimeMillis(), licenseExpiryDate);
+            if (remainingMills <= 0)
             {
                 errors.add(I18NUtil.getMessage("system.usage.err.limit_license_expired"));
                 level = RepoUsageLevel.LOCKED_DOWN;

--- a/repository/src/main/java/org/alfresco/util/DateUtil.java
+++ b/repository/src/main/java/org/alfresco/util/DateUtil.java
@@ -71,4 +71,34 @@ public class DateUtil
         }
         return days;
     }
+    
+    /**
+     * Calculate the number of milliseconds between start and end dates based on the <b>default</b> timezone.
+     * If the end date is before the start date, the returned value is negative.
+     *
+     * @param startMs start date in milliseconds
+     * @param endMs   end date in milliseconds
+     * @return number milliseconds between
+     */
+    public static long calculateMs(long startMs, long endMs)
+    {
+        DateTime startDateTime = new DateTime(startMs);
+        DateTime endDateTime = new DateTime(endMs);
+
+        long milliseconds;
+        if (endDateTime.isBefore(startDateTime))
+        {
+            Interval interval = new Interval(endDateTime, startDateTime);
+            Period period = interval.toPeriod(PeriodType.millis());
+            milliseconds = 0 - period.getMillis();
+        }
+        else
+        {
+            Interval interval = new Interval(startDateTime, endDateTime);
+            Period period = interval.toPeriod(PeriodType.millis());
+            milliseconds = period.getMillis();
+        }
+        return milliseconds;
+    }
+    
 }


### PR DESCRIPTION
* MNT-21837 - License expires 23h earlier
* Original problem is that the remaining time to license expires is calculated in days (long, not double) and anything less then 24h computes to 0 days. The validation for license being valid is that the remaining days is more than zero.
* Added method calculateMs in DateUtil class to return the interval in ms considering 2 given dates and respective timezones
* Changed the validation to use the remaining milliseconds value instead of remaining days
* Added unit test where license expires 6 hours from now - repo is not supposed to enter read-only mode
* Added unit test where license expired 1 minute ago - repo is supposed to enter read-only mode

(cherry picked from commit 630cd99067bc7f8d4137431c434e5e51f64460fd)