### PR TITLE
 MNT-21837 - License expires 23h earlier - correction

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/usage/RepoUsageComponentImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/usage/RepoUsageComponentImpl.java
@@ -461,11 +461,15 @@ public class RepoUsageComponentImpl implements RepoUsageComponent
         if (licenseExpiryDate != null)
         {
             //For informational purposes, get the remaining number of days, counting from the beginning of the day of each date (now and expiration date)
-            long remainingDays = DateUtil.calculateDays(System.currentTimeMillis(), licenseExpiryDate);
+            int remainingDays = DateUtil.calculateDays(System.currentTimeMillis(), licenseExpiryDate);
+            int remainingMills = 0;
+            if (remainingDays == 0)
+            {
+                //Get exact number of milliseconds between license expiration time and now to see if is expired
+                remainingMills = DateUtil.calculateMs(System.currentTimeMillis(), licenseExpiryDate);
+            }
             
-            //Get exact number of milliseconds between license expiration time and now to see if is expired
-            long remainingMills = DateUtil.calculateMs(System.currentTimeMillis(), licenseExpiryDate);
-            if (remainingMills <= 0)
+            if (remainingDays <= 0 && remainingMills < 0)
             {
                 errors.add(I18NUtil.getMessage("system.usage.err.limit_license_expired"));
                 level = RepoUsageLevel.LOCKED_DOWN;

--- a/repository/src/main/java/org/alfresco/repo/usage/RepoUsageComponentImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/usage/RepoUsageComponentImpl.java
@@ -469,7 +469,7 @@ public class RepoUsageComponentImpl implements RepoUsageComponent
                 remainingMills = DateUtil.calculateMs(System.currentTimeMillis(), licenseExpiryDate);
             }
             
-            if (remainingDays <= 0 && remainingMills < 0)
+            if (remainingDays < 0 || remainingMills < 0)
             {
                 errors.add(I18NUtil.getMessage("system.usage.err.limit_license_expired"));
                 level = RepoUsageLevel.LOCKED_DOWN;

--- a/repository/src/main/java/org/alfresco/util/DateUtil.java
+++ b/repository/src/main/java/org/alfresco/util/DateUtil.java
@@ -80,12 +80,12 @@ public class DateUtil
      * @param endMs   end date in milliseconds
      * @return number milliseconds between
      */
-    public static long calculateMs(long startMs, long endMs)
+    public static int calculateMs(long startMs, long endMs)
     {
         DateTime startDateTime = new DateTime(startMs);
         DateTime endDateTime = new DateTime(endMs);
 
-        long milliseconds;
+        int milliseconds;
         if (endDateTime.isBefore(startDateTime))
         {
             Interval interval = new Interval(endDateTime, startDateTime);

--- a/repository/src/test/java/org/alfresco/repo/usage/RepoUsageComponentTest.java
+++ b/repository/src/test/java/org/alfresco/repo/usage/RepoUsageComponentTest.java
@@ -327,6 +327,35 @@ public class RepoUsageComponentTest extends TestCase
         assertEquals("System is not at OK Level",status.getLevel(),RepoUsageLevel.OK);
     }
     
+    public void testLicenceDaysAfterExpiration() throws Exception
+    {
+        // Update usage
+        updateUsage(UsageType.USAGE_ALL);
+
+        // Set the restrictions for license expired 5 days ago
+        RepoUsage restrictions = new RepoUsage(
+                System.currentTimeMillis(),
+                5000L,
+                100000L,
+                LicenseMode.TEAM,
+                System.currentTimeMillis() - TimeUnit.DAYS.toMillis(5),
+                false);
+        repoUsageComponent.setRestrictions(restrictions);
+        
+        // Update use
+        updateUsage(UsageType.USAGE_ALL);
+
+        // Get the usage
+        RepoUsage usage = getUsage();        
+        
+        // Check we are in read-only mode
+        assertTrue("Usage is not in read-only mode",usage.isReadOnly());
+        assertFalse("System is not in read-only mode",transactionService.getAllowWrite());
+        
+        RepoUsageStatus status = repoUsageComponent.getUsageStatus();
+        assertEquals("System is not at Locked Level",status.getLevel(),RepoUsageLevel.LOCKED_DOWN);   
+    }
+    
     /**
      * Check that concurrent updates are prevented
      *

--- a/repository/src/test/java/org/alfresco/repo/usage/RepoUsageComponentTest.java
+++ b/repository/src/test/java/org/alfresco/repo/usage/RepoUsageComponentTest.java
@@ -297,6 +297,36 @@ public class RepoUsageComponentTest extends TestCase
         assertEquals("System is not at Locked Level",status.getLevel(),RepoUsageLevel.LOCKED_DOWN);        
     }
     
+    
+    public void testLicenceMonthsBeforeExpiration() throws Exception
+    {
+        // Update usage
+        updateUsage(UsageType.USAGE_ALL);
+
+        // Set the restrictions for license to expire in 60 days from now
+        RepoUsage restrictions = new RepoUsage(
+                System.currentTimeMillis(),
+                5000L,
+                100000L,
+                LicenseMode.TEAM,
+                System.currentTimeMillis() + TimeUnit.DAYS.toMillis(60),
+                false);
+        repoUsageComponent.setRestrictions(restrictions);
+        
+        // Update use
+        updateUsage(UsageType.USAGE_ALL);
+
+        // Get the usage
+        RepoUsage usage = getUsage();        
+        
+        // Check        
+        assertFalse("Usage is in read-only mode",usage.isReadOnly());
+        assertTrue("System is in read-only mode",transactionService.getAllowWrite());
+        
+        RepoUsageStatus status = repoUsageComponent.getUsageStatus();
+        assertEquals("System is not at OK Level",status.getLevel(),RepoUsageLevel.OK);
+    }
+    
     /**
      * Check that concurrent updates are prevented
      *


### PR DESCRIPTION
* period.getMillis() (joda lib) returns an int instead of a long, so on larger periods (like 30days) we get an error that the value cannot fit in an int
* Changed the validation to only calculate the remaining milliseconds in the edge case of the remaining days being zero (as both 23h before and 23h after correspond to 0 remaining days)
* Added a unit test that validates the usage 60 days up from the licence expiring to validate the problem stops occurring
* Added a unit test that validates the usage 30 days after the licence expiring to cover all use cases