### PR TITLE
PRODSEC-4422 - Scripts not in Data Dictionary can be executed by acti…

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/action/executer/ScriptActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ScriptActionExecuter.java
@@ -35,6 +35,9 @@ import org.alfresco.repo.admin.SysAdminParams;
 import org.alfresco.repo.jscript.ScriptAction;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.action.Action;
+import org.alfresco.service.cmr.action.ActionDefinition;
+import org.alfresco.service.cmr.action.ActionService;
+import org.alfresco.service.cmr.action.ParameterConstraint;
 import org.alfresco.service.cmr.action.ParameterDefinition;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -126,6 +129,10 @@ public class ScriptActionExecuter extends ActionExecuterAbstractBase
         if (nodeService.exists(actionedUponNodeRef))
         {
             NodeRef scriptRef = (NodeRef)action.getParameterValue(PARAM_SCRIPTREF);
+            if(!isValidScriptRef(action))
+            {
+                throw new IllegalStateException("Invalid script ref path: " + scriptRef);
+            }
             NodeRef spaceRef = this.serviceRegistry.getRuleService().getOwningNodeRef(action);
             if (spaceRef == null)
             {
@@ -221,5 +228,20 @@ public class ScriptActionExecuter extends ActionExecuterAbstractBase
         companyHomeRef = refs.get(0);
 
         return companyHomeRef;
+    }
+    
+    private boolean isValidScriptRef(Action action)
+    {
+        NodeRef scriptRef = (NodeRef) action.getParameterValue(PARAM_SCRIPTREF);
+        ActionService actionService = this.serviceRegistry.getActionService();
+        ActionDefinition actDef = actionService.getActionDefinition(action.getActionDefinitionName());
+        ParameterDefinition parameterDef = actDef.getParameterDefintion(PARAM_SCRIPTREF);
+        String paramConstraintName = parameterDef.getParameterConstraintName();
+        if (paramConstraintName != null)
+        {
+            ParameterConstraint paramConstraint = actionService.getParameterConstraint(paramConstraintName);
+            return paramConstraint.isValidValue(scriptRef.toString());
+        }
+        return true;
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/action/ActionServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/ActionServiceImplTest.java
@@ -805,46 +805,6 @@ public class ActionServiceImplTest extends BaseAlfrescoSpringTest
         assertEquals(action4, savedAction2.getAction(2));
     }
     
-    /**
-     * Test the action result parameter
-     */
-    @Test
-    public void testActionResult()
-    {
-        // We need to run this test as Administrator. The ScriptAction has to run as a full user (instead of as System)
-        // so that we can setup the Person object in the ScriptNode
-        AuthenticationUtil.setFullyAuthenticatedUser(AuthenticationUtil.getAdminUserName());
-        try
-        {
-            // Create the script node reference
-            NodeRef script = this.nodeService.createNode(
-                    this.folder,
-                    ContentModel.ASSOC_CONTAINS,
-                    QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "testScript.js"),
-                    ContentModel.TYPE_CONTENT).getChildRef();
-            this.nodeService.setProperty(script, ContentModel.PROP_NAME, "testScript.js");
-            ContentWriter contentWriter = this.contentService.getWriter(script, ContentModel.PROP_CONTENT, true);
-            contentWriter.setMimetype("text/plain");
-            contentWriter.setEncoding("UTF-8");
-            contentWriter.putContent("\"VALUE\";");
-
-            // Create the action
-            Action action1 = this.actionService.createAction(ScriptActionExecuter.NAME);
-            action1.setParameterValue(ScriptActionExecuter.PARAM_SCRIPTREF, script);
-
-            // Execute the action
-            this.actionService.executeAction(action1, this.nodeRef);
-
-            // Get the result
-            String result = (String)action1.getParameterValue(ActionExecuter.PARAM_RESULT);
-            assertNotNull(result);
-            assertEquals("VALUE", result);
-        }
-        finally
-        {
-            AuthenticationUtil.clearCurrentSecurityContext();
-        }
-    }
     
     /** ===================================================================================
      *  Test asynchronous actions


### PR DESCRIPTION
…on (#596)

* Added validation to the ScriptActionExecuter class to enforce the existing constraints on parameter script-ref (Repo has the constraint to only allow scripts in Data Dictionary / Scripts and AGS has the constraint to only allow scripts in Data Dictionary / Records Management / Records Management Scripts") by validating if the given scriptRef is in the allowed valued of the constraint set on that param
* Added new case in ActionServiceImpl2Test#testExecuteScript to assert that the transaction fails when we execute the action with an invalid script
* Moved test testActionResult from ActionServiceImplTest to class ActionServiceImpl2Test - Before it ran with a script not in Data Dictionary so with the added validation it started to fail. I moved the unit test do avoid duplicating the code to create the script in the correct location.

(cherry picked from commit ac4a1643e1bd55565288a6c7ffefd232607c46f7)