### PR TITLE
[REPO-4514] Removed dom4j dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -127,11 +127,6 @@
          <version>2.3.0.1</version>
       </dependency>
       <dependency>
-         <groupId>dom4j</groupId>
-         <artifactId>dom4j</artifactId>
-         <version>1.6.1</version>
-      </dependency>
-      <dependency>
          <groupId>org.codehaus.guessencoding</groupId>
          <artifactId>guessencoding</artifactId>
          <version>1.4</version>


### PR DESCRIPTION
Removed dom4j:dom4j:1.6.1 dependency as org.dom4j:dom4j:2.1.1 is being brought in by surf-webscripts