### PR TITLE
ACS-1742 - Marked test as NOT_SUPPORTED_ON_SINGLE_PIPELINE

### DIFF
--- a/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CancelCheckOutTests.java
+++ b/packaging/tests/tas-cmis/src/test/java/org/alfresco/cmis/CancelCheckOutTests.java
@@ -90,7 +90,7 @@ public class CancelCheckOutTests extends CmisTest
                       .cancelCheckOut();
     }
 
-    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS})
+    @Test(groups = {  TestGroup.NOT_SUPPORTED_ON_SINGLE_PIPELINE, TestGroup.REGRESSION, TestGroup.CMIS})
     @TestRail(section = {"cmis-api"}, executionType= ExecutionType.REGRESSION,
             description = "Verify that cancel check out on document created with Versioning State CHECKED OUT deletes the document")
     public void cancelCheckOutOnDocWithVersioningStateCheckedOut() throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency.mysql.version>8.0.25</dependency.mysql.version>
         <dependency.mysql-image.version>8</dependency.mysql-image.version>
         <dependency.mariadb.version>2.7.2</dependency.mariadb.version>
-        <dependency.tas-utility.version>3.0.44</dependency.tas-utility.version>
+        <dependency.tas-utility.version>3.0.45</dependency.tas-utility.version>
         <dependency.rest-assured.version>3.3.0</dependency.rest-assured.version>
         <dependency.tas-restapi.version>1.61</dependency.tas-restapi.version>
         <dependency.tas-cmis.version>1.30</dependency.tas-cmis.version>


### PR DESCRIPTION
This feature is working when tested against a standard environment, but not when tested against an environment with AGS on top of it. 

Hence, to be able to run the test suite in both the standard community pipeline and in the enterprise, AGS-powered Single-Pipeline, and have both green (while the bug, if any, gets analyzed and eventually fixed), I've created a new marker for problems like this.

It will then be used by the Single PIpeline to exclude these tests only there and will save us the need to use a temporary `@BUG` annotation that would exclude the test for good even from here, where it works and where we want to continue to run it.