### PR TITLE
[ACS-1776] Add missing pipeline outlookMsgToLibreofficeViaText

### DIFF
--- a/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
+++ b/repository/src/main/resources/alfresco/transforms/0100-basePipelines.json
@@ -252,6 +252,18 @@
       ]
     },
     {
+      "transformerName": "outlookMsgToLibreofficeViaText",
+      "transformerPipeline" : [
+        {"transformerName": "OutlookMsg",                              "targetMediaType": "text/plain"},
+        {"transformerName": "libreoffice"}
+      ],
+      "supportedSourceAndTargetList": [
+      ],
+      "transformOptions": [
+        "tikaOptions"
+      ]
+    },
+    {
       "transformerName": "htmlToPdfViaTXT",
       "transformerPipeline" : [
         {"transformerName": "string", "targetMediaType": "text/plain"},


### PR DESCRIPTION
This PR has been raised to ensure both master, 7.0.N and 6.2.N have the same 0100-basePipelines.json files as they all use the same versions of T-Engines.