### PR TITLE
ACS-1112 Upgrade the BatchProcessor counting mechanism to work with "long" Java type

### DIFF
--- a/repository/src/main/java/org/alfresco/encryption/ReEncryptor.java
+++ b/repository/src/main/java/org/alfresco/encryption/ReEncryptor.java
@@ -242,6 +242,12 @@ public class ReEncryptor implements ApplicationContextAware
             }
 
             @Override
+            public long getTotalEstimatedWorkSizeLong()
+            {
+                return properties.size();
+            }
+
+            @Override
             public Collection<NodePropertyEntity> getNextWork()
             {
                 List<NodePropertyEntity> sublist = new ArrayList<NodePropertyEntity>(chunkSize);

--- a/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/opencmis/AlfrescoCmisServiceImpl.java
@@ -1960,6 +1960,12 @@ public class AlfrescoCmisServiceImpl extends AbstractCmisService implements Alfr
             }
 
             @Override
+            public synchronized long getTotalEstimatedWorkSizeLong()
+            {
+                return size;
+            }
+
+            @Override
             public synchronized Collection<BulkEntry> getNextWork()
             {
                 Collection<BulkEntry> results = new ArrayList<BulkEntry>(batchSize);

--- a/repository/src/main/java/org/alfresco/repo/activities/feed/FeedNotifierImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/activities/feed/FeedNotifierImpl.java
@@ -428,6 +428,12 @@ public class FeedNotifierImpl implements FeedNotifier, ApplicationContextAware
                 }
 
                 @Override
+                public long getTotalEstimatedWorkSizeLong()
+                {
+                    return personService.countPeople();
+                }
+
+                @Override
                 public Collection<PersonInfo> getNextWork()
                 {
                     if (!hasMore)

--- a/repository/src/main/java/org/alfresco/repo/activities/feed/local/LocalFeedGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/activities/feed/local/LocalFeedGenerator.java
@@ -163,6 +163,16 @@ public class LocalFeedGenerator extends AbstractFeedGenerator
             }
 
             @Override
+            public long getTotalEstimatedWorkSizeLong()
+            {
+                long size = maxSequence - minSequence + 1;
+                long remain = size % batchSize;
+                long workSize = (remain == 0) ? (size / batchSize) : (size / batchSize + 1);
+                return workSize;
+            }
+
+
+            @Override
             public Collection<JobSettings> getNextWork()
             {
                 if (!hasMore)

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/AbstractPatch.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/AbstractPatch.java
@@ -486,6 +486,11 @@ public abstract class AbstractPatch implements Patch,  ApplicationEventPublisher
                     return tenants.size();
                 }
 
+                public long getTotalEstimatedWorkSizeLong()
+                {
+                    return tenants.size();
+                }
+
                 @Override
                 public Collection<Tenant> getNextWork()
                 {
@@ -554,13 +559,13 @@ public abstract class AbstractPatch implements Patch,  ApplicationEventPublisher
                 logger.debug("batch worker finished processing id:" + id);
             }
             
-            if (batchProcessor.getTotalErrors() > 0)
+            if (batchProcessor.getTotalErrorsLong() > 0)
             {
-                sb.append("\n" + " and failure during update of tennants total success: " + batchProcessor.getSuccessfullyProcessedEntries() + " number of errors: " +batchProcessor.getTotalErrors() + " lastError" + batchProcessor.getLastError());
+                sb.append("\n" + " and failure during update of tennants total success: " + batchProcessor.getSuccessfullyProcessedEntriesLong() + " number of errors: " +batchProcessor.getTotalErrorsLong() + " lastError" + batchProcessor.getLastError());
             }
             else
             {
-                sb.append("\n" + " and successful batch update of " + batchProcessor.getTotalResults() + "tennants");
+                sb.append("\n" + " and successful batch update of " + batchProcessor.getTotalResultsLong() + "tennants");
             }
         }
 

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/impl/AddUnmovableAspectToSitesPatch.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/impl/AddUnmovableAspectToSitesPatch.java
@@ -91,6 +91,12 @@ public class AddUnmovableAspectToSitesPatch extends AsynchronousPatch
             }
 
             @Override
