### PR TITLE
Node API create 2 versions instead of 1 when using cm:versionable

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -3116,6 +3116,9 @@ public class NodesImpl implements Nodes
     private NodeRef createNewFile(NodeRef parentNodeRef, String fileName, QName nodeType, Content content, Map<QName, Serializable> props, QName assocTypeQName, Parameters params,
                                   Boolean versionMajor, String versionComment)
     {
+      if ((versionMajor != null) || (versionComment != null)) {
+            behaviourFilter.disableBehaviour(ContentModel.ASPECT_VERSIONABLE);
+        }
         NodeRef nodeRef = createNodeImpl(parentNodeRef, fileName, nodeType, props, assocTypeQName);
         
         if (content == null)
@@ -3129,25 +3132,18 @@ public class NodesImpl implements Nodes
             writeContent(nodeRef, fileName, content.getInputStream(), true);
         }
         
-        if ((versionMajor != null) || (versionComment != null))
+        if ((versionMajor != null) || (versionComment != null)) 
         {
-            behaviourFilter.disableBehaviour(nodeRef, ContentModel.ASPECT_VERSIONABLE);
-            try
+            // by default, first version is major, unless specified otherwise
+            VersionType versionType = VersionType.MAJOR;
+            if ((versionMajor != null) && (!versionMajor))
             {
-                // by default, first version is major, unless specified otherwise
-                VersionType versionType = VersionType.MAJOR;
-                if ((versionMajor != null) && (!versionMajor))
-                {
-                    versionType = VersionType.MINOR;
-                }
-
-                createVersion(nodeRef, false, versionType, versionComment);
-
-                extractMetadata(nodeRef);
-            } finally
-            {
-                behaviourFilter.enableBehaviour(nodeRef, ContentModel.ASPECT_VERSIONABLE);
+                versionType = VersionType.MINOR;
             }
+
+            createVersion(nodeRef, false, versionType, versionComment);
+
+            extractMetadata(nodeRef);
         }
 
         return nodeRef;

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -3116,9 +3116,6 @@ public class NodesImpl implements Nodes
     private NodeRef createNewFile(NodeRef parentNodeRef, String fileName, QName nodeType, Content content, Map<QName, Serializable> props, QName assocTypeQName, Parameters params,
                                   Boolean versionMajor, String versionComment)
     {
-      if ((versionMajor != null) || (versionComment != null)) {
-            behaviourFilter.disableBehaviour(ContentModel.ASPECT_VERSIONABLE);
-        }
         NodeRef nodeRef = createNodeImpl(parentNodeRef, fileName, nodeType, props, assocTypeQName);
         
         if (content == null)

--- a/remote-api/src/test/resources/models/custom-model.xml
+++ b/remote-api/src/test/resources/models/custom-model.xml
@@ -54,6 +54,20 @@
       		</property>
          </properties>
       </type>
+
+     <!-- MNT-22462 -->
+     <type name="custom:document">
+       <title>Sample Document Type</title>
+       <parent>cm:content</parent>
+       <properties>
+         <property name="custom:sample">
+           <type>d:text</type>
+         </property>
+       </properties>
+       <mandatory-aspects>
+         <aspect>cm:versionable</aspect>
+       </mandatory-aspects>
+     </type>
 	  
 	</types>
 	 


### PR DESCRIPTION
From MNT-22462/ACS-1842:
When a custom model is defined with` cm:versionable `mandatory aspect, this cause the node creation REST  API service to create 2 versions instead of one. The new document created has versions _1.0_ and _2.0_ created at the same time in the version history.

We should consider that:
- creating an empty file without content (via POST json) is **not** auto-versioned, and any subsequent file content updates are not versioned
- creating a file with content (via POST of multipart/form-data) is auto-versioned, and any subsequent file content updates are versioned
- If `versioningEnabled` is false and the node is **not** using cm:versionable, the version history is not created. 
- Right now, when the node is cm:versionable, setting versioningEnabled to false will avoid the issue of having version 2.0 but the API will still create version 1.0 in the history because of the cm:versionable aspect.

The goal of the fix is to disable the cm:versionable behaviour when the versioning is managed through the API (versioningEnabled=true or default behaviour when using POST of multipart/form-data calls)