### PR TITLE
SEARCH-2833 Add field for association Qname in NodeResource and ChildAssociationResource

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/event2/ChildAssociationEventConsolidator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/ChildAssociationEventConsolidator.java
@@ -27,7 +27,6 @@ package org.alfresco.repo.event2;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-
 import org.alfresco.repo.event.v1.model.ChildAssociationResource;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.EventData;
@@ -117,8 +116,9 @@ public class ChildAssociationEventConsolidator implements ChildAssociationEventS
     {
         String parentId = childAssociationRef.getParentRef().getId();
         String childId = childAssociationRef.getChildRef().getId();
+        String assocQName = helper.getQNamePrefixString(childAssociationRef.getQName());
         String assocType = helper.getQNamePrefixString(childAssociationRef.getTypeQName());
-        return new ChildAssociationResource(parentId, childId, assocType);
+        return new ChildAssociationResource(parentId, childId, assocType, assocQName);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/event2/NodeResourceHelper.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/NodeResourceHelper.java
@@ -46,6 +46,7 @@ import org.alfresco.repo.event2.filter.NodePropertyFilter;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
+import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.MLText;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -148,6 +149,7 @@ public class NodeResourceHelper implements InitializingBean
                            .setModifiedByUser(getUserInfo((String) properties.get(ContentModel.PROP_MODIFIER), mapUserCache))
                            .setModifiedAt(getZonedDateTime((Date)properties.get(ContentModel.PROP_MODIFIED)))
                            .setContent(getContentInfo(properties))
+                           .setAssocQName(getAssocQName(nodeRef))
                            .setPrimaryHierarchy(PathUtil.getNodeIdsInReverse(path, false))
                            .setProperties(mapToNodeProperties(properties))
                            .setAspectNames(getMappedAspects(nodeRef));
@@ -156,6 +158,15 @@ public class NodeResourceHelper implements InitializingBean
     private boolean isSubClass(QName className, QName ofClassQName)
     {
         return dictionaryService.isSubClass(className, ofClassQName);
+    }
+
+    private String getAssocQName(NodeRef nodeRef) {
+        String result = null;
+        ChildAssociationRef primaryParent = nodeService.getPrimaryParent(nodeRef);
+        if(primaryParent != null) {
+            result = primaryParent.getQName().getPrefixedQName(namespaceService).getPrefixString(); 
+        }
+        return result; 
     }
 
     private UserInfo getUserInfo(String userName, Map<String, UserInfo> mapUserCache)

--- a/repository/src/test/java/org/alfresco/repo/event2/ChildAssociationRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/ChildAssociationRepoEventIT.java
@@ -50,6 +50,7 @@ public class ChildAssociationRepoEventIT extends AbstractContextAwareRepoEvent
     @Test
     public void testAddChildAssociation()
     {
+        String assocLocalName = GUID.generate();
         final NodeRef parentNodeRef = createNode(ContentModel.TYPE_FOLDER);
         final NodeRef childNodeRef = createNode(ContentModel.TYPE_CONTENT);
 
@@ -64,11 +65,11 @@ public class ChildAssociationRepoEventIT extends AbstractContextAwareRepoEvent
             resultRepoEvent.getType());
 
         retryingTransactionHelper.doInTransaction(() ->
-            nodeService.addChild(
-                parentNodeRef,
-                childNodeRef,
-                ContentModel.ASSOC_CONTAINS,
-                QName.createQName(TEST_NAMESPACE, GUID.generate())));
+                                                      nodeService.addChild(
+                                                          parentNodeRef,
+                                                          childNodeRef,
+                                                          ContentModel.ASSOC_CONTAINS,
+                                                          QName.createQName(TEST_NAMESPACE, assocLocalName)));
 
         List<ChildAssociationRef> childAssociationRefs = retryingTransactionHelper.doInTransaction(() ->
                 nodeService.getChildAssocs(parentNodeRef));
@@ -101,6 +102,7 @@ public class ChildAssociationRepoEventIT extends AbstractContextAwareRepoEvent
         assertEquals("Wrong parent", parentNodeRef.getId(), childAssociationResource.getParent().getId());
         assertEquals("Wrong child", childNodeRef.getId(), childAssociationResource.getChild().getId());
         assertEquals("Wrong assoc type", "cm:contains", childAssociationResource.getAssocType());
+        assertEquals("Wrong assoc name", "ce:" + assocLocalName, childAssociationResource.getAssocQName());
     }
 
     @Test

--- a/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
@@ -43,7 +43,6 @@ import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.PropertyMap;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -55,28 +54,17 @@ public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
 
     @Autowired
     private NodeDAO nodeDAO;