+            public long getTotalEstimatedWorkSizeLong()
+            {
+                return sites.size();
+            }
+
+            @Override
             public Collection<ChildAssociationRef> getNextWork()
             {
                 List<ChildAssociationRef> sites = new ArrayList<ChildAssociationRef>(BATCH_SIZE);

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/impl/AliasableAspectPatch.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/impl/AliasableAspectPatch.java
@@ -93,6 +93,11 @@ public class AliasableAspectPatch extends AbstractPatch
                 return result.size();
             }
 
+            public long getTotalEstimatedWorkSizeLong()
+            {
+                return result.size();
+            }
+
             public Collection<NodeRef> getNextWork()
             {
                 if(val != null)

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/impl/FixBpmPackagesPatch.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/impl/FixBpmPackagesPatch.java
@@ -238,6 +238,12 @@ public class FixBpmPackagesPatch extends AbstractPatch
                 }
 
                 @Override
+                public synchronized long getTotalEstimatedWorkSizeLong()
+                {
+                    return assocCount;
+                }
+
+                @Override
                 public synchronized Collection<ChildAssociationRef> getNextWork()
                 {
                     int nextMaxSize = skipCount + batchSize;

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/impl/ImapUnsubscribedAspectPatch.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/impl/ImapUnsubscribedAspectPatch.java
@@ -76,6 +76,11 @@ public class ImapUnsubscribedAspectPatch extends AbstractPatch
                 return result.size();
             }
 
+            public long getTotalEstimatedWorkSizeLong()
+            {
+                return result.size();
+            }
+
             public Collection<NodeRef> getNextWork()
             {
                 result.clear();

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/impl/RenameSiteAuthorityDisplayName.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/impl/RenameSiteAuthorityDisplayName.java
@@ -143,6 +143,12 @@ public class RenameSiteAuthorityDisplayName  extends AbstractPatch
             {
                 return siteInfos.size();
             }
+
+            @Override
+            public long getTotalEstimatedWorkSizeLong()
+            {
+                return siteInfos.size();
+            }
             
             @Override
             public Collection<SiteInfo> getNextWork()

--- a/repository/src/main/java/org/alfresco/repo/admin/patch/impl/SurfConfigFolderPatch.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/patch/impl/SurfConfigFolderPatch.java
@@ -462,6 +462,20 @@ public class SurfConfigFolderPatch extends AsynchronousPatch
         }
 
         @Override
+        public synchronized long getTotalEstimatedWorkSizeLong()
+        {
+            if (maxId == Long.MAX_VALUE)
+            {
+                maxId = patchDAO.getMaxAdmNodeID();
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("\tQ: Max node id: " + maxId);
+                }
+            }
+            return 0;
+        }
+
+        @Override
         public synchronized Collection<NodeRef> getNextWork()
         {
             // Record the user folder node IDs

--- a/repository/src/main/java/org/alfresco/repo/batch/BatchMonitor.java
+++ b/repository/src/main/java/org/alfresco/repo/batch/BatchMonitor.java
@@ -50,10 +50,10 @@ public interface BatchMonitor
 
     /**
      * Gets the total number of results.
-     * 
+     * @deprecated use {@link #getTotalResultsLong()} instead
      * @return the total number of results
      */
-    public int getTotalResults();
+    @Deprecated public int getTotalResults();
 
     /**
      * Gets the ID of the entry being processed
@@ -64,10 +64,10 @@ public interface BatchMonitor
 
     /**
      * Gets the number of successfully processed entries.
-     * 
+     * @deprecated use {@link #getSuccessfullyProcessedEntriesLong()} instead
      * @return the successfully processed entries
      */
-    public int getSuccessfullyProcessedEntries();
+    @Deprecated public int getSuccessfullyProcessedEntries();
 
     /**
      * Gets the progress expressed as a percentage.
@@ -78,10 +78,10 @@ public interface BatchMonitor
 
     /**
      * Gets the total number of errors.
-     * 
+     * @deprecated use {@link #getTotalErrorsLong()} instead
      * @return the total number of errors
      */
-    public int getTotalErrors();
+    @Deprecated public int getTotalErrors();
 
     /**
      * Gets the stack trace of the last error.
@@ -103,4 +103,35 @@ public interface BatchMonitor
      * @return the end time
      */
     public Date getEndTime();
+
+    /**
+     * Gets the total number of results.
+     *
+     * @return the total number of results
+     */
+    public default long getTotalResultsLong()
+    {
+        throw new UnsupportedOperationException("getTotalResultsLong need to be implemented");
+
+    }
+
+    /**
+     * Gets the total number of errors.
+     *
+     * @return the total number of errors
+     */
+    public default long getTotalErrorsLong()
+    {
+        throw new UnsupportedOperationException("getTotalErrorsLong need to be implemented");
+    }
+
+    /**
+     * Gets the number of successfully processed entries.
+     *
+     * @return the successfully processed entries
+     */
+    public default long getSuccessfullyProcessedEntriesLong()
+    {
+        throw new UnsupportedOperationException("getSuccessfullyProcessedEntriesLong need to be implemented");
+    }
 }

