### PR TITLE
Feature/acs 1924 remove version renditions end point

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeRenditionsRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeRenditionsRelation.java
@@ -120,7 +120,7 @@ public class NodeRenditionsRelation implements RelationshipResourceAction.Read<R
     }
 
     @Operation("request-direct-access-url")
-    @WebApiParam (name = "requestRenditionDirectAccessUrl", title = "Request direct access url", description = "Request direct access url", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
+    @WebApiParam (name = "directAccessUrlRequest", title = "Request direct access url", description = "Options for direct access url request", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Request content url",
             description="Generates a direct access URL.",
             successStatus = HttpServletResponse.SC_OK)

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeVersionRenditionsRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeVersionRenditionsRelation.java
@@ -26,28 +26,18 @@
 
 package org.alfresco.rest.api.nodes;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
-import org.alfresco.repo.content.directurl.DirectAccessUrlDisabledException;
-import org.alfresco.rest.api.DirectAccessUrlHelper;
 import org.alfresco.rest.api.Renditions;
-import org.alfresco.rest.api.model.DirectAccessUrlRequest;
 import org.alfresco.rest.api.model.Rendition;
 import org.alfresco.rest.framework.BinaryProperties;
-import org.alfresco.rest.framework.Operation;
 import org.alfresco.rest.framework.WebApiDescription;
-import org.alfresco.rest.framework.WebApiParam;
-import org.alfresco.rest.framework.core.ResourceParameter;
-import org.alfresco.rest.framework.core.exceptions.DisabledServiceException;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceBinaryAction;
 import org.alfresco.rest.framework.resource.content.BinaryResource;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.rest.framework.webscripts.WithResponse;
-import org.alfresco.service.cmr.repository.DirectAccessUrl;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.util.PropertyCheck;
@@ -62,7 +52,6 @@ import org.springframework.extensions.webscripts.Status;
  * - POST /nodes/{nodeId}/versions/{versionId}/renditions
  * - GET  /nodes/{nodeId}/versions/{versionId}/renditions/{renditionId}
  * - GET  /nodes/{nodeId}/versions/{versionId}/renditions/{renditionId}/content
- * - POST /nodes/{nodeId}/versions/{versionId}/renditions/{renditionId}/requestVersionDirectAccessUrl
  *
  * @author janv
  */
@@ -74,16 +63,10 @@ public class NodeVersionRenditionsRelation implements RelationshipResourceAction
         InitializingBean
 {
     private Renditions renditions;
-    private DirectAccessUrlHelper directAccessUrlHelper;
 
     public void setRenditions(Renditions renditions)
     {
         this.renditions = renditions;
-    }
-
-    public void setDirectAccessUrlHelper(DirectAccessUrlHelper directAccessUrlHelper)
-    {
-        this.directAccessUrlHelper = directAccessUrlHelper;
     }
 
     @Override
@@ -130,30 +113,6 @@ public class NodeVersionRenditionsRelation implements RelationshipResourceAction
 
         NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, nodeId);
         return renditions.getContent(nodeRef, versionId, renditionId, parameters);
-    }
-
-    @Operation ("request-direct-access-url")
-    @WebApiParam (name = "requestVersionRenditionDirectAccessUrl", title = "Request direct access url", description = "Request direct access url", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
-    @WebApiDescription(title = "Request content url",
-            description="Generates a direct access URL.",
-            successStatus = HttpServletResponse.SC_OK)
-    public DirectAccessUrl requestContentDirectUrl(String nodeId, String versionId, DirectAccessUrlRequest directAccessUrlRequest, Parameters parameters, WithResponse withResponse)
-    {
-        boolean attachment = directAccessUrlHelper.getAttachment(directAccessUrlRequest);
-        Long validFor = directAccessUrlHelper.getDefaultExpiryTimeInSec();
-        NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, nodeId);
-        String renditionId = parameters.getRelationship2Id();
-
-        DirectAccessUrl directAccessUrl;
-        try
-        {
-            directAccessUrl = renditions.requestContentDirectUrl(nodeRef, versionId, renditionId, attachment, validFor);
-        }
-        catch (DirectAccessUrlDisabledException ex)
-        {
-            throw new DisabledServiceException(ex.getMessage());
-        }
-        return directAccessUrl;
     }
 
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeVersionsRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeVersionsRelation.java
@@ -303,7 +303,7 @@ public class NodeVersionsRelation extends AbstractNodeRelation implements
     }
 
     @Operation("request-direct-access-url")