-    
-    @Autowired
-    private NamespaceDAO namespaceDAO;
-    
-    @Before
-    public void setup() {
-        if(namespaceDAO.getNamespaceURI("ce") == null) 
-        {
-            namespaceDAO.addURI(TEST_NAMESPACE);
-            namespaceDAO.addPrefix("ce", TEST_NAMESPACE);
-        }
-    }
-    
+
     @Test
     public void testCreateEvent()
     {
         // Create a node without content
         final String name = "TestFile-" + System.currentTimeMillis() + ".txt";
+        String localName = GUID.generate();
         PropertyMap propertyMap = new PropertyMap();
         propertyMap.put(ContentModel.PROP_TITLE, "test title");
         propertyMap.put(ContentModel.PROP_NAME, name);
-        final NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT, propertyMap);
+        final NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT, localName, propertyMap);
 
         final RepoEvent<EventData<NodeResource>> resultRepoEvent = getRepoEvent(1);
         // Repo event attributes
@@ -117,7 +105,7 @@ public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
         assertEquals("Wrong node modifier display name.", "Administrator",
             nodeResource.getModifiedByUser().getDisplayName());
         assertNotNull("Missing modifiedAt property.", nodeResource.getModifiedAt());
-        assertTrue("Wrong assocQName prefix, it doesn't start with \"ce:\".", nodeResource.getAssocQName().startsWith("ce:"));
+        assertEquals("Wrong assocQName prefix.", "ce:" + localName, nodeResource.getAssocQName());
     }
 
     @Test

--- a/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/CreateRepoEventIT.java
@@ -32,6 +32,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.alfresco.model.ContentModel;
+import org.alfresco.repo.dictionary.NamespaceDAO;
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.node.Transaction;
 import org.alfresco.repo.event.v1.model.EventData;
@@ -42,6 +43,7 @@ import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.PropertyMap;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -53,6 +55,18 @@ public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
 
     @Autowired
     private NodeDAO nodeDAO;
+    
+    @Autowired
+    private NamespaceDAO namespaceDAO;
+    
+    @Before
+    public void setup() {
+        if(namespaceDAO.getNamespaceURI("ce") == null) 
+        {
+            namespaceDAO.addURI(TEST_NAMESPACE);
+            namespaceDAO.addPrefix("ce", TEST_NAMESPACE);
+        }
+    }
     
     @Test
     public void testCreateEvent()
@@ -103,6 +117,7 @@ public class CreateRepoEventIT extends AbstractContextAwareRepoEvent
         assertEquals("Wrong node modifier display name.", "Administrator",
             nodeResource.getModifiedByUser().getDisplayName());
         assertNotNull("Missing modifiedAt property.", nodeResource.getModifiedAt());
+        assertTrue("Wrong assocQName prefix, it doesn't start with \"ce:\".", nodeResource.getAssocQName().startsWith("ce:"));
     }
 
     @Test

--- a/repository/src/test/java/org/alfresco/repo/event2/DeleteRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/DeleteRepoEventIT.java
@@ -45,9 +45,10 @@ public class DeleteRepoEventIT extends AbstractContextAwareRepoEvent
     @Test
     public void testDeleteContent()
     {
+        String localName = GUID.generate();
         PropertyMap propertyMap = new PropertyMap();
         propertyMap.put(ContentModel.PROP_TITLE, "test title");
-        NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT, propertyMap);
+        NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT, localName, propertyMap);
 
         NodeResource createdResource = getNodeResource(1);
 
@@ -64,6 +65,7 @@ public class DeleteRepoEventIT extends AbstractContextAwareRepoEvent
 
         assertEquals("Repo event type:", EventType.NODE_DELETED.getType(), resultRepoEvent.getType());
         assertEquals(createdResource.getId(), getNodeResource(resultRepoEvent).getId());
+        assertEquals("Wrong assocQName prefix.", "ce:" + localName, createdResource.getAssocQName());
 
         // There should be no resourceBefore
         EventData<NodeResource> eventData = getEventData(resultRepoEvent);

--- a/repository/src/test/java/org/alfresco/repo/event2/UpdateRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/UpdateRepoEventIT.java
@@ -33,11 +33,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.dictionary.M2Model;
 import org.alfresco.repo.dictionary.M2Type;
+import org.alfresco.repo.dictionary.NamespaceDAO;
 import org.alfresco.repo.event.v1.model.ContentInfo;
 import org.alfresco.repo.event.v1.model.EventData;
 import org.alfresco.repo.event.v1.model.EventType;
