### PR TITLE
MNT-22481 - Unable to Create Custom Metadata

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/script/CustomPropertyDefinitionPost.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/script/CustomPropertyDefinitionPost.java
@@ -140,9 +140,8 @@ public class CustomPropertyDefinitionPost extends BaseCustomPropertyWebScript
         for (Iterator iter = json.keys(); iter.hasNext(); )
         {
             String nextKeyString = (String)iter.next();
-            String nextValueString = json.getString(nextKeyString);
-
-            params.put(nextKeyString, nextValueString);
+            Serializable nextValue = (Serializable) json.get(nextKeyString);
+            params.put(nextKeyString, nextValue);
         }
 
         return params;


### PR DESCRIPTION
* Upgrading org.json:json from version 20090211 to 20201115 introduced the issue as getString method in the newer version does not allow for values other than strings
* Replaced getString for the get method