### PR TITLE
ACS-2147: Fixing docker logins in init.sh

### DIFF
--- a/scripts/travis/init.sh
+++ b/scripts/travis/init.sh
@@ -9,10 +9,8 @@ mkdir -p "${HOME}/.m2" && cp -f .travis.settings.xml "${HOME}/.m2/settings.xml"
 find "${HOME}/.m2/repository/" -type d -name "*-SNAPSHOT*" | xargs -r -l rm -rf
 
 # Docker Logins
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
-  echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" --password-stdin quay.io
-fi
+echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
+echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" --password-stdin quay.io
 
 popd
 set +vex


### PR DESCRIPTION
Removing conditional docker login (both dockerhub and quay) from init.sh .
This way all Travis builds (including a PR build) will run docker login.