### PR TITLE
ACS-1734 Remove broken transformerFailover from libreofficeToPdf

### DIFF
--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -175,7 +175,6 @@
     },
     {
       "transformerName": "libreofficeToPdf",
-      "transformerFailover" : [ "libreoffice" ],
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/vnd.oasis.opendocument.graphics", "priority": 150, "targetMediaType": "application/pdf" },
         {"sourceMediaType": "application/vnd.sun.xml.calc.template",       "priority": 150, "targetMediaType": "application/pdf" },


### PR DESCRIPTION
`transformerFailover` requires two transformers. As one of the two used by `libreofficeToPdf` was removed, the `transformerFailover` also needed to be removed. 