-    @WebApiParam (name = "requestVersionDirectAccessUrl", title = "Request direct access url", description = "Request direct access url", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
+    @WebApiParam (name = "directAccessUrlRequest", title = "Request direct access url", description = "Options for direct access url request", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Request content url",
             description="Generates a direct access URL.",
             successStatus = HttpServletResponse.SC_OK)

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodesEntityResource.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodesEntityResource.java
@@ -203,7 +203,7 @@ public class NodesEntityResource implements
     }
 
     @Operation("request-direct-access-url")
-    @WebApiParam(name = "requestNodeDirectAccessUrl", title = "Request direct access url", description = "Request direct access url", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
+    @WebApiParam(name = "directAccessUrlRequest", title = "Request direct access url", description = "Options for direct access url request", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Request content url",
             description="Generates a direct access URL.",
             successStatus = HttpServletResponse.SC_OK)

--- a/remote-api/src/main/java/org/alfresco/rest/api/trashcan/TrashcanEntityResource.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/trashcan/TrashcanEntityResource.java
@@ -101,7 +101,7 @@ public class TrashcanEntityResource implements
     }
 
     @Operation("request-direct-access-url")
-    @WebApiParam(name = "requestDeletedNodeDirectAccessUrl", title = "Request direct access url", description = "Request direct access url", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
+    @WebApiParam(name = "directAccessUrlRequest", title = "Request direct access url", description = "Options for direct access url request", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Request content url",
             description="Generates a direct access URL.",
             successStatus = HttpServletResponse.SC_OK)

--- a/remote-api/src/main/java/org/alfresco/rest/api/trashcan/TrashcanRenditionsRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/trashcan/TrashcanRenditionsRelation.java
@@ -90,7 +90,7 @@ public class TrashcanRenditionsRelation
     }
 
     @Operation ("request-direct-access-url")
