### PR TITLE
ACS-1734 Remove libreofficeToPdf + libreofficeToPdfBoxViaPdf

### DIFF
--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -185,7 +185,7 @@
         {"sourceMediaType": "application/vnd.oasis.opendocument.graphics", "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.graphics",                                  "priority": 150, "targetMediaType": "application/xhtml+xml"},
         {"sourceMediaType": "application/vnd.oasis.opendocument.graphics",                                  "priority": 150, "targetMediaType": "text/xml"},
-        
+
         {"sourceMediaType": "application/vnd.sun.xml.calc.template",                                        "priority": 150, "targetMediaType": "text/csv"},
         {"sourceMediaType": "application/vnd.sun.xml.calc.template",                                        "priority": 150, "targetMediaType": "text/html"},
         {"sourceMediaType": "application/vnd.sun.xml.calc.template",       "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},

--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -174,6 +174,71 @@
       ]
     },
     {
+      "transformerName": "libreofficeToPdfBoxViaPdf",
+      "transformerPipeline" : [
+        {"transformerName": "libreoffice", "targetMediaType": "application/pdf"},
+        {"transformerName": "PdfBox"}
+      ],
+      "supportedSourceAndTargetList": [
+        {"sourceMediaType": "application/vnd.oasis.opendocument.graphics",                                  "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.graphics",                                  "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.graphics", "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.graphics",                                  "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.oasis.opendocument.graphics",                                  "priority": 150, "targetMediaType": "text/xml"},
+        
+        {"sourceMediaType": "application/vnd.sun.xml.calc.template",                                        "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc.template",                                        "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc.template",       "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc.template",                                        "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc.template",                                        "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.sun.xml.impress.template",                                     "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress.template",                                     "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress.template",    "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress.template",                                     "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress.template",                                     "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.sun.xml.writer.template",                                      "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.sun.xml.writer.template",                                      "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.sun.xml.writer.template",     "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.sun.xml.writer.template",                                      "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.sun.xml.writer.template",                                      "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "text/tab-separated-values",                                                    "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "text/tab-separated-values",                                                    "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "text/tab-separated-values",                   "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "text/tab-separated-values",                                                    "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "text/tab-separated-values",                                                    "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.visio2013",                                                    "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.visio2013",                                                    "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.visio2013",                   "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.visio2013",                                                    "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.visio2013",                                                    "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/wordperfect",                                                      "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/wordperfect",                                                      "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/wordperfect",                     "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/wordperfect",                                                      "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/wordperfect",                                                      "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.sun.xml.calc",                                                 "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc",                                                 "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc",                "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc",                                                 "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.sun.xml.calc",                                                 "priority": 150, "targetMediaType": "text/xml"},
+
+        {"sourceMediaType": "application/vnd.sun.xml.impress",                                              "priority": 150, "targetMediaType": "text/csv"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress",                                              "priority": 150, "targetMediaType": "text/html"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress",             "maxSourceSizeBytes": 26214400,  "priority": 150, "targetMediaType": "text/plain"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress",                                              "priority": 150, "targetMediaType": "application/xhtml+xml"},
+        {"sourceMediaType": "application/vnd.sun.xml.impress",                                              "priority": 150, "targetMediaType": "text/xml"}
+      ],
+      "transformOptions": [
+        "pdfboxOptions"
+      ]
+    },
+    {
       "transformerName": "textBasedToImageViaText",
       "transformerPipeline" : [
         {"transformerName": "string",                                 "targetMediaType": "text/plain"},

--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -175,7 +175,6 @@
     },
     {
       "transformerName": "libreofficeToPdf",
-      "transformerFailover" : [ "libreoffice" ],
       "supportedSourceAndTargetList": [
         {"sourceMediaType": "application/vnd.oasis.opendocument.graphics", "priority": 150, "targetMediaType": "application/pdf" },
         {"sourceMediaType": "application/vnd.sun.xml.calc.template",       "priority": 150, "targetMediaType": "application/pdf" },

--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -174,34 +174,6 @@
       ]
     },
     {
-      "transformerName": "libreofficeToPdf",
-      "supportedSourceAndTargetList": [
-        {"sourceMediaType": "application/vnd.oasis.opendocument.graphics", "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/vnd.sun.xml.calc.template",       "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/vnd.sun.xml.impress.template",    "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/vnd.sun.xml.writer.template",     "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "text/tab-separated-values",                   "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/vnd.visio2013",                   "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/wordperfect",                     "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/vnd.sun.xml.calc",                "priority": 150, "targetMediaType": "application/pdf" },
-        {"sourceMediaType": "application/vnd.sun.xml.impress",             "priority": 150, "targetMediaType": "application/pdf" }
-      ],
-      "transformOptions": [
-      ]
-    },
-    {
-      "transformerName": "libreofficeToPdfBoxViaPdf",
-      "transformerPipeline" : [
-        {"transformerName": "libreofficeToPdf", "targetMediaType": "application/pdf"},
-        {"transformerName": "PdfBox"}
-      ],
-      "supportedSourceAndTargetList": [
-      ],
-      "transformOptions": [
-        "pdfboxOptions"
-      ]
-    },
-    {
       "transformerName": "textBasedToImageViaText",
       "transformerPipeline" : [
         {"transformerName": "string",                                 "targetMediaType": "text/plain"},


### PR DESCRIPTION
Follow on from #572.
Removed broken transformer `libreofficeToPdf`
Populate the source & target for the `libreofficeToPdfBoxViaPdf` transformer.
We take the each `libreofficeToPdf` Source and combine with `pdfbox` application/pdf Targets.