### PR TITLE
ACS-2147: Adding Experimental annotation.

### DIFF
--- a/data-model/src/main/java/org/alfresco/service/Experimental.java
+++ b/data-model/src/main/java/org/alfresco/service/Experimental.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * Alfresco Data model classes
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.service;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark a type/method/field as experimental.
+ * <p>
+ * If this annotation is present on an element it marks it as experimental and subject to change without further notice.
+ * The element may even be deleted or renamed without any notice.
+ * Experimental element may likely become a valid one (not experimental anymore) in future releases but there is no guarantee when
+ * and if that happens.
+ *
+ * @author mpichura
+ */
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+@Documented
+public @interface Experimental {
+    /**
+     * Further description that can optionally be added to clarify possible future changes of annotated object.
+     *
+     * @return a String, the default is an empty String.
+     */
+    String description() default "";
+
+}


### PR DESCRIPTION
As per @skopf 's comment in PR#761 - moving addition of `@Experimental` annotation to a separate PR.