@@ -48,10 +48,13 @@ import org.alfresco.service.cmr.dictionary.TypeDefinition;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.Pair;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Iulian Aftene
@@ -59,6 +62,22 @@ import org.junit.Test;
  */
 public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
 {
+
+    @Autowired
+    private NamespaceDAO namespaceDAO;
+
+    @Autowired
+    private NamespaceService namespaceService;
+
+    @Before
+    public void setup() {
+        if(namespaceDAO.getNamespaceURI("ce") == null)
+        {
+            namespaceDAO.addURI(TEST_NAMESPACE);
+            namespaceDAO.addPrefix("ce", TEST_NAMESPACE);
+        }
+    }
+    
     @Test
     public void testUpdateNodeResourceContent()
     {
@@ -138,6 +157,7 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertNull(resourceBefore.getProperties());
         assertNull(resourceBefore.getAspectNames());
         assertNull(resourceBefore.getPrimaryHierarchy());
+        assertNull(resourceBefore.getAssocQName());
     }
 
     @Test
@@ -198,6 +218,7 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertNull(resourceBefore.getProperties());
         assertNull(resourceBefore.getAspectNames());
         assertNull(resourceBefore.getPrimaryHierarchy());
+        assertNull(resourceBefore.getAssocQName());
     }
 
     @Test
@@ -274,6 +295,7 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertNull(resourceBefore.getProperties());
         assertNull(resourceBefore.getAspectNames());
         assertNull(resourceBefore.getPrimaryHierarchy());
+        assertNull(resourceBefore.getAssocQName());
     }
 
     @Test
@@ -539,6 +561,7 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertNull(resourceBefore.getProperties());
         assertNull(resourceBefore.getAspectNames());
         assertNull(resourceBefore.getPrimaryHierarchy());
+        assertNull(resourceBefore.getAssocQName());
     }
 
     @Test
@@ -573,7 +596,8 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertEquals("Wrong repo event type.", EventType.NODE_CREATED.getType(), resultRepoEvent.getType());
         NodeResource nodeResource = getNodeResource(resultRepoEvent);
         assertEquals("Incorrect node type was found", "cm:dictionaryModel", nodeResource.getNodeType());
-
+        
+        setup(); //init again the prefix mapping after the custom model creation
         final NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT);
         // old node's type
         assertEquals(ContentModel.TYPE_CONTENT, nodeService.getType(nodeRef));
@@ -613,7 +637,7 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertNull(resourceBefore.getProperties());
         assertNull(resourceBefore.getAspectNames());
         assertNull(resourceBefore.getPrimaryHierarchy());
-
+        assertNull(resourceBefore.getAssocQName());
     }
 
     @Test
@@ -660,6 +684,7 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertNull(resourceBefore.getProperties());
         assertNull(resourceBefore.getAspectNames());
         assertNull(resourceBefore.getPrimaryHierarchy());
+        assertNull(resourceBefore.getAssocQName());
     }
 
     @Test

--- a/repository/src/test/java/org/alfresco/repo/event2/UpdateRepoEventIT.java
+++ b/repository/src/test/java/org/alfresco/repo/event2/UpdateRepoEventIT.java
@@ -37,7 +37,6 @@ import org.alfresco.model.ContentModel;
 import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.dictionary.M2Model;
 import org.alfresco.repo.dictionary.M2Type;
-import org.alfresco.repo.dictionary.NamespaceDAO;
 import org.alfresco.repo.event.v1.model.ContentInfo;
 import org.alfresco.repo.event.v1.model.EventData;
 import org.alfresco.repo.event.v1.model.EventType;
@@ -48,13 +47,10 @@ import org.alfresco.service.cmr.dictionary.TypeDefinition;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.NodeRef;
-import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.Pair;
-import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Iulian Aftene
@@ -63,21 +59,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
 {
 
-    @Autowired
-    private NamespaceDAO namespaceDAO;
-
-    @Autowired
-    private NamespaceService namespaceService;
-
-    @Before
-    public void setup() {
-        if(namespaceDAO.getNamespaceURI("ce") == null)
-        {
-            namespaceDAO.addURI(TEST_NAMESPACE);
-            namespaceDAO.addPrefix("ce", TEST_NAMESPACE);
-        }
-    }
-    
     @Test
     public void testUpdateNodeResourceContent()
     {
@@ -596,8 +577,8 @@ public class UpdateRepoEventIT extends AbstractContextAwareRepoEvent
         assertEquals("Wrong repo event type.", EventType.NODE_CREATED.getType(), resultRepoEvent.getType());
         NodeResource nodeResource = getNodeResource(resultRepoEvent);
         assertEquals("Incorrect node type was found", "cm:dictionaryModel", nodeResource.getNodeType());
-        
-        setup(); //init again the prefix mapping after the custom model creation
+
+        initTestNamespacePrefixMapping();
         final NodeRef nodeRef = createNode(ContentModel.TYPE_CONTENT);
         // old node's type
         assertEquals(ContentModel.TYPE_CONTENT, nodeService.getType(nodeRef));


### PR DESCRIPTION
In order to implement the path live indexing, we need to retrieve the prefix string and the local name used in the association. 

In this PR we are setting the value to fields added in 