### PR TITLE
ACS-2067: Fix probes when DAU (Direct Access Url) support is enabled

### DIFF
--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -1070,7 +1070,7 @@
         <property name="enabled" value="${system.api.discovery.enabled}" />
         <property name="thumbnailService" ref="ThumbnailService" />
         <property name="restApiDirectUrlConfig" ref="restApiDirectUrlConfig" />
-        <property name="contentService" ref="ContentService" />
+        <property name="contentService" ref="contentService" />
     </bean>
 
     <bean id="org.alfresco.rest.api.probes.ProbeEntityResource.get" class="org.alfresco.rest.api.probes.ProbeEntityResource">


### PR DESCRIPTION
- note: sanity checked in local dev context (went from 503 to 200 success) ...
- fix needed to unblock ACS-2063 (for epic ACS-118)