### PR TITLE
[PRODSEC-5254] Bump commons-compress to 1.21 (#658)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency.jboss.logging.version>3.4.1.Final</dependency.jboss.logging.version>
         <dependency.camel.version>3.7.4</dependency.camel.version>
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
-        <dependency.apache-compress.version>1.20</dependency.apache-compress.version>
+        <dependency.apache-compress.version>1.21</dependency.apache-compress.version>
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>
         <dependency.awaitility.version>4.1.0</dependency.awaitility.version>
 


### PR DESCRIPTION
(cherry picked from commit 3530e3dc3b9ac13c1bfd40360a318e58b4695bfd)