--- a/repository/src/main/java/org/alfresco/repo/batch/BatchProcessWorkProvider.java
+++ b/repository/src/main/java/org/alfresco/repo/batch/BatchProcessWorkProvider.java
@@ -43,10 +43,10 @@ public interface BatchProcessWorkProvider<T>
      * Instances can provide accurate answers on each call, but only if the answer can be
      * provided quickly and efficiently; usually it is enough to to cache the result after
      * providing an initial estimate.
-     * 
+     * @deprecated use {@link #getTotalEstimatedWorkSizeLong()} instead.
      * @return                  a total work size estimate
      */
-    int getTotalEstimatedWorkSize();
+    @Deprecated int getTotalEstimatedWorkSize();
     
     /**
      * Get the next lot of work for the batch processor.  Implementations should return
@@ -58,4 +58,18 @@ public interface BatchProcessWorkProvider<T>
      *                          if there is no more work remaining.
      */
     Collection<T> getNextWork();
+
+    /**
+     * Get an estimate of the total number of objects that will be provided by this instance.
+     * Instances can provide accurate answers on each call, but only if the answer can be
+     * provided quickly and efficiently; usually it is enough to to cache the result after
+     * providing an initial estimate.
+     *
+     * @return                  a total work size estimate
+     */
+    default long getTotalEstimatedWorkSizeLong()
+    {
+        throw new UnsupportedOperationException("getTotalEstimatedWorkSizeLong need to implemented");
+    }
+
 }

--- a/repository/src/main/java/org/alfresco/repo/batch/BatchProcessor.java
+++ b/repository/src/main/java/org/alfresco/repo/batch/BatchProcessor.java
@@ -110,10 +110,10 @@ public class BatchProcessor<T> implements BatchMonitor
     private String lastErrorEntryId;
 
     /** The total number of errors. */
-    private int totalErrors;
+    private long totalErrors;
 
     /** The number of successfully processed entries. */
-    private int successfullyProcessedEntries;
+    private long successfullyProcessedEntries;
 
     /** The start time. */
     private Date startTime;
@@ -280,7 +280,15 @@ public class BatchProcessor<T> implements BatchMonitor
     /**
      * {@inheritDoc}
      */
