### PR TITLE
Feature/acs 1904 fix node ref vs content url

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -25,8 +25,6 @@
  */
 package org.alfresco.repo.content;
 
-import java.util.Date;
-
 import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.service.cmr.repository.ContentAccessor;
 import org.alfresco.service.cmr.repository.ContentIOException;
@@ -34,7 +32,6 @@ import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentStreamListener;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.DirectAccessUrl;
-import org.alfresco.service.cmr.repository.NodeRef;
 
 
 /**

--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -254,9 +254,10 @@ public interface ContentStore
     /**
      * Checks if the store supports the retrieving of a direct access URL for the given node.
      *
+     * @param contentUrl    the {@code URL} of the content for which to request a direct access {@code URL}
      * @return {@code true} if direct access URLs retrieving is supported for the node, {@code false} otherwise
      */
-    default boolean isContentDirectUrlEnabled(NodeRef nodeRef)
+    default boolean isContentDirectUrlEnabled(String contentUrl)
     {
         return false;
     }
@@ -291,32 +292,5 @@ public interface ContentStore
     {
         throw new UnsupportedOperationException(
                 "Retrieving direct access URLs is not supported by this content store.");
-    }
-
-    /**
-     * Gets a presigned URL to directly access a binary content. It is up to the actual store
-     * implementation if it can fulfil this request with an expiry time or not.
-     *
-     * @param contentUrl A content store URL
-     * @param expiresAt An optional expiry date, so the direct access url would become invalid when the expiry date is reached
-     * @return A direct access URL object for a binary content
-     * @throws UnsupportedOperationException if the store is unable to provide the information
-     */
-    @Deprecated
-    default DirectAccessUrl getDirectAccessUrl(String contentUrl, Date expiresAt)
-    {
-        throw new UnsupportedOperationException(
-                "Retrieving direct access URLs is not supported by this content store.");
-    }
-
-    /**
-     * Checks if the store supports the retrieving of direct access URLs.
-     *
-     * @return true if direct access URLs retrieving is supported, false otherwise
-     */
-    @Deprecated
-    default boolean isDirectAccessSupported()
-    {
-        return false;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -27,7 +27,6 @@ package org.alfresco.repo.content;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -520,12 +519,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         return tempStore.getWriter(ContentContext.NULL_CONTEXT);
     }
 
-    @Deprecated
-    public DirectAccessUrl getDirectAccessUrl(NodeRef nodeRef, Date expiresAt)
-    {
-        return requestContentDirectUrl(nodeRef, true, null);
-    }
-
     /**
      * Ensures that, upon closure of the output stream, the node is updated with
      * the latest URL of the content to which it refers.
@@ -612,7 +605,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 throw new IllegalArgumentException("The supplied nodeRef " + nodeRef + " has no content.");
             }
 
-            contentDirectUrlEnabled = (store.isContentDirectUrlEnabled(nodeRef));
+            contentDirectUrlEnabled = (store.isContentDirectUrlEnabled(getContentUrl(nodeRef)));
         }
 
         return contentDirectUrlEnabled;

--- a/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
@@ -489,9 +489,9 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
     /**
      * {@inheritDoc}
      */
-    public boolean isContentDirectUrlEnabled(NodeRef nodeRef)
+    public boolean isContentDirectUrlEnabled(String contentUrl)
     {
-        return backingStore.isContentDirectUrlEnabled(nodeRef);
+        return backingStore.isContentDirectUrlEnabled(contentUrl);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -294,10 +294,10 @@ public class AggregatingContentStore extends AbstractContentStore
     /**
      * @return Returns {@code true} if at least one store supports direct access URL for node
      */
-    public boolean isContentDirectUrlEnabled(NodeRef nodeRef)
+    public boolean isContentDirectUrlEnabled(String contentUrl)
     {
         // Check the primary store
-        boolean isContentDirectUrlEnabled = primaryStore.isContentDirectUrlEnabled(nodeRef);
+        boolean isContentDirectUrlEnabled = primaryStore.isContentDirectUrlEnabled(contentUrl);
 
         if (!isContentDirectUrlEnabled)
         {
@@ -305,7 +305,7 @@ public class AggregatingContentStore extends AbstractContentStore
             // other stores
             for (ContentStore store : secondaryStores)
             {
-                isContentDirectUrlEnabled = store.isContentDirectUrlEnabled(nodeRef);
+                isContentDirectUrlEnabled = store.isContentDirectUrlEnabled(contentUrl);
 
                 if (isContentDirectUrlEnabled)
                 {

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -25,7 +25,6 @@
  */
 package org.alfresco.service.cmr.repository;
 
-import java.util.Date;
 
 import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.service.Auditable;
@@ -154,23 +153,6 @@ public interface ContentService
      */
     @Auditable
     public ContentWriter getTempWriter();
-
-    /**
-     * Gets a presigned URL to directly access a binary content. It is up to the
-     * content store if it can fulfil this request with an expiry time (in
-     * milliseconds) or not.
-     *
-     * @param nodeRef
-     *            a reference to a node having a content property
-     * @param expiresAt
-     *            an optional expiry date, so the direct access url would become
-     *            invalid when the expiry date is reached
-     * @return A direct access URL object for a binary content or returns null if not supported
-     * @throws IllegalArgumentException if there is no binary content for the node
-     */
-    @Deprecated
-    @Auditable(parameters = {"nodeRef", "expiresAt"})
-    public DirectAccessUrl getDirectAccessUrl(NodeRef nodeRef, Date expiresAt);
 
     /**
      * Checks if the system and at least one store supports the retrieving of direct access URLs.

--- a/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -492,7 +492,7 @@ public class CachingContentStoreTest
     }
 
     @Test
-    public void isDirectAccessSupported()
+    public void isContentDirectUrlSupported()
     {
         assertFalse(cachingStore.isContentDirectUrlEnabled());
 
@@ -501,7 +501,7 @@ public class CachingContentStoreTest
     }
 
     @Test
-    public void getDirectAccessUrlUnsupported()
+    public void getRequestContentDirectUrlUnsupported()
     {
         try
         {
@@ -516,7 +516,7 @@ public class CachingContentStoreTest
     }
 
     @Test
-    public void getDirectAccessUrl()
+    public void getRequestContentDirectUrl()
     {
         when(backingStore.requestContentDirectUrl(anyString(), eq(true), anyString(), anyLong())).thenReturn(new DirectAccessUrl());
         cachingStore.requestContentDirectUrl("url", true,"someFile", 30L);

--- a/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
@@ -216,7 +216,7 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
     }
 
     @Test
-    public void testGetDirectAccessUrl()
+    public void testRequestContentDirectUrl()
     {
         // Create the aggregating store
         AggregatingContentStore aggStore = new AggregatingContentStore();


### PR DESCRIPTION
Ensure the content url rather than the node ref iss passed to the adapter. Also, remove deprecated methods