### PR TITLE
MNT-22600 Nodes with security marks appear unfiltered on CMIS DB quer…

### DIFF
--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/base/BaseRMRestTest.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/base/BaseRMRestTest.java
@@ -620,10 +620,26 @@ public class BaseRMRestTest extends RestTest
      */
     public List<String> searchForContentAsUser(UserModel user, String term)
     {
+        String query = "cm:name:*" + term + "*";
+        return searchForContentAsUser(user,query,"afts");
+    }
+
+    /**
+     * Returns search results for the given search term
+     *
+     * @param user
+     * @param term
+     * @param query language
+     * @return
+     * @throws Exception
+     */
+    public List<String> searchForContentAsUser(UserModel user, String q, String queryLanguage)
+    {
         getRestAPIFactory().getRmRestWrapper().authenticateUser(user);
         RestRequestQueryModel queryReq = new RestRequestQueryModel();
         SearchRequest query = new SearchRequest(queryReq);
-        queryReq.setQuery("cm:name:*" + term + "*");
+        queryReq.setQuery(q);
+        queryReq.setLanguage(queryLanguage);
 
         List<String> names = new ArrayList<>();
         // wait for solr indexing

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/capability/RMAfterInvocationProvider.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/capability/RMAfterInvocationProvider.java
@@ -306,7 +306,7 @@ public class RMAfterInvocationProvider extends RMSecurityCommon
         }
     }
 
-    private boolean isUnfiltered(NodeRef nodeRef)
+    protected boolean isUnfiltered(NodeRef nodeRef)
     {
         return !nodeService.hasAspect(nodeRef, RecordsManagementModel.ASPECT_FILE_PLAN_COMPONENT);
 


### PR DESCRIPTION
…ies (#702)

* Change isUnfiltered to protected so we can extend it in enterprise
* Added test method to be able to do a cmis query test

Original commit in governance-services: https://github.com/Alfresco/governance-services/commit/e4e3235328543439c9fce5a778b0c3474071ec14

(cherry picked from commit c5281d7f1087106aea9a37494730723e82d7c59c)