-    @WebApiParam (name = "requestArchivedNodeRenditionDirectAccessUrl", title = "Request direct access url", description = "Request direct access url", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
+    @WebApiParam (name = "directAccessUrlRequest", title = "Request direct access url", description = "Options for direct access url request", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
     @WebApiDescription(title = "Request content url",
             description="Generates a direct access URL.",
             successStatus = HttpServletResponse.SC_OK)

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -1429,7 +1429,6 @@
 
     <bean class="org.alfresco.rest.api.nodes.NodeVersionRenditionsRelation">
         <property name="renditions" ref="Renditions" />
-        <property name="directAccessUrlHelper" ref="directAccessUrlHelper" />
     </bean>
 
     <bean class="org.alfresco.rest.api.quicksharelinks.QuickShareLinkRenditionsRelation">

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -141,8 +141,6 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
     private String groupA = null;
     private String groupB = null;
 
-    private final static long DELAY_IN_MS = 500;
-
     @Before
     public void setup() throws Exception
     {
@@ -6367,113 +6365,6 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         assertEquals(Rendition.RenditionStatus.CREATED, rendition.getStatus());
 
         HttpResponse dauResponse = post(getRequestContentDirectUrl(contentNodeId), null, null, null, null, 501);
-    }
-
-
-    @Test
-    public void testCreateRenditionForNewVersion() throws Exception
-    {
-        setRequestContext(user1);
-
-        RepoService.TestNetwork networkN1;
-        RepoService.TestPerson userOneN1;
-        Site userOneN1Site;
-
-        networkN1 = repoService.createNetworkWithAlias("ping", true);
-        networkN1.create();
-        userOneN1 = networkN1.createUser();
-
-        setRequestContext(networkN1.getId(), userOneN1.getId(), null);
-
-        String siteTitle = "RandomSite" + System.currentTimeMillis();
-        userOneN1Site = createSite(siteTitle, SiteVisibility.PRIVATE);
-
-        String PROP_LTM = "cm:lastThumbnailModification";
-
-        String RENDITION_NAME = "imgpreview";
-
-        String userId = userOneN1.getId();
-        setRequestContext(networkN1.getId(), userOneN1.getId(), null);
-
-        // Create a folder within the site document's library
-        String folderName = "folder" + System.currentTimeMillis();
-        String parentId = getSiteContainerNodeId(userOneN1Site.getId(), "documentLibrary");
-        String folder_Id = createNode(parentId, folderName, TYPE_CM_FOLDER, null).getId();
-
-        // Create multipart request - pdf file
-        String fileName = "quick.pdf";
-        File file = getResourceFile(fileName);
-        MultiPartRequest reqBody = MultiPartBuilder.create()
-            .setFileData(new FileData(fileName, file))
-            .build();
-        Map<String, String> params = Collections.singletonMap("include", "properties");
-
-        // Upload quick.pdf file into 'folder' - do not include request to create 'doclib' thumbnail
-        HttpResponse response = post(getNodeChildrenUrl(folder_Id), reqBody.getBody(), params, null, "alfresco", reqBody.getContentType(), 201);
-        Document document1 = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
-        String contentNodeId = document1.getId();
-        assertNotNull(document1.getProperties());
-
-        // pause briefly
-        Thread.sleep(DELAY_IN_MS);
-
-        // Get rendition (not created yet) information for node
-        response = getSingle(getNodeRenditionsUrl(contentNodeId), RENDITION_NAME, 200);
-        Rendition rendition = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Rendition.class);
-        assertNotNull(rendition);
-        assertEquals(Rendition.RenditionStatus.NOT_CREATED, rendition.getStatus());
-
-        params = new HashMap<>();
-        params.put("placeholder", "false");
-        getSingle(getNodeRenditionsUrl(contentNodeId), (RENDITION_NAME+"/content"), params, 404);
-
-        // Create and get 'imgpreview' rendition
-        rendition = createAndGetRendition(contentNodeId, RENDITION_NAME);
-        assertNotNull(rendition);
-
-        params = new HashMap<>();
-        params.put("placeholder", "false");
-        response = getSingle(getNodeRenditionsUrl(contentNodeId), (RENDITION_NAME+"/content"), params, 200);
-
-        byte[] renditionBytes1 = response.getResponseAsBytes();
-        assertNotNull(renditionBytes1);
-
-        // check node details ...
-        params = Collections.singletonMap("include", "properties");
-        response = getSingle(NodesEntityResource.class, contentNodeId, params, 200);
-        Document document1b = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
-        assertEquals(document1b.getModifiedByUser().getId(), document1.getModifiedByUser().getId());
-
-        // upload another version of "quick.pdf" and check again
-        fileName = "quick-2.pdf";
-        file = getResourceFile(fileName);
-        reqBody = MultiPartBuilder.create()
-            .setFileData(new FileData("quick.pdf", file))
-            .setOverwrite(true)
-            .build();
-
-        response = post(getNodeChildrenUrl(folder_Id), reqBody.getBody(), null, null, "alfresco", reqBody.getContentType(), 201);
-        Document document2 = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
-        assertEquals(contentNodeId, document2.getId());
-
-        // wait to allow new version of the rendition to be created ...
-        Thread.sleep(DELAY_IN_MS * 4);
-
-        params = new HashMap<>();
-        params.put("placeholder", "false");
-        response = getSingle(getNodeRenditionsUrl(contentNodeId), (RENDITION_NAME+"/content"), params, 200);
-        assertNotNull(response.getResponseAsBytes());
-
-        // check rendition binary has changed
-        assertNotEquals(renditionBytes1, response.getResponseAsBytes());
-
-        params = Collections.singletonMap("include", "properties");
-        response = getSingle(NodesEntityResource.class, contentNodeId, params, 200);
-        Document document2b = RestApiUtil.parseRestApiEntry(response.getJsonResponse(), Document.class);
-
-        String contentNodeId2b = document2b.getId();
-        HttpResponse dauResponse = post(getRequestContentDirectUrl(contentNodeId2b), null, null, null, null, 501);
-
     }
 }
 


### PR DESCRIPTION
- Removed direct access url version renditions endpoint from NodeVersionsRelation
- Removed its associated test
- Also, correct WebApiParam names for all direct access url endpoints