### PR TITLE
ACS-2121 Alfresco community repo migration from Mockito 1 to Mockito 3

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/pom.xml
+++ b/amps/ags/rm-community/rm-community-repo/pom.xml
@@ -108,7 +108,7 @@
       </dependency>
       <dependency>
          <groupId>org.mockito</groupId>
-         <artifactId>mockito-all</artifactId>
+         <artifactId>mockito-core</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/action/dm/DeclareAsVersionRecordActionUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/action/dm/DeclareAsVersionRecordActionUnitTest.java
@@ -27,8 +27,8 @@
 
 package org.alfresco.module.org_alfresco_module_rm.action.dm;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -352,7 +352,7 @@ public class DeclareAsVersionRecordActionUnitTest extends BaseActionUnitTest
     private void setupMockedAspects()
     {
         doReturn(true).when(mockedNodeService).exists(actionedUponNodeRef);
-        doReturn(true).when(mockedDictionaryService).isSubClass(any(QName.class), eq(ContentModel.TYPE_CONTENT));
+        doReturn(true).when(mockedDictionaryService).isSubClass(eq(null), eq(ContentModel.TYPE_CONTENT));
         doReturn(true).when(mockedNodeService).hasAspect(actionedUponNodeRef, ContentModel.ASPECT_VERSIONABLE);
         doReturn(false).when(mockedNodeService).hasAspect(actionedUponNodeRef, ASPECT_RECORD);
         doReturn(false).when(mockedNodeService).hasAspect(actionedUponNodeRef, ContentModel.ASPECT_WORKING_COPY);

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/AddToHoldAuditEventUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/AddToHoldAuditEventUnitTest.java
@@ -38,13 +38,11 @@ import org.mockito.Mock;
 
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Unit tests for {@link AddToHoldAuditEvent}.
@@ -67,8 +65,6 @@ public class AddToHoldAuditEventUnitTest extends BaseUnitTest
     @Before
     public void setUp()
     {
-        initMocks(this);
-
         holdNodeRef = generateNodeRef();
         String holdName = "Hold " + GUID.generate();
 
@@ -87,6 +83,6 @@ public class AddToHoldAuditEventUnitTest extends BaseUnitTest
     public void testAddToHoldCausesAuditEvent()
     {
         addToHoldAuditEvent.onAddToHold(holdNodeRef, contentNodeRef);
-        verify(mockedRecordsManagementAuditService, times(1)).auditEvent(eq(contentNodeRef), any(String.class), isNull(Map.class), any(Map.class), eq(true), eq(false));
+        verify(mockedRecordsManagementAuditService, times(1)).auditEvent(eq(contentNodeRef), eq(null), eq(null), any(Map.class), eq(true), eq(false));
     }
 }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/CreateHoldAuditEventUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/CreateHoldAuditEventUnitTest.java
@@ -39,13 +39,11 @@ import org.mockito.Mock;
 
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Unit tests for {@link CreateHoldAuditEvent}.
@@ -68,8 +66,6 @@ public class CreateHoldAuditEventUnitTest extends BaseUnitTest
     @Before
     public void setUp()
     {
-        initMocks(this);
-
         holdNodeRef = generateNodeRef();
         String holdName = "Hold " + GUID.generate();
         String holdReason = "Reason " + GUID.generate();
@@ -88,6 +84,6 @@ public class CreateHoldAuditEventUnitTest extends BaseUnitTest
     public void testCreateHoldCausesAuditEvent()
     {
         createHoldAuditEvent.onCreateNode(childAssociationRef);
-        verify(mockedRecordsManagementAuditService, times(1)).auditEvent(eq(holdNodeRef), any(String.class), isNull(Map.class), any(Map.class));
+        verify(mockedRecordsManagementAuditService, times(1)).auditEvent(eq(holdNodeRef), eq(null), eq(null), any(Map.class));
     }
 }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/DeleteHoldAuditEventUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/DeleteHoldAuditEventUnitTest.java
@@ -34,18 +34,15 @@ import org.alfresco.util.GUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Unit tests for {@link DeleteHoldAuditEvent}.
@@ -67,8 +64,6 @@ public class DeleteHoldAuditEventUnitTest extends BaseUnitTest
     @Before
     public void setUp()
     {
-        initMocks(this);
-
         holdNodeRef = generateNodeRef();
         String holdName = "Hold " + GUID.generate();
 
@@ -84,6 +79,6 @@ public class DeleteHoldAuditEventUnitTest extends BaseUnitTest
     {
         deleteHoldAuditEvent.beforeDeleteNode(holdNodeRef);
         verify(mockedRecordsManagementAuditService, times(1))
-            .auditEvent(eq(holdNodeRef), any(String.class), any(Map.class), isNull(Map.class), Matchers.eq(true), Matchers.eq(false));
+            .auditEvent(eq(holdNodeRef), eq(null), any(Map.class), eq(null), eq(true), eq(false));
     }
 }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/RemoveFromHoldAuditEventUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/audit/event/RemoveFromHoldAuditEventUnitTest.java
@@ -27,25 +27,25 @@
 
 package org.alfresco.module.org_alfresco_module_rm.audit.event;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Map;
 
 import org.alfresco.module.org_alfresco_module_rm.test.util.BaseUnitTest;
-import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.util.GUID;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Unit tests for {@link RemoveFromHoldAuditEvent}.
@@ -53,6 +53,7 @@ import org.mockito.Mock;
  * @author Chris Shields
  * @since 3.3
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RemoveFromHoldAuditEventUnitTest extends BaseUnitTest
 {
     @InjectMocks
@@ -70,16 +71,14 @@ public class RemoveFromHoldAuditEventUnitTest extends BaseUnitTest
     @Before
     public void setUp()
     {
-        initMocks(this);
-
         holdNodeRef = generateNodeRef();
         String holdName = "Hold " + GUID.generate();
 
         contentNodeRef = generateNodeRef();
         String contentName = "Content " + GUID.generate();
 
-        when(mockedNodeService.getProperty(holdNodeRef, PROP_NAME)).thenReturn(holdName);
-        when(mockedNodeService.getProperty(contentNodeRef, PROP_NAME)).thenReturn(contentName);
+        lenient().when(mockedNodeService.getProperty(holdNodeRef, PROP_NAME)).thenReturn(holdName);
+        lenient().when(mockedNodeService.getProperty(contentNodeRef, PROP_NAME)).thenReturn(contentName);
     }
 
     /**
@@ -89,7 +88,7 @@ public class RemoveFromHoldAuditEventUnitTest extends BaseUnitTest
     public void testRemoveFromHoldCausesAuditEvent()
     {
         removeFromHoldAuditEvent.onRemoveFromHold(holdNodeRef, contentNodeRef);
-        verify(mockedRecordsManagementAuditService, times(1)).auditEvent(eq(contentNodeRef), any(String.class), any(Map.class), isNull(Map.class), eq(true));
+        verify(mockedRecordsManagementAuditService, times(1)).auditEvent(eq(contentNodeRef), eq(null), any(Map.class), eq(null), eq(true));
     }
 
 }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/forms/RecordsManagementTypeFormFilterUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/forms/RecordsManagementTypeFormFilterUnitTest.java
@@ -28,14 +28,15 @@
 package org.alfresco.module.org_alfresco_module_rm.forms;
 
 import static org.alfresco.module.org_alfresco_module_rm.test.util.AlfMock.generateQName;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -45,13 +46,11 @@ import java.util.Map;
 
 import org.alfresco.module.org_alfresco_module_rm.admin.RecordsManagementAdminService;
 import org.alfresco.module.org_alfresco_module_rm.test.util.BaseUnitTest;
-import org.alfresco.repo.forms.Field;
 import org.alfresco.repo.forms.FieldDefinition;
 import org.alfresco.repo.forms.Form;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.dictionary.TypeDefinition;
-import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -81,7 +80,7 @@ public class RecordsManagementTypeFormFilterUnitTest extends BaseUnitTest
     public void testAddCustomRMPropertiesNoneFound()
     {        
         typeFormFilter.addCustomRMProperties(MY_CUSTOM_TYPE, mockForm);
-        verifyZeroInteractions(mockForm);        
+        verifyNoMoreInteractions(mockForm);
     }
     
     /**
@@ -130,8 +129,8 @@ public class RecordsManagementTypeFormFilterUnitTest extends BaseUnitTest
         
         typeFormFilter.afterGenerate(mockTypeDefinition, null, null, mockForm, null);
         
-        verify(mockedIdentifierService).generateIdentifier(any(QName.class), any(NodeRef.class));
-        verify(idDef).setDefaultValue(anyString());
+        verify(mockedIdentifierService).generateIdentifier(eq(null), eq(null));
+        verify(idDef).setDefaultValue(eq(null));
         verify(vrDef).setDefaultValue(Boolean.FALSE.toString());
         verify(rpDef).setDefaultValue("none|0");
     }
@@ -162,7 +161,7 @@ public class RecordsManagementTypeFormFilterUnitTest extends BaseUnitTest
         typeFormFilter.addCustomRMProperties(MY_CUSTOM_TYPE, mockForm);
         
         // ensure that two custom properties have been added to the form
-        verify(mockForm, times(1)).addFields(anyListOf(Field.class));       
+        verify(mockForm, times(1)).addFields(anyList());
     }
     
     /**

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
@@ -30,16 +30,16 @@ package org.alfresco.module.org_alfresco_module_rm.job;
 import static org.alfresco.module.org_alfresco_module_rm.test.util.AlfMock.generateQName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -57,7 +57,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 
@@ -98,7 +97,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
             return callback.execute();
         };
         doAnswer(doInTransactionAnswer).when(mockedRetryingTransactionHelper).doInTransaction(any(RetryingTransactionCallback.class),
-            Matchers.anyBoolean(), Matchers.anyBoolean());
+            anyBoolean(), anyBoolean());
 
         // setup data
         List<String> dispositionActions = buildList(CUTOFF, RETAIN);
@@ -141,7 +140,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         verifyQueryTimes(1);
 
         // ensure nothing else happens becuase we have no results
-        verifyZeroInteractions(mockedNodeService, mockedRecordFolderService, mockedRetryingTransactionHelper);
+        verifyNoMoreInteractions(mockedNodeService, mockedRecordFolderService, mockedRetryingTransactionHelper);
     }
 
     /**
@@ -178,7 +177,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         // ensure work is executed in transaction for each node processed
         verify(mockedNodeService, times(2)).exists(any(NodeRef.class));
         verify(mockedRetryingTransactionHelper, times(2)).doInTransaction(any(RetryingTransactionCallback.class),
-            Matchers.anyBoolean(), Matchers.anyBoolean());
+            anyBoolean(), anyBoolean());
 
         // ensure each node is process correctly
         verify(mockedNodeService, times(1)).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
@@ -186,7 +185,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
 
         // ensure no more interactions
         verifyNoMoreInteractions(mockedNodeService);
-        verifyZeroInteractions(mockedRecordsManagementActionService);
+        verifyNoMoreInteractions(mockedRecordsManagementActionService);
 
     }
 
@@ -216,7 +215,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
 
         // ensure no more interactions
         verifyNoMoreInteractions(mockedNodeService);
-        verifyZeroInteractions(mockedRecordsManagementActionService);
+        verifyNoMoreInteractions(mockedRecordsManagementActionService);
     }
 
     /**
@@ -258,7 +257,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         // ensure work is executed in transaction for each node processed
         verify(mockedNodeService, times(2)).exists(any(NodeRef.class));
         verify(mockedRetryingTransactionHelper, times(2)).doInTransaction(any(RetryingTransactionCallback.class),
-            Matchers.anyBoolean(), Matchers.anyBoolean());
+            anyBoolean(), anyBoolean());
 
         // ensure each node is process correctly
         // node1
@@ -307,7 +306,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
 
         // mock the search service to return the right page
         when(mockedSearchService.query(any(SearchParameters.class))).thenAnswer((Answer<ResultSet>) invocation -> {
-            SearchParameters params = invocation.getArgumentAt(0, SearchParameters.class);
+            SearchParameters params = invocation.getArgument(0, SearchParameters.class);
             if (params.getSkipCount() == 0)
             {
                 // mock first page

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/model/rma/aspect/RecordAspectUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/model/rma/aspect/RecordAspectUnitTest.java
@@ -33,7 +33,6 @@ import static org.alfresco.module.org_alfresco_module_rm.model.RecordsManagement
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.module.org_alfresco_module_rm.security.ExtendedSecurityService;
@@ -43,14 +42,17 @@ import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Unit tests for the {@link RecordAspect}.
  *
  * @author Claudia Agache
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RecordAspectUnitTest
 {
     private static final NodeRef NODE_REF = new NodeRef("node://Ref/");
@@ -72,7 +74,7 @@ public class RecordAspectUnitTest
     @Before
     public void setUp()
     {
-        initMocks(this);
+        recordAspect.setNodeService(mockNodeService);
     }
 
     /** Check that the bin is duplicated before adding the aspect if the file has a copy. */

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/model/rma/type/NonElectronicRecordTypeUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/model/rma/type/NonElectronicRecordTypeUnitTest.java
@@ -45,13 +45,15 @@ import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.util.GUID;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author silviudinuta
  */
+@RunWith(MockitoJUnitRunner.class)
 public class NonElectronicRecordTypeUnitTest implements RecordsManagementModel, ContentModel
 {
     private final static NodeRef CHILD_NODE_REF = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE,
@@ -74,17 +76,15 @@ public class NonElectronicRecordTypeUnitTest implements RecordsManagementModel, 
     @Before
     public void setUp()
     {
-        MockitoAnnotations.initMocks(this);
         MockAuthenticationUtilHelper.setup(mockAuthenticationUtil);
         when(mockedNodeService.exists(CHILD_NODE_REF)).thenReturn(true);
-        when(mockedNodeService.exists(PARENT_NODE_REF)).thenReturn(true);
 
         ChildAssociationRef generateChildAssociationRef = mock(ChildAssociationRef.class);
         when(generateChildAssociationRef.getParentRef()).thenReturn(PARENT_NODE_REF);
-        when(generateChildAssociationRef.getChildRef()).thenReturn(CHILD_NODE_REF);
 
         when(mockedNodeService.getPrimaryParent(CHILD_NODE_REF)).thenReturn(generateChildAssociationRef);
         when(mockedNodeService.getType(PARENT_NODE_REF)).thenReturn(TYPE_UNFILED_RECORD_FOLDER);
+        nonElectronicRecordType.setNodeService(mockedNodeService);
     }
 
     @Test

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/script/hold/BaseHoldWebScriptUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/script/hold/BaseHoldWebScriptUnitTest.java
@@ -27,6 +27,7 @@
 
 package org.alfresco.module.org_alfresco_module_rm.script.hold;
 
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -71,8 +72,8 @@ public abstract class BaseHoldWebScriptUnitTest extends BaseWebScriptUnitTest
 
         // generate active content
         dmNodeRef = generateNodeRef(TYPE_CONTENT);
-        when(mockedExtendedPermissionService.hasPermission(dmNodeRef, PermissionService.WRITE)).thenReturn(AccessStatus.ALLOWED);
-        when(mockedDictionaryService.isSubClass(mockedNodeService.getType(dmNodeRef), ContentModel.TYPE_CONTENT)).thenReturn(true);
+        lenient().when(mockedExtendedPermissionService.hasPermission(dmNodeRef, PermissionService.WRITE)).thenReturn(AccessStatus.ALLOWED);
+        lenient().when(mockedDictionaryService.isSubClass(mockedNodeService.getType(dmNodeRef), ContentModel.TYPE_CONTENT)).thenReturn(true);
 
         // list of active contents
         activeContents = Collections.singletonList(dmNodeRef);

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/script/hold/HoldPutUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/script/hold/HoldPutUnitTest.java
@@ -37,9 +37,12 @@ import java.util.List;
 
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.extensions.webscripts.DeclarativeWebScript;
 
 /**
@@ -48,6 +51,7 @@ import org.springframework.extensions.webscripts.DeclarativeWebScript;
  * @author Roy Wetherall
  * @since 2.2
  */
+@RunWith(MockitoJUnitRunner.class)
 public class HoldPutUnitTest extends BaseHoldWebScriptWithContentUnitTest
 {
     /** classpath location of ftl template for web script */
@@ -77,6 +81,12 @@ public class HoldPutUnitTest extends BaseHoldWebScriptWithContentUnitTest
     /**
      * Test that a record can be removed from holds.
      */
+
+    @Before
+    public void setUp(){
+        webScript.setHoldService(mockedHoldService);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void removeRecordFromHolds() throws Exception

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImplUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImplUnitTest.java
@@ -34,11 +34,12 @@ import static org.alfresco.service.cmr.security.PermissionService.GROUP_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anySet;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -75,10 +76,11 @@ import org.alfresco.service.namespace.RegexQNamePattern;
 import org.alfresco.service.transaction.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -89,6 +91,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
  * @author Roy Wetherall
  * @since 2.5
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ExtendedSecurityServiceImplUnitTest
 {
     /** service mocks*/
@@ -145,9 +148,6 @@ public class ExtendedSecurityServiceImplUnitTest
     @SuppressWarnings("unchecked")
     @Before public void before()
     {
-        // initialise mocks 
-        MockitoAnnotations.initMocks(this);
-        
         // setup node
         nodeRef = AlfMock.generateNodeRef(mockedNodeService);
         
@@ -157,7 +157,7 @@ public class ExtendedSecurityServiceImplUnitTest
             .thenReturn(filePlan);
         
         // set-up application context
-        when(mockedApplicationContext.getBean("dbNodeService"))
+        lenient().when(mockedApplicationContext.getBean("dbNodeService"))
             .thenReturn(mockedNodeService);
 
         // setup retrying transaction helper
@@ -199,6 +199,7 @@ public class ExtendedSecurityServiceImplUnitTest
             .forEach((a) -> 
                when(mockedAuthorityService.authorityExists(a))
                    .thenReturn(true));
+        extendedSecurityService.setNodeService(mockedNodeService);
     }
     
     /**
@@ -481,7 +482,7 @@ public class ExtendedSecurityServiceImplUnitTest
         .thenReturn(mockedWritePagingResults);
         
         // setup exact match
-        when(mockedAuthorityService.authorityExists(GROUP_PREFIX + writeGroup))
+        lenient().when(mockedAuthorityService.authorityExists(GROUP_PREFIX + writeGroup))
             .thenReturn(true);
         when(mockedAuthorityService.getContainedAuthorities(null, GROUP_PREFIX + readGroup, true))
             .thenReturn(Stream
@@ -560,7 +561,7 @@ public class ExtendedSecurityServiceImplUnitTest
         .thenReturn(mockedWritePagingResults);
         
         // setup exact match
-        when(mockedAuthorityService.authorityExists(GROUP_PREFIX + writeGroup))
+        lenient().when(mockedAuthorityService.authorityExists(GROUP_PREFIX + writeGroup))
             .thenReturn(true);
         when(mockedAuthorityService.getContainedAuthorities(null, GROUP_PREFIX + readGroup, true))
             .thenReturn(Stream
@@ -651,7 +652,7 @@ public class ExtendedSecurityServiceImplUnitTest
         .thenReturn(mockedWritePagingResults);
 
         // setup exact match
-        when(mockedAuthorityService.authorityExists(GROUP_PREFIX + writeGroup))
+        lenient().when(mockedAuthorityService.authorityExists(GROUP_PREFIX + writeGroup))
             .thenReturn(true);
         when(mockedAuthorityService.getContainedAuthorities(null, GROUP_PREFIX + readGroup, true))
             .thenReturn(Stream

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/AlfMock.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/AlfMock.java
@@ -27,8 +27,9 @@
 
 package org.alfresco.module.org_alfresco_module_rm.test.util;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
@@ -119,7 +120,7 @@ public class AlfMock
     public static NodeRef generateNodeRef(NodeService mockedNodeService, QName type, boolean exists)
     {
         NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, GUID.generate());
-        when(mockedNodeService.exists(eq(nodeRef))).thenReturn(exists);
+        lenient().when(mockedNodeService.exists(eq(nodeRef))).thenReturn(exists);
         if (type != null)
         {
             when(mockedNodeService.getType(eq(nodeRef))).thenReturn(type);

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/BaseUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/BaseUnitTest.java
@@ -28,10 +28,10 @@
 package org.alfresco.module.org_alfresco_module_rm.test.util;
 
 import static org.alfresco.module.org_alfresco_module_rm.test.util.AlfMock.generateQName;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -168,7 +168,7 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
         MockitoAnnotations.initMocks(this);
 
         // setup application context
-        doReturn(mockedNodeService).when(mockedApplicationContext).getBean("dbNodeService");
+        lenient().doReturn(mockedNodeService).when(mockedApplicationContext).getBean("dbNodeService");
 
         // setup retrying transaction helper
         Answer<Object> doInTransactionAnswer = new Answer<Object>()
@@ -181,7 +181,7 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
                 return callback.execute();
             }
         };
-        doAnswer(doInTransactionAnswer).when(mockedRetryingTransactionHelper).<Object>doInTransaction(any(RetryingTransactionCallback.class));
+        lenient().doAnswer(doInTransactionAnswer).when(mockedRetryingTransactionHelper).<Object>doInTransaction(any(RetryingTransactionCallback.class));
 
         // setup mocked authentication util
         MockAuthenticationUtilHelper.setup(mockedAuthenticationUtil);
@@ -189,15 +189,15 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
         // setup file plan
         filePlan = generateNodeRef(TYPE_FILE_PLAN);
         setupAsFilePlanComponent(filePlan);
-        doReturn(true).when(mockedFilePlanService).isFilePlan(filePlan);
+        lenient().doReturn(true).when(mockedFilePlanService).isFilePlan(filePlan);
 
         // setup basic file plan component
         filePlanComponent = generateNodeRef();
         setupAsFilePlanComponent(filePlanComponent);
 
         // setup namespace service
-        doReturn(RM_URI).when(mockedNamespaceService).getNamespaceURI(RM_PREFIX);
-        doReturn(CollectionUtils.unmodifiableSet(RM_PREFIX)).when(mockedNamespaceService).getPrefixes(RM_URI);
+        lenient().doReturn(RM_URI).when(mockedNamespaceService).getNamespaceURI(RM_PREFIX);
+        lenient().doReturn(CollectionUtils.unmodifiableSet(RM_PREFIX)).when(mockedNamespaceService).getPrefixes(RM_URI);
 
         // setup record folder and record
         recordFolder = generateRecordFolder();
@@ -206,10 +206,10 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
         // set record as child of record folder
         List<ChildAssociationRef> result = new ArrayList<>(1);
         result.add(new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, recordFolder, generateQName(RM_URI), record, true, 1));
-        doReturn(result).when(mockedNodeService).getChildAssocs(eq(recordFolder), eq(ContentModel.ASSOC_CONTAINS), any(QNamePattern.class));
-        doReturn(result).when(mockedNodeService).getParentAssocs(record);
-        doReturn(Collections.singletonList(recordFolder)).when(mockedRecordFolderService).getRecordFolders(record);
-        doReturn(Collections.singletonList(record)).when(mockedRecordService).getRecords(recordFolder);
+        lenient().doReturn(result).when(mockedNodeService).getChildAssocs(eq(recordFolder), eq(ContentModel.ASSOC_CONTAINS), any(QNamePattern.class));
+        lenient().doReturn(result).when(mockedNodeService).getParentAssocs(record);
+        lenient().doReturn(Collections.singletonList(recordFolder)).when(mockedRecordFolderService).getRecordFolders(record);
+        lenient().doReturn(Collections.singletonList(record)).when(mockedRecordService).getRecords(recordFolder);
     }
 
     /**
@@ -221,7 +221,7 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
     protected NodeRef generateHoldNodeRef(String name)
     {
         NodeRef hold = generateNodeRef(TYPE_HOLD);
-        doReturn(name).when(mockedNodeService).getProperty(hold, ContentModel.PROP_NAME);
+        lenient().doReturn(name).when(mockedNodeService).getProperty(hold, ContentModel.PROP_NAME);
         doReturn(true).when(mockedHoldService).isHold(hold);
         return hold;
     }
@@ -235,7 +235,7 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
     {
         NodeRef recordFolder = generateNodeRef(TYPE_RECORD_FOLDER);
         setupAsFilePlanComponent(recordFolder);
-        doReturn(true).when(mockedRecordFolderService).isRecordFolder(recordFolder);
+        lenient().doReturn(true).when(mockedRecordFolderService).isRecordFolder(recordFolder);
         return recordFolder;
     }
 
@@ -248,8 +248,8 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
     {
         NodeRef record = generateNodeRef(ContentModel.TYPE_CONTENT);
         setupAsFilePlanComponent(record);
-        doReturn(true).when(mockedNodeService).hasAspect(record, ASPECT_RECORD);
-        doReturn(true).when(mockedRecordService).isRecord(record);
+        lenient().doReturn(true).when(mockedNodeService).hasAspect(record, ASPECT_RECORD);
+        lenient().doReturn(true).when(mockedRecordService).isRecord(record);
         return record;
     }
 
@@ -260,10 +260,10 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
      */
     protected void setupAsFilePlanComponent(NodeRef nodeRef)
     {
-        doReturn(true).when(mockedNodeService).hasAspect(nodeRef, ASPECT_FILE_PLAN_COMPONENT);
-        doReturn(true).when(mockedFilePlanService).isFilePlanComponent(nodeRef);
-        doReturn(filePlan).when(mockedFilePlanService).getFilePlan(nodeRef);
-        doReturn(filePlan).when(mockedNodeService).getProperty(nodeRef, PROP_ROOT_NODEREF);
+        lenient().doReturn(true).when(mockedNodeService).hasAspect(nodeRef, ASPECT_FILE_PLAN_COMPONENT);
+        lenient().doReturn(true).when(mockedFilePlanService).isFilePlanComponent(nodeRef);
+        lenient().doReturn(filePlan).when(mockedFilePlanService).getFilePlan(nodeRef);
+        lenient().doReturn(filePlan).when(mockedNodeService).getProperty(nodeRef, PROP_ROOT_NODEREF);
     }
 
     /**
@@ -297,7 +297,7 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
     protected NodeRef generateCmContent(String name)
     {
         NodeRef nodeRef = generateNodeRef(ContentModel.TYPE_CONTENT, true);
-        doReturn(name).when(mockedNodeService).getProperty(nodeRef, ContentModel.PROP_NAME);
+        lenient().doReturn(name).when(mockedNodeService).getProperty(nodeRef, ContentModel.PROP_NAME);
         return nodeRef;
     }
 
@@ -312,11 +312,11 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
     protected NodeRef generateNodeRef(QName type, boolean exists)
     {
         NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, GUID.generate());
-        when(mockedNodeService.exists(eq(nodeRef))).thenReturn(exists);
+        lenient().when(mockedNodeService.exists(eq(nodeRef))).thenReturn(exists);
         if (type != null)
         {
-            when(mockedNodeService.getType(eq(nodeRef))).thenReturn(type);
-            when(mockedNodeTypeUtility.instanceOf(type, type)).thenReturn(true);
+            lenient().when(mockedNodeService.getType(eq(nodeRef))).thenReturn(type);
+            lenient().when(mockedNodeTypeUtility.instanceOf(type, type)).thenReturn(true);
         }
         return nodeRef;
     }
@@ -334,7 +334,7 @@ public class BaseUnitTest implements RecordsManagementModel, ContentModel
 
         if (parent != null)
         {
-            doReturn(parent).when(mockedChildAssociationRef).getParentRef();
+            lenient().doReturn(parent).when(mockedChildAssociationRef).getParentRef();
         }
 
         if (child != null)

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/BaseWebScriptUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/BaseWebScriptUnitTest.java
@@ -29,10 +29,12 @@ package org.alfresco.module.org_alfresco_module_rm.test.util;
 
 import static java.util.Collections.emptyMap;
 
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -191,7 +193,7 @@ public abstract class BaseWebScriptUnitTest extends BaseUnitTest
         
         String [] paramNames = (String[])parameters.keySet().toArray(new String[parameters.size()]);
         doReturn(paramNames).when(mockedRequest).getParameterNames();
-        doAnswer(new Answer()
+        lenient().doAnswer(new Answer()
         {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable
@@ -230,10 +232,10 @@ public abstract class BaseWebScriptUnitTest extends BaseUnitTest
     protected Container getMockedContainer(String template) throws Exception
     {
         FormatRegistry mockedFormatRegistry = mock(FormatRegistry.class);
-        doReturn("application/json").when(mockedFormatRegistry).getMimeType(anyString(), anyString());
+        doReturn("application/json").when(mockedFormatRegistry).getMimeType(nullable(String.class), nullable(String.class));
         
         ScriptProcessorRegistry mockedScriptProcessorRegistry = mock(ScriptProcessorRegistry.class);
-        doReturn(null).when(mockedScriptProcessorRegistry).findValidScriptPath(anyString());
+        lenient().doReturn(null).when(mockedScriptProcessorRegistry).findValidScriptPath(anyString());
         
         TemplateProcessorRegistry mockedTemplateProcessorRegistry = mock(TemplateProcessorRegistry.class);
         doReturn(template).when(mockedTemplateProcessorRegistry).findValidTemplatePath(anyString());
@@ -266,7 +268,7 @@ public abstract class BaseWebScriptUnitTest extends BaseUnitTest
         
         // setup description
         Description mockDescription = mock(Description.class);
-        doReturn(mock(RequiredCache.class)).when(mockDescription).getRequiredCache();
+        lenient().doReturn(mock(RequiredCache.class)).when(mockDescription).getRequiredCache();
         
         return mockedContainer;
     }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/MockAuthenticationUtilHelper.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/test/util/MockAuthenticationUtilHelper.java
@@ -27,11 +27,10 @@
 
 package org.alfresco.module.org_alfresco_module_rm.test.util;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
 import org.alfresco.module.org_alfresco_module_rm.util.AuthenticationUtil;
 import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
@@ -74,7 +73,7 @@ public class MockAuthenticationUtilHelper
         reset(mockAuthenticationUtil);
 
         // just do the work
-        doAnswer(new Answer<Object>()
+        lenient().doAnswer(new Answer<Object>()
         {
             @SuppressWarnings("rawtypes")
             @Override
@@ -87,7 +86,7 @@ public class MockAuthenticationUtilHelper
         }).when(mockAuthenticationUtil).<Object> runAsSystem(any(RunAsWork.class));
 
         // just do the work
-        doAnswer(new Answer<Object>()
+        lenient().doAnswer(new Answer<Object>()
         {
             @SuppressWarnings("rawtypes")
             @Override
@@ -99,10 +98,10 @@ public class MockAuthenticationUtilHelper
 
         }).when(mockAuthenticationUtil).<Object> runAs(any(RunAsWork.class), anyString());
 
-        when(mockAuthenticationUtil.getAdminUserName()).thenReturn(ADMIN_USER);
-        when(mockAuthenticationUtil.getFullyAuthenticatedUser()).thenReturn(fullyAuthenticatedUser);
-        when(mockAuthenticationUtil.getRunAsUser()).thenReturn(fullyAuthenticatedUser);
-        when(mockAuthenticationUtil.getSystemUserName()).thenReturn(SYSTEM_USER);
-        when(mockAuthenticationUtil.getGuestUserName()).thenReturn(GUEST_USER);
+        lenient().when(mockAuthenticationUtil.getAdminUserName()).thenReturn(ADMIN_USER);
+        lenient().when(mockAuthenticationUtil.getFullyAuthenticatedUser()).thenReturn(fullyAuthenticatedUser);
+        lenient().when(mockAuthenticationUtil.getRunAsUser()).thenReturn(fullyAuthenticatedUser);
+        lenient().when(mockAuthenticationUtil.getSystemUserName()).thenReturn(SYSTEM_USER);
+        lenient().when(mockAuthenticationUtil.getGuestUserName()).thenReturn(GUEST_USER);
     }
 }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/util/ContentBinDuplicationUtilityUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/util/ContentBinDuplicationUtilityUnitTest.java
@@ -87,6 +87,7 @@ public class ContentBinDuplicationUtilityUnitTest
     public void setUp()
     {
         MockitoAnnotations.initMocks(this);
+        contentBinDuplicationUtility.setNodeService(mockNodeService);
     }
 
     /**

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/version/RecordableVersionServiceImplUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/version/RecordableVersionServiceImplUnitTest.java
@@ -29,10 +29,11 @@ package org.alfresco.module.org_alfresco_module_rm.version;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -52,7 +53,6 @@ import org.alfresco.module.org_alfresco_module_rm.test.util.BaseUnitTest;
 import org.alfresco.repo.version.Version2Model;
 import org.alfresco.repo.version.VersionModel;
 import org.alfresco.repo.version.common.VersionImpl;
-import org.alfresco.service.cmr.model.FileInfo;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
@@ -61,9 +61,11 @@ import org.alfresco.service.cmr.version.VersionType;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Recordable version service implementation unit test.
@@ -71,6 +73,7 @@ import org.mockito.Spy;
  * @author Roy Wetherall
  * @since 2.3
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
 {
     /** versioned content name */
@@ -108,34 +111,23 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
         recordableVersionService.initialise();
 
         doReturn(generateChildAssociationRef(null, generateNodeRef(Version2Model.TYPE_QNAME_VERSION_HISTORY)))
-            .when(mockedDbNodeService).createNode(any(NodeRef.class),
-                                                  any(QName.class),
-                                                  any(QName.class),
+            .when(mockedDbNodeService).createNode(nullable(NodeRef.class),
+                                                  nullable(QName.class),
+                                                  nullable(QName.class),
                                                   eq(Version2Model.TYPE_QNAME_VERSION_HISTORY),
-                                                  anyMap());
-        doReturn(generateChildAssociationRef(null, generateNodeRef(TYPE_CONTENT)))
-        .when(mockedDbNodeService).createNode(any(NodeRef.class),
-                                              any(QName.class),
-                                              any(QName.class),
-                                              eq(TYPE_CONTENT),
-                                              anyMap());
+                                                  nullable(Map.class));
 
         doReturn(filePlan).when(mockedFilePlanService).getFilePlanBySiteId(FilePlanService.DEFAULT_RM_SITE_ID);
-        doReturn(unfiledRecordContainer).when(mockedFilePlanService).getUnfiledContainer(any(NodeRef.class));
 
         record = generateCmContent(CONTENT_NAME);
-        FileInfo mockedFileInfo = mock(FileInfo.class);
-        doReturn(record).when(mockedFileInfo).getNodeRef();
-        doReturn(mockedFileInfo).when(mockedFileFolderService).copy(any(NodeRef.class),
-                                                                    any(NodeRef.class),
-                                                                    any(String.class));
         version = generateNodeRef(TYPE_CONTENT);
         doReturn(generateChildAssociationRef(null, version)).when(mockedDbNodeService).createNode(
-                                                                any(NodeRef.class),
+                                                                nullable(NodeRef.class),
                                                                 eq(Version2Model.CHILD_QNAME_VERSIONS),
-                                                                any(QName.class),
+                                                                nullable(QName.class),
                                                                 eq(TYPE_CONTENT),
-                                                                anyMap());
+                                                                nullable(Map.class));
+        recordableVersionService.setDbNodeService(mockedDbNodeService);
     }
 
     /**
@@ -167,7 +159,6 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
      {
          // setup given conditions
          doReturn(false).when(mockedNodeService).hasAspect(nodeRef, RecordableVersionModel.ASPECT_VERSIONABLE);
-         doReturn(null).when(mockedNodeService).getProperty(nodeRef, RecordableVersionModel.PROP_RECORDABLE_VERSION_POLICY);
          versionProperties.put(VersionModel.PROP_VERSION_TYPE, VersionType.MINOR);
 
          // when version is created
@@ -357,7 +348,6 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
     public void filePlanSpecifiedNoPolicy() throws Exception
     {
         // setup given conditions
-        doReturn(true).when(mockedNodeService).hasAspect(nodeRef, RecordableVersionModel.ASPECT_VERSIONABLE);
         versionProperties.put(VersionModel.PROP_VERSION_TYPE, VersionType.MAJOR);
         versionProperties.put(RecordableVersionServiceImpl.KEY_RECORDABLE_VERSION, true);
 
@@ -376,7 +366,6 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
     public void adHocRecordedVersionNoPolicy() throws Exception
     {
         // setup given conditions
-        doReturn(true).when(mockedNodeService).hasAspect(nodeRef, RecordableVersionModel.ASPECT_VERSIONABLE);
         versionProperties.put(VersionModel.PROP_VERSION_TYPE, VersionType.MAJOR);
         versionProperties.put(RecordableVersionServiceImpl.KEY_RECORDABLE_VERSION, true);
 
@@ -391,8 +380,6 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
     public void adHocRecordedVersionOverridePolicy() throws Exception
     {
         // setup given conditions
-        doReturn(true).when(mockedNodeService).hasAspect(nodeRef, RecordableVersionModel.ASPECT_VERSIONABLE);
-        doReturn(RecordableVersionPolicy.MAJOR_ONLY.toString()).when(mockedNodeService).getProperty(nodeRef, RecordableVersionModel.PROP_RECORDABLE_VERSION_POLICY);
         versionProperties.put(VersionModel.PROP_VERSION_TYPE, VersionType.MINOR);
         versionProperties.put(RecordableVersionServiceImpl.KEY_RECORDABLE_VERSION, true);
 
@@ -461,16 +448,15 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
         // latest version is not recorded
         Version mockedVersion = mock(VersionImpl.class);
         NodeRef versionNodeRef = generateNodeRef();
-        doReturn(Collections.emptyMap()).when(mockedVersion).getVersionProperties();        
         doReturn(true).when(mockedNodeService).hasAspect(nodeRef, ContentModel.ASPECT_VERSIONABLE);
         
         // version history
         NodeRef versionHistoryNodeRef = generateNodeRef();
-        doReturn(versionHistoryNodeRef).when(mockedDbNodeService).getChildByName(any(NodeRef.class), eq(Version2Model.CHILD_QNAME_VERSION_HISTORIES), any(String.class));
+        doReturn(versionHistoryNodeRef).when(mockedDbNodeService).getChildByName(nullable(NodeRef.class), eq(Version2Model.CHILD_QNAME_VERSION_HISTORIES), nullable(String.class));
         
         // version number
         doReturn(mockedVersion).when(recordableVersionService).getCurrentVersion(nodeRef);
-        doReturn(versionNodeRef).when(recordableVersionService).convertNodeRef(any(NodeRef.class));
+        doReturn(versionNodeRef).when(recordableVersionService).convertNodeRef(nullable(NodeRef.class));
         makePrimaryParentOf(versionNodeRef, versionHistoryNodeRef, ContentModel.ASSOC_CONTAINS, QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "something-0"), mockedDbNodeService);
         
         // created version
@@ -478,18 +464,18 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
         doReturn(generateChildAssociationRef(versionHistoryNodeRef, newVersionNodeRef)).when(mockedDbNodeService).createNode(
                 eq(versionHistoryNodeRef),
                 eq(Version2Model.CHILD_QNAME_VERSIONS),
-                any(QName.class),
-                any(QName.class),
-                any(Map.class));
+                nullable(QName.class),
+                nullable(QName.class),
+                nullable(Map.class));
         
         // created record
         NodeRef newRecordNodeRef = generateNodeRef();
         doReturn(newRecordNodeRef).when(mockedRecordService).createRecordFromContent(
-                eq(filePlan), 
-                any(String.class), 
-                any(QName.class), 
-                any(Map.class), 
-                any(ContentReader.class));
+                eq(filePlan),
+                nullable(String.class),
+                nullable(QName.class),
+                nullable(Map.class),
+                nullable(ContentReader.class));
                 
         // create record from version
         recordableVersionService.createRecordFromLatestVersion(filePlan, nodeRef);
@@ -497,17 +483,17 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
         // verify that the version is converted to a recorded version
         verify(mockedRecordService, times(1)).createRecordFromContent(
                 eq(filePlan), 
-                any(String.class), 
-                any(QName.class), 
+                eq(null),
+                eq(null),
                 any(Map.class), 
-                any(ContentReader.class));
+                eq(null));
         verify(mockedDbNodeService, times(1)).deleteNode(any(NodeRef.class));
         verify(mockedDbNodeService, times(1)).createNode(
                 eq(versionHistoryNodeRef),
                 eq(Version2Model.CHILD_QNAME_VERSIONS),
-                any(QName.class),
-                any(QName.class),
-                any(Map.class));
+                nullable(QName.class),
+                nullable(QName.class),
+                nullable(Map.class));
         verify(mockedNodeService, times(1)).addAspect(eq(newVersionNodeRef), eq(Version2Model.ASPECT_VERSION), any(Map.class));
         verify(mockedNodeService, times(1)).addAspect(
                 newVersionNodeRef, 
@@ -605,19 +591,12 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
         // set up version
         Version mockedVersion = mock(VersionImpl.class);
         NodeRef versionNodeRef = generateNodeRef();
-        NodeRef versionRecordNodeRef = generateNodeRef();
         when(mockedVersion.getFrozenStateNodeRef())
             .thenReturn(versionNodeRef);
-        when(mockedDbNodeService.exists(versionRecordNodeRef))
-            .thenReturn(true);
-        
+
         // indicate that the version doesn't have the aspect
         when(mockedDbNodeService.hasAspect(versionNodeRef, RecordableVersionModel.ASPECT_RECORDED_VERSION))
             .thenReturn(true);
-        
-        // indicate that the associated version record exists
-        when(mockedDbNodeService.getProperty(versionNodeRef, RecordableVersionModel.PROP_RECORD_NODE_REF))
-            .thenReturn(versionRecordNodeRef);
         
         // mark as destroyed
         recordableVersionService.destroyRecordedVersion(mockedVersion);
@@ -643,19 +622,12 @@ public class RecordableVersionServiceImplUnitTest extends BaseUnitTest
         // set up version
         Version mockedVersion = mock(VersionImpl.class);
         NodeRef versionNodeRef = generateNodeRef();
-        NodeRef versionRecordNodeRef = generateNodeRef();
         when(mockedVersion.getFrozenStateNodeRef())
             .thenReturn(versionNodeRef);
-        when(mockedDbNodeService.exists(versionRecordNodeRef))
-            .thenReturn(false);
-        
+
         // indicate that the version doesn't have the aspect
         when(mockedDbNodeService.hasAspect(versionNodeRef, RecordableVersionModel.ASPECT_RECORDED_VERSION))
             .thenReturn(true);
-        
-        // indicate that the associated version record exists
-        when(mockedDbNodeService.getProperty(versionNodeRef, RecordableVersionModel.PROP_RECORD_NODE_REF))
-            .thenReturn(versionRecordNodeRef);
         
         // mark as destroyed
         recordableVersionService.destroyRecordedVersion(mockedVersion);

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/repo/web/scripts/roles/DynamicAuthoritiesGetUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/repo/web/scripts/roles/DynamicAuthoritiesGetUnitTest.java
@@ -33,10 +33,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -562,7 +562,7 @@ public class DynamicAuthoritiesGetUnitTest extends BaseWebScriptUnitTest impleme
         executeWebScript(parameters);
 
         verify(contentStreamer, times(1)).streamContent(any(WebScriptRequest.class), any(WebScriptResponse.class),
-                    csvFileCaptor.capture(), any(Long.class), any(Boolean.class), any(String.class), any(Map.class));
+                    csvFileCaptor.capture(), eq(null), any(Boolean.class), any(String.class), any(Map.class));
 
         File fileForDownload = csvFileCaptor.getValue();
         assertNotNull(fileForDownload);

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/rm/rest/api/impl/RMSitesImplUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/rm/rest/api/impl/RMSitesImplUnitTest.java
@@ -28,8 +28,8 @@
 package org.alfresco.rm.rest.api.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -41,7 +41,6 @@ import org.alfresco.module.org_alfresco_module_rm.dod5015.DOD5015Model;
 import org.alfresco.module.org_alfresco_module_rm.model.RecordsManagementModel;
 import org.alfresco.module.org_alfresco_module_rm.test.util.AlfMock;
 import org.alfresco.module.org_alfresco_module_rm.test.util.BaseUnitTest;
-import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.rest.api.impl.SiteImportPackageHandler;
 import org.alfresco.rest.api.model.Site;
 import org.alfresco.rest.api.model.SiteUpdate;
@@ -59,10 +58,11 @@ import org.alfresco.service.cmr.view.Location;
 import org.alfresco.service.namespace.QName;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Unit Test class for RMSitesImpl.
@@ -71,6 +71,7 @@ import org.mockito.MockitoAnnotations;
  * @since 2.6
  *
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RMSitesImplUnitTest  extends BaseUnitTest
 {
     private static final String RM_SITE_TITLE_AFTER_UPDATE = "Updated Title";
@@ -86,8 +87,6 @@ public class RMSitesImplUnitTest  extends BaseUnitTest
     @Mock
     private SiteService mockedSiteService;
     @Mock
-    AuthenticationUtil mockAuthenticationUtil;
-    @Mock
     private ImporterService mockedImporterService;
     @Mock
     private FavouritesService mockedFavouritesService;
@@ -95,7 +94,6 @@ public class RMSitesImplUnitTest  extends BaseUnitTest
     @Before
     public void before()
     {
-        MockitoAnnotations.initMocks(this);
     }
 
     @Test
@@ -138,7 +136,7 @@ public class RMSitesImplUnitTest  extends BaseUnitTest
 
         verify(mockedImporterService, times(1)).importView(any(SiteImportPackageHandler.class), any(Location.class), any(ImporterBinding.class), eq(null));
         verify(mockedSiteService, times(1)).createContainer(RM_SITE_ID, SiteService.DOCUMENT_LIBRARY, ContentModel.TYPE_FOLDER, null);
-        verify(mockedFavouritesService, times(1)).addFavourite(any(String.class), any(NodeRef.class));
+        verify(mockedFavouritesService, times(1)).addFavourite(eq(null), any(NodeRef.class));
 
         //verify returned values for RM site are the right ones
         assertEquals(RMSiteCompliance.STANDARD, createdRMSite.getCompliance());
@@ -191,7 +189,7 @@ public class RMSitesImplUnitTest  extends BaseUnitTest
 
         verify(mockedImporterService, times(1)).importView(any(SiteImportPackageHandler.class), any(Location.class), any(ImporterBinding.class), eq(null));
         verify(mockedSiteService, times(1)).createContainer(RM_SITE_ID, SiteService.DOCUMENT_LIBRARY, ContentModel.TYPE_FOLDER, null);
-        verify(mockedFavouritesService, times(1)).addFavourite(any(String.class), any(NodeRef.class));
+        verify(mockedFavouritesService, times(1)).addFavourite(eq(null), any(NodeRef.class));
 
         //verify returned values for RM site are the right ones
         assertEquals(RMSiteCompliance.DOD5015, createdRMSite.getCompliance());
@@ -253,13 +251,12 @@ public class RMSitesImplUnitTest  extends BaseUnitTest
         when(mockedNodeService.getType(siteNodeRef)).thenReturn(RecordsManagementModel.TYPE_RM_SITE);
 
         when(mockedSiteService.getSite(siteId)).thenReturn(mockedSiteInfo);
-        when(mockedSiteService.getMembersRole(eq(siteId), any(String.class))).thenReturn(RM_SITE_MANAGER_ROLE);
+        when(mockedSiteService.getMembersRole(eq(siteId), eq(null))).thenReturn(RM_SITE_MANAGER_ROLE);
 
         //mock UpdateSite
         SiteUpdate mockedSiteUpdate= mock(SiteUpdate.class);
         when(mockedSiteUpdate.getDescription()).thenReturn(RM_SITE_DESCRIPTION_AFTER_UPDATE);
         when(mockedSiteUpdate.getTitle()).thenReturn(RM_SITE_TITLE_AFTER_UPDATE);
-        when(mockedSiteUpdate.getVisibility()).thenReturn(null);
         when(mockedSiteUpdate.wasSet(Site.TITLE)).thenReturn(true);
         when(mockedSiteUpdate.wasSet(Site.DESCRIPTION)).thenReturn(true);
 
@@ -309,7 +306,7 @@ public class RMSitesImplUnitTest  extends BaseUnitTest
         when(mockedNodeService.getType(siteNodeRef)).thenReturn(RecordsManagementModel.TYPE_RM_SITE);
 
         when(mockedSiteService.getSite(siteId)).thenReturn(mockedSiteInfo);
-        when(mockedSiteService.getMembersRole(eq(siteId), any(String.class))).thenReturn(RM_SITE_MANAGER_ROLE);
+        when(mockedSiteService.getMembersRole(eq(siteId), eq(null))).thenReturn(RM_SITE_MANAGER_ROLE);
 
         //STANDARD compliance
         RMSite rmSite = rmSitesImpl.getRMSite(siteId);

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <dependency.webscripts.version>8.24</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.69</dependency.bouncycastle.version>
         <dependency.mockito-core.version>3.11.2</dependency.mockito-core.version>
-        <dependency.mockito-all.version>1.10.19</dependency.mockito-all.version>
         <dependency.org-json.version>20210307</dependency.org-json.version>
         <dependency.commons-dbcp.version>1.4-DBCP330</dependency.commons-dbcp.version>
         <dependency.commons-io.version>2.11.0</dependency.commons-io.version>
@@ -732,11 +731,6 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>gunit</artifactId>
                 <version>${dependency.antlr.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${dependency.mockito-all.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/repository/src/test/java/org/alfresco/util/BeanExtenderUnitTest.java
+++ b/repository/src/test/java/org/alfresco/util/BeanExtenderUnitTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.alfresco.util.GUID;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +43,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.PropertyValue;
@@ -82,8 +80,6 @@ public class BeanExtenderUnitTest
     @Before
     public void before() throws Exception
     {
-        MockitoAnnotations.initMocks(this);
-
         // setup common interactions
         doReturn(mockedPropertyValuesBean).when(mockedBeanDefinition).getPropertyValues();
         doReturn(mockedPropertyValuesExtendingBean).when(mockedExtendingBeanDefinition).getPropertyValues();
@@ -139,7 +135,6 @@ public class BeanExtenderUnitTest
         beanExtender.setBeanName(BEAN_NAME);
         beanExtender.setExtendingBeanName(EXTENDING_BEAN_NAME);
         doReturn(false).when(mockedBeanFactory).containsBean(BEAN_NAME);
-        doReturn(true).when(mockedBeanFactory).containsBean(EXTENDING_BEAN_NAME);
 
         // expecting exception
         exception.expect(NoSuchBeanDefinitionException.class);
@@ -230,7 +225,6 @@ public class BeanExtenderUnitTest
         doReturn(mockedExtendingBeanDefinition).when(mockedBeanFactory).getBeanDefinition(EXTENDING_BEAN_NAME);
 
         // bean class names
-        doReturn("a").when(mockedBeanDefinition).getBeanClassName();
         doReturn(null).when(mockedExtendingBeanDefinition).getBeanClassName();
 
         PropertyValue mockedPropertyValueOne = generateMockedPropertyValue("one", "1");


### PR DESCRIPTION
Mockito 1 is VERY old and has some bugs so migration to version 3 is a good idea.

Had to slightly change some tests due to contract differences between versions.

All deprecated calls were substituted with non-deprecated.

Also deleted some unused mocking code (which Mockito 3 is rightfully unhappy about).