-    public synchronized int getSuccessfullyProcessedEntries()
+    @Deprecated public synchronized int getSuccessfullyProcessedEntries()
+    {
+        return Math.toIntExact(this.successfullyProcessedEntries);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public synchronized long getSuccessfullyProcessedEntriesLong()
     {
         return this.successfullyProcessedEntries;
     }
@@ -290,8 +298,8 @@ public class BatchProcessor<T> implements BatchMonitor
      */
     public synchronized String getPercentComplete()
     {
-        int totalResults = this.workProvider.getTotalEstimatedWorkSize();
-        int processed = this.successfullyProcessedEntries + this.totalErrors;
+        long totalResults = this.workProvider.getTotalEstimatedWorkSizeLong();
+        long processed = this.successfullyProcessedEntries + this.totalErrors;
         return processed <= totalResults ? NumberFormat.getPercentInstance().format(
                 totalResults == 0 ? 1.0F : (float) processed / totalResults) : "Unknown";
     }
@@ -299,7 +307,23 @@ public class BatchProcessor<T> implements BatchMonitor
     /**
      * {@inheritDoc}
      */
-    public synchronized int getTotalErrors()
+    @Deprecated public synchronized int getTotalErrors()
+    {
+        return Math.toIntExact(this.totalErrors);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated public int getTotalResults()
+    {
+        return this.workProvider.getTotalEstimatedWorkSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public synchronized long getTotalErrorsLong()
     {
         return this.totalErrors;
     }
@@ -307,9 +331,9 @@ public class BatchProcessor<T> implements BatchMonitor
     /**
      * {@inheritDoc}
      */
-    public int getTotalResults()
+    public long getTotalResultsLong()
     {
-        return this.workProvider.getTotalEstimatedWorkSize();
+        return this.workProvider.getTotalEstimatedWorkSizeLong();
     }
 
     /**
@@ -340,12 +364,42 @@ public class BatchProcessor<T> implements BatchMonitor
      *            increased performance. If <code>false</code>, all invocations are performed in the current
      *            transaction. This is required if calling synchronously (e.g. in response to an authentication event in
      *            the same transaction).
+     * @deprecated use {@link #processLong(BatchProcessWorker, boolean)} instead
      * @return the number of invocations
      */
     @SuppressWarnings("serial")
-    public int process(final BatchProcessWorker<T> worker, final boolean splitTxns)
+    @Deprecated public int process(final BatchProcessWorker<T> worker, final boolean splitTxns)
     {
         int count = workProvider.getTotalEstimatedWorkSize();
+        return (int)process(worker, splitTxns, count);
+
+    }
+
+    /**
+     * Invokes the worker for each entry in the collection, managing transactions and collating success / failure
+     * information.
+     *
+     * @param worker
+     *            the worker
+     * @param splitTxns
+     *            Can the modifications to Alfresco be split across multiple transactions for maximum performance? If
+     *            <code>true</code>, worker invocations are isolated in separate transactions in batches for
+     *            increased performance. If <code>false</code>, all invocations are performed in the current
+     *            transaction. This is required if calling synchronously (e.g. in response to an authentication event in
+     *            the same transaction).
+     * @return the number of invocations
+     */
+    @SuppressWarnings("serial")
+    public long processLong(final BatchProcessWorker<T> worker, final boolean splitTxns)
+    {
+        long count = workProvider.getTotalEstimatedWorkSizeLong();
+        return process(worker, splitTxns, count);
+
+    }
+
+
+    private long process(final BatchProcessWorker<T> worker, final boolean splitTxns, long count)
+    {
         synchronized (this)
         {
             this.startTime = new Date();
@@ -365,27 +419,27 @@ public class BatchProcessor<T> implements BatchMonitor
 
         // Create a thread pool executor with the specified number of threads and a finite blocking queue of jobs
         ExecutorService executorService = splitTxns && this.workerThreads > 1 ?
-                new ThreadPoolExecutor(
-                        this.workerThreads, this.workerThreads, 0L, TimeUnit.MILLISECONDS,
-                        new ArrayBlockingQueue<Runnable>(this.workerThreads * this.batchSize * 10)
-                {
-                    // Add blocking behaviour to work queue
-                    @Override
-                    public boolean offer(Runnable o)
-                    {
-                        try
-                        {
-                            put(o);
-                        }
-                        catch (InterruptedException e)
-                        {
-                            return false;
-                        }
-                        return true;
-                    }
+                    new ThreadPoolExecutor(
+                                this.workerThreads, this.workerThreads, 0L, TimeUnit.MILLISECONDS,
+                                new ArrayBlockingQueue<Runnable>(this.workerThreads * this.batchSize * 10)
+                                {
+                                    // Add blocking behaviour to work queue
+                                    @Override
+                                    public boolean offer(Runnable o)
+                                    {
+                                        try
+                                        {
+                                            put(o);
+                                        }
+                                        catch (InterruptedException e)
+                                        {
+                                            return false;
+                                        }
+                                        return true;
+                                    }
 
-                },
-                threadFactory) : null;
+                                },
+                                threadFactory) : null;
         try
         {
             Iterator<T> iterator = new WorkProviderIterator<T>(this.workProvider);
@@ -402,7 +456,7 @@ public class BatchProcessor<T> implements BatchMonitor
                     {
                         batch = new ArrayList<T>(this.batchSize);
                     }
-                    
+
                     if (executorService == null)
                     {
                         callback.run();
@@ -447,13 +501,12 @@ public class BatchProcessor<T> implements BatchMonitor
                 if (this.totalErrors > 0 && this.logger.isErrorEnabled())
                 {
                     this.logger.error(getProcessName() + ": " + this.totalErrors
-                            + " error(s) detected. Last error from entry \"" + this.lastErrorEntryId + "\"",
-                            this.lastError);
+                                            + " error(s) detected. Last error from entry \"" + this.lastErrorEntryId + "\"",
+                                this.lastError);
                 }
             }
         }
     }
-
     /**
      * Reports the current progress.
      * 
@@ -464,12 +517,20 @@ public class BatchProcessor<T> implements BatchMonitor
      */
     private synchronized void reportProgress(boolean last)
     {
-        int processed = this.successfullyProcessedEntries + this.totalErrors;
+        long processed = this.successfullyProcessedEntries + this.totalErrors;
         if (processed % this.loggingInterval == 0 ^ last)
         {
             StringBuilder message = new StringBuilder(100).append(getProcessName()).append(": Processed ").append(
                     processed).append(" entries");
-            int totalResults = this.workProvider.getTotalEstimatedWorkSize();
+            long totalResults = 0;
+            try
+            {
+                 totalResults = this.workProvider.getTotalEstimatedWorkSizeLong();
+            }
+            catch (UnsupportedOperationException uoe)
+            {
+                totalResults = this.workProvider.getTotalEstimatedWorkSize();
+            }
             if (totalResults >= processed)
             {
                 message.append(" out of ").append(totalResults).append(". ").append(
@@ -830,11 +891,11 @@ public class BatchProcessor<T> implements BatchMonitor
             {
                 if (this.txnErrors > 0)
                 {
-                    int processed = BatchProcessor.this.successfullyProcessedEntries + BatchProcessor.this.totalErrors;
-                    int currentIncrement = processed % BatchProcessor.this.loggingInterval;
-                    int newErrors = BatchProcessor.this.totalErrors + this.txnErrors;
+                    long processed = BatchProcessor.this.successfullyProcessedEntries + BatchProcessor.this.totalErrors;
+                    long currentIncrement = processed % BatchProcessor.this.loggingInterval;
+                    long newErrors = BatchProcessor.this.totalErrors + this.txnErrors;
                     // Work out the number of logging intervals we will cross and report them
-                    int intervals = (this.txnErrors + currentIncrement) / BatchProcessor.this.loggingInterval;
+                    long intervals = (this.txnErrors + currentIncrement) / BatchProcessor.this.loggingInterval;
                     if (intervals > 0)
                     {
                         BatchProcessor.this.totalErrors += BatchProcessor.this.loggingInterval - currentIncrement;
@@ -850,11 +911,11 @@ public class BatchProcessor<T> implements BatchMonitor
 
                 if (this.txnSuccesses > 0)
                 {
-                    int processed = BatchProcessor.this.successfullyProcessedEntries + BatchProcessor.this.totalErrors;
-                    int currentIncrement = processed % BatchProcessor.this.loggingInterval;
-                    int newSuccess = BatchProcessor.this.successfullyProcessedEntries + this.txnSuccesses;
+                    long processed = BatchProcessor.this.successfullyProcessedEntries + BatchProcessor.this.totalErrors;
+                    long currentIncrement = processed % BatchProcessor.this.loggingInterval;
+                    long newSuccess = BatchProcessor.this.successfullyProcessedEntries + this.txnSuccesses;
                     // Work out the number of logging intervals we will cross and report them
-                    int intervals = (this.txnSuccesses + currentIncrement) / BatchProcessor.this.loggingInterval;
+                    long intervals = (this.txnSuccesses + currentIncrement) / BatchProcessor.this.loggingInterval;
                     if (intervals > 0)
                     {
                         BatchProcessor.this.successfullyProcessedEntries += BatchProcessor.this.loggingInterval

--- a/repository/src/main/java/org/alfresco/repo/bulkimport/impl/StripingFilesystemTracker.java
+++ b/repository/src/main/java/org/alfresco/repo/bulkimport/impl/StripingFilesystemTracker.java
@@ -196,6 +196,12 @@ public class StripingFilesystemTracker extends AbstractFilesystemTracker
 			}
 
 			@Override
+			public long getTotalEstimatedWorkSizeLong()
+			{
+				return count();
+			}
+
+			@Override
 			public Collection<ImportableItem> getNextWork()
 			{
 				// TODO perhaps some multiple of the batchSize to limit calls

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/FixedAclUpdater.java
@@ -244,6 +244,12 @@ public class FixedAclUpdater extends TransactionListenerAdapter implements Appli
             int workSize = getNodesWithAspects.getWorkSize();
             return workSize;
         }
+        @Override
+        public long getTotalEstimatedWorkSizeLong()
+        {
+            return getNodesWithAspects.getWorkSize();
+        }
+
 
         @Override
         public Collection<NodeRef> getNextWork()

--- a/repository/src/main/java/org/alfresco/repo/node/archive/NodeArchiveServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/archive/NodeArchiveServiceImpl.java
@@ -244,6 +244,15 @@ public class NodeArchiveServiceImpl implements NodeArchiveService
             {
                 return 0;
             }
+
+            /**
+             * @return              Returns 0, always
+             */
+            public synchronized long getTotalEstimatedWorkSizeLong()
+            {
+                return 0;
+            }
+
             public synchronized Collection<NodeRef> getNextWork()
             {
                 if (vmShutdownLister.isVmShuttingDown())

--- a/repository/src/main/java/org/alfresco/repo/node/db/NodeStringLengthWorker.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/NodeStringLengthWorker.java
@@ -241,6 +241,12 @@ public class NodeStringLengthWorker implements ApplicationContextAware
         }
 
         @Override
+        public long getTotalEstimatedWorkSizeLong()
+        {
+            return -1;
+        }
+
+        @Override
         public Collection<NodePropertyEntity> getNextWork()
         {
             // Check that there are not too many errors

--- a/repository/src/main/java/org/alfresco/repo/security/authentication/UpgradePasswordHashWorker.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/UpgradePasswordHashWorker.java
@@ -404,6 +404,15 @@ public class UpgradePasswordHashWorker implements ApplicationContextAware, Initi
         }
 
         @Override
+        public long getTotalEstimatedWorkSizeLong()
+        {
+            // execute a query to get total number of user nodes in the system.
+            long totalUserCount = patchDAO.getCountNodesWithTypId(ContentModel.TYPE_USER);
+
+            return totalUserCount;
+        }
+
+        @Override
         public Collection<Long> getNextWork()
         {
             // Check that there are not too many errors

--- a/repository/src/main/java/org/alfresco/repo/security/person/HomeFolderProviderSynchronizer.java
+++ b/repository/src/main/java/org/alfresco/repo/security/person/HomeFolderProviderSynchronizer.java
@@ -320,8 +320,8 @@ public class HomeFolderProviderSynchronizer extends AbstractLifecycleBean
                     threadCount, peoplePerTransaction,
                     null,
                     batchLogger, 100);
-            processor.process(worker, true);
-            if (processor.getTotalErrors() > 0)
+            processor.processLong(worker, true);
+            if (processor.getTotalErrorsLong() > 0)
             {
                 logger.info("  -- Give up after error --");
                 break;
@@ -870,6 +870,12 @@ public class HomeFolderProviderSynchronizer extends AbstractLifecycleBean
 
         @Override
         public synchronized int getTotalEstimatedWorkSize()
+        {
+            return size;
+        }
+
+        @Override
+        public synchronized long getTotalEstimatedWorkSizeLong()
         {
             return size;
         }

--- a/repository/src/main/java/org/alfresco/tools/RenameUser.java
+++ b/repository/src/main/java/org/alfresco/tools/RenameUser.java
@@ -550,6 +550,12 @@ public class RenameUser extends Tool
         }
 
         @Override
+        public synchronized long getTotalEstimatedWorkSizeLong()
+        {
+            return size;
+        }
+
+        @Override
         public synchronized Collection<User> getNextWork()
         {
             if (vmShutdownLister.isVmShuttingDown())


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/ACS-1112

The current BatchProcessor works internally using "int" to count. This may be a problem when used in large data manipulations, like the ones used by the QueryAccelerator.  The current limit of int is 2,147.483.647. The code changes mainly  include full swap of "int" counting to "long" counting inside the BatchProcessor, including the related interfaces (and implementations) such as BatchMonitor: