### PR TITLE
SEARCH-2965 avoid exception for case sensitive for fields: TEXT, name, content, and description

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContext.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContext.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 
+import java.util.Set;
 import org.alfresco.repo.dictionary.IndexTokenisationMode;
 import org.alfresco.repo.search.adaptor.LuceneFunction;
 import org.alfresco.repo.search.adaptor.QueryParserAdaptor;
@@ -54,7 +55,11 @@ import org.alfresco.service.namespace.QName;
 @SuppressWarnings("deprecation")
 public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationContext
 {
-    private static HashSet<String> EXPOSED_FIELDS = new HashSet<String>();
+    private static Set<String> EXPOSED_FIELDS = new HashSet<>();
+
+    //The field names in the two collections below are fixed in getLuceneFieldName in order to allow users to use case insensitive field name
+    private static Set<String> CASE_INSENSITIVE_FIELDS_UPPERCASE = Set.of(QueryConstants.FIELD_TEXT);
+    private static Set<String> CASE_INSENSITIVE_FIELDS_LOWERCASE = Set.of("content", "name", "description", "score");
 
     private NamespacePrefixResolver namespacePrefixResolver;
 
@@ -233,7 +238,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
                 if (propertyDef.getDataType().getName().equals(DataTypeDefinition.CONTENT))
                 {
                     throw new FTSQueryException("Order on content properties is not curently supported");
-                }
+                } 
                 else if (propertyDef.getDataType().getName().equals(DataTypeDefinition.TEXT))
                 {
                     if(propertyDef.getIndexTokenisationMode() == IndexTokenisationMode.FALSE)
@@ -327,7 +332,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
             QName propertyQName = stripSuffixes(fullQName);
             if (dictionaryService.getProperty(propertyQName) != null)
             {
-                return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName.toString();
+                return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName;
             }
             else if(dictionaryService.getDataType(fullQName) != null)
             {
@@ -335,7 +340,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
             }
             else
             {
-                throw new FTSQueryException("Unknown property: " + fullQName.toString());
+                throw new FTSQueryException("Unknown property: " + fullQName);
             }
         }
 
@@ -347,7 +352,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
             QName propertyQName = stripSuffixes(fullQName);
             if (dictionaryService.getProperty(propertyQName) != null)
             {
-                return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName.toString();
+                return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName;
             }
             else if(dictionaryService.getDataType(fullQName) != null)
             {
@@ -355,7 +360,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
             }
             else
             {
-                throw new FTSQueryException("Unknown property: " + fullQName.toString());
+                throw new FTSQueryException("Unknown property: " + fullQName);
             }
         }
 
@@ -369,11 +374,11 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
                 QName propertyQName = stripSuffixes(fullQName);
                 if (dictionaryService.getProperty(propertyQName) != null)
                 {
-                    return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName.toString();
+                    return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName;
                 }
                 else
                 {
-                    throw new FTSQueryException("Unknown property: " + fullQName.toString());
+                    throw new FTSQueryException("Unknown property: " + fullQName);
                 }
             }
         }
@@ -387,7 +392,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
         QName propertyQName = stripSuffixes(fullQName);
         if (dictionaryService.getProperty(propertyQName) != null)
         {
-            return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName.toString();
+            return QueryConstants.PROPERTY_FIELD_PREFIX + fullQName;
         }
         else if(dictionaryService.getDataType(fullQName) != null)
         {
@@ -395,12 +400,18 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
         }
         else
         {
-            if(propertyName.equalsIgnoreCase("Score"))
+
+            if (CASE_INSENSITIVE_FIELDS_LOWERCASE.contains(propertyName.toLowerCase()))
             {
                 return propertyName.toLowerCase();
             }
+
+            if (CASE_INSENSITIVE_FIELDS_UPPERCASE.contains(propertyName.toUpperCase()))
+            {
+                return propertyName.toUpperCase();
+            }
                     
-            throw new FTSQueryException("Unknown property: " + fullQName.toString());
+            throw new FTSQueryException("Unknown property: " + fullQName);
         }
 
     }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContext.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContext.java
@@ -59,7 +59,7 @@ public class AlfrescoFunctionEvaluationContext implements FunctionEvaluationCont
 
     //The field names in the two collections below are fixed in getLuceneFieldName in order to allow users to use case insensitive field name
     private static Set<String> CASE_INSENSITIVE_FIELDS_UPPERCASE = Set.of(QueryConstants.FIELD_TEXT);
-    private static Set<String> CASE_INSENSITIVE_FIELDS_LOWERCASE = Set.of("content", "name", "description", "score");
+    private static Set<String> CASE_INSENSITIVE_FIELDS_LOWERCASE = Set.of("content", "name", "description", "score", "title");
 
     private NamespacePrefixResolver namespacePrefixResolver;
 

--- a/data-model/src/test/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContextTest.java
+++ b/data-model/src/test/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContextTest.java
@@ -1,0 +1,62 @@
+package org.alfresco.repo.search.impl.parsers;
+
+import static org.alfresco.repo.search.adaptor.QueryConstants.FIELD_TEXT;
+import static org.junit.Assert.assertEquals;
+
+import org.alfresco.service.cmr.dictionary.DictionaryService;
+import org.alfresco.service.namespace.NamespacePrefixResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AlfrescoFunctionEvaluationContextTest
+{
+
+    @Mock
+    private NamespacePrefixResolver namespacePrefixResolve;
+
+    @Mock
+    private DictionaryService dictionaryService;
+
+    private AlfrescoFunctionEvaluationContext alfrescoFunctionEvaluationContext;
+
+    @Before
+    public void setup()
+    {
+        alfrescoFunctionEvaluationContext = new AlfrescoFunctionEvaluationContext(namespacePrefixResolve, dictionaryService, null);
+    }
+
+    @Test
+    public void shouldReturnValidFieldNameWhenFieldNameIsLowercase()
+    {
+        assertEquals(FIELD_TEXT, alfrescoFunctionEvaluationContext.getLuceneFieldName("text"));
+        assertEquals("content", alfrescoFunctionEvaluationContext.getLuceneFieldName("content"));
+        assertEquals("name", alfrescoFunctionEvaluationContext.getLuceneFieldName("name"));
+        assertEquals("description", alfrescoFunctionEvaluationContext.getLuceneFieldName("description"));
+        assertEquals("score", alfrescoFunctionEvaluationContext.getLuceneFieldName("score"));
+    }
+
+    @Test
+    public void shouldReturnValidFieldNameWhenFieldNameIsUpperCase()
+    {
+        assertEquals(FIELD_TEXT, alfrescoFunctionEvaluationContext.getLuceneFieldName("TEXT"));
+        assertEquals("content", alfrescoFunctionEvaluationContext.getLuceneFieldName("CONTENT"));
+        assertEquals("name", alfrescoFunctionEvaluationContext.getLuceneFieldName("NAME"));
+        assertEquals("description", alfrescoFunctionEvaluationContext.getLuceneFieldName("DESCRIPTION"));
+        assertEquals("score", alfrescoFunctionEvaluationContext.getLuceneFieldName("SCORE"));
+    }
+
+    @Test
+    public void shouldReturnValidFieldNameWhenFieldNameIsMixedCase()
+    {
+        assertEquals(FIELD_TEXT, alfrescoFunctionEvaluationContext.getLuceneFieldName("tExT"));
+        assertEquals("content", alfrescoFunctionEvaluationContext.getLuceneFieldName("cOnTeNt"));
+        assertEquals("name", alfrescoFunctionEvaluationContext.getLuceneFieldName("NaMe"));
+        assertEquals("description", alfrescoFunctionEvaluationContext.getLuceneFieldName("DeScRiPtIoN"));
+        assertEquals("score", alfrescoFunctionEvaluationContext.getLuceneFieldName("sCoRe"));
+    }
+
+}

--- a/data-model/src/test/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContextTest.java
+++ b/data-model/src/test/java/org/alfresco/repo/search/impl/parsers/AlfrescoFunctionEvaluationContextTest.java
@@ -37,6 +37,7 @@ public class AlfrescoFunctionEvaluationContextTest
         assertEquals("name", alfrescoFunctionEvaluationContext.getLuceneFieldName("name"));
         assertEquals("description", alfrescoFunctionEvaluationContext.getLuceneFieldName("description"));
         assertEquals("score", alfrescoFunctionEvaluationContext.getLuceneFieldName("score"));
+        assertEquals("title", alfrescoFunctionEvaluationContext.getLuceneFieldName("title"));
     }
 
     @Test
@@ -47,6 +48,7 @@ public class AlfrescoFunctionEvaluationContextTest
         assertEquals("name", alfrescoFunctionEvaluationContext.getLuceneFieldName("NAME"));
         assertEquals("description", alfrescoFunctionEvaluationContext.getLuceneFieldName("DESCRIPTION"));
         assertEquals("score", alfrescoFunctionEvaluationContext.getLuceneFieldName("SCORE"));
+        assertEquals("title", alfrescoFunctionEvaluationContext.getLuceneFieldName("TITLE"));
     }
 
     @Test
@@ -57,6 +59,7 @@ public class AlfrescoFunctionEvaluationContextTest
         assertEquals("name", alfrescoFunctionEvaluationContext.getLuceneFieldName("NaMe"));
         assertEquals("description", alfrescoFunctionEvaluationContext.getLuceneFieldName("DeScRiPtIoN"));
         assertEquals("score", alfrescoFunctionEvaluationContext.getLuceneFieldName("sCoRe"));
+        assertEquals("title", alfrescoFunctionEvaluationContext.getLuceneFieldName("TiTlE"));
     }
 
 }


### PR DESCRIPTION
I also removed some useless toString() methods invocations.

In the past, there was a similar behaviour for the Score field, so I included also it in my fix.