### PR TITLE
ACS-2222 Add ArchivedIOException

### DIFF
--- a/data-model/src/main/java/org/alfresco/service/cmr/repository/ArchivedIOException.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/repository/ArchivedIOException.java
@@ -23,8 +23,9 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.rest.framework.core.exceptions;
+package org.alfresco.service.cmr.repository;
 
+import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.service.Experimental;
 
 /**
@@ -34,24 +35,19 @@ import org.alfresco.service.Experimental;
  * @author David Edwards
  */
 @Experimental
-public class ArchivedIOException extends ApiException
+@AlfrescoPublicApi
+public class ArchivedIOException extends ContentIOException
 {
+    private static final long serialVersionUID = 3258135874596276087L;
 
-    public static String DEFAULT_MESSAGE_ID = "framework.exception.AchivedIOException";
-
-    public ArchivedIOException() 
+    public ArchivedIOException(String msg) 
     {
-        super(DEFAULT_MESSAGE_ID);
+        super(msg);
     }
 
-    public ArchivedIOException(String msgId) 
+    public ArchivedIOException(String msg, Throwable cause) 
     {
-        super(msgId);
-    }
-
-    public ArchivedIOException(String msgId, Object[] msgParams) 
-    {
-        super(msgId, msgParams);
+        super(msg, cause);
     }
 
 }

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/content/ContentStreamer.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/content/ContentStreamer.java
@@ -44,6 +44,7 @@ import org.alfresco.repo.content.filestore.FileContentReader;
 import org.alfresco.sync.repo.events.EventPublisher;
 import org.alfresco.repo.web.util.HttpRangeProcessor;
 import org.alfresco.rest.framework.resource.content.CacheDirective;
+import org.alfresco.service.cmr.repository.ArchivedIOException;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentService;
@@ -449,7 +450,11 @@ public class ContentStreamer implements ResourceLoaderAware
             if (logger.isInfoEnabled())
                 logger.info("Client aborted stream read:\n\tcontent: " + reader);
         }
-        catch (ContentIOException e2)
+        catch (ArchivedIOException e2)
+        {
+            throw e2;
+        }
+        catch (ContentIOException e3)
         {
             if (logger.isInfoEnabled())
                 logger.info("Client aborted stream read:\n\tcontent: " + reader);

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ApiException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ApiException.java
@@ -64,6 +64,18 @@ public class ApiException extends PlatformRuntimeException
         super(msgId, cause);
         this.msgId = msgId;
     }
+
+    public ApiException(String msgId, String message)
+    {
+        super(message);
+        this.msgId = msgId;
+    }
+
+    public ApiException(String msgId, String message, Throwable cause)
+    {
+        super(message, cause);
+        this.msgId = msgId;
+    }
     
     public ApiException(String msgId, Throwable cause, Map<String,Object> additionalState)
     {

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
@@ -43,19 +43,30 @@ public class ArchivedContentException  extends  ApiException
     {
         super(DEFAULT_MESSAGE_ID);
     }
-    public ArchivedContentException(String msgId) 
+
+    public ArchivedContentException(String message) 
     {
-        super(msgId);
+        this(DEFAULT_MESSAGE_ID, message);
+    }
+
+    public ArchivedContentException(String msgId, String message) 
+    {
+        super(msgId, message);
     }
 
     public ArchivedContentException(Throwable cause) 
     {
-        super(DEFAULT_MESSAGE_ID, cause);
+        this(DEFAULT_MESSAGE_ID, cause.getLocalizedMessage(), cause);
     }
     
-    public ArchivedContentException(String msgId, Throwable cause) 
+    public ArchivedContentException(String message, Throwable cause) 
     {
-        super(msgId, cause);
+        this(DEFAULT_MESSAGE_ID, message, cause);
+    }
+    
+    public ArchivedContentException(String msgId, String message, Throwable cause) 
+    {
+        super(msgId, message, cause);
     }
     
 }

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.framework.core.exceptions;
+
+import org.alfresco.service.Experimental;
+
+/**
+ * Thrown when the content is archived and not readily accessible.
+ * Status is <i>Precondition Failed</i> client error = 412.
+ *
+ * @author David Edwards
+ */
+@Experimental
+public class ArchivedContentException  extends  ApiException
+{
+
+    public static String DEFAULT_MESSAGE_ID = "framework.exception.ArchivedContent";
+
+    public ArchivedContentException() 
+    {
+        super(DEFAULT_MESSAGE_ID);
+    }
+    public ArchivedContentException(String msgId) 
+    {
+        super(msgId);
+    }
+
+    public ArchivedContentException(Throwable cause) 
+    {
+        super(DEFAULT_MESSAGE_ID, cause);
+    }
+    
+    public ArchivedContentException(String msgId, Throwable cause) 
+    {
+        super(msgId, cause);
+    }
+    
+}

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
@@ -49,7 +49,7 @@ public class ArchivedContentException  extends  ApiException
         this(DEFAULT_MESSAGE_ID, message);
     }
 
-    public ArchivedContentException(String msgId, String message) 
+    private ArchivedContentException(String msgId, String message) 
     {
         super(msgId, message);
     }
@@ -64,7 +64,7 @@ public class ArchivedContentException  extends  ApiException
         this(DEFAULT_MESSAGE_ID, message, cause);
     }
     
-    public ArchivedContentException(String msgId, String message, Throwable cause) 
+    private ArchivedContentException(String msgId, String message, Throwable cause) 
     {
         super(msgId, message, cause);
     }

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedIOException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedIOException.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * Alfresco Data model classes
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.framework.core.exceptions;
+
+/**
+ * Unable to access as content is in an Archived state.
+ * Default status is <i>Precondition Failed<i> Client Error = 412
+ * 
+ * @author David Edwards
+ */
+public class ArchivedIOException extends ApiException
+{
+
+    public static String DEFAULT_MESSAGE_ID = "framework.exception.AchivedIOException";
+
+    public ArchivedIOException() 
+    {
+        super(DEFAULT_MESSAGE_ID);
+    }
+
+    public ArchivedIOException(String msgId) 
+    {
+        super(msgId);
+    }
+
+    public ArchivedIOException(String msgId, Object[] msgParams) 
+    {
+        super(msgId, msgParams);
+    }
+
+}

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedIOException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedIOException.java
@@ -25,12 +25,15 @@
  */
 package org.alfresco.rest.framework.core.exceptions;
 
+import org.alfresco.service.Experimental;
+
 /**
  * Unable to access as content is in an Archived state.
  * Default status is <i>Precondition Failed<i> Client Error = 412
  * 
  * @author David Edwards
  */
+@Experimental
 public class ArchivedIOException extends ApiException
 {
 

--- a/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
@@ -230,7 +230,7 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
         res.setHeader(HEADER_CONTENT_LENGTH, String.valueOf(-1));
         if (exception instanceof ArchivedIOException)
         {
-            renderException(new ArchivedContentException(exception.getLocalizedMessage(), exception), res, assistant);
+            renderException(new ArchivedContentException(exception.getMsgId(), exception), res, assistant);
         }
         else
         {

--- a/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
@@ -52,6 +52,7 @@ import org.alfresco.rest.framework.resource.content.FileBinaryResource;
 import org.alfresco.rest.framework.resource.content.NodeBinaryResource;
 import org.alfresco.rest.framework.resource.parameters.Params;
 import org.alfresco.rest.framework.tools.ResponseWriter;
+import org.alfresco.service.cmr.repository.ContentIOException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -83,6 +84,8 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
     private ParamsExtractor paramsExtractor;
     private ContentStreamer streamer;
     protected ResourceWebScriptHelper helper;
+
+    private static final String HEADER_CONTENT_LENGTH = "Content-Length";
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -172,6 +175,12 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
                 }
             }
 
+        }
+        catch (ContentIOException cioe)
+        {
+            // If the Content-Length is not set back to -1 any client will expect to receive binary and will hang until it times out
+            res.setHeader(HEADER_CONTENT_LENGTH, String.valueOf(-1));
+            renderException(cioe, res, assistant);
         }
         catch (AlfrescoRuntimeException | ApiException | WebScriptException xception )
         {

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -174,7 +174,7 @@
                 <entry key="org.springframework.http.InvalidMediaTypeException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_UNSUPPORTED_MEDIA_TYPE}" />
                 <entry key="org.alfresco.rest.framework.core.exceptions.ServiceUnavailableException" value="503" />
                 <entry key="org.alfresco.service.cmr.dictionary.InvalidTypeException" value="409" />
-                <entry key="org.alfresco.rest.framework.core.exceptions.ArchivedIOException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_PRECONDITION_FAILED}" />
+                <entry key="org.alfresco.service.cmr.repository.ArchivedIOException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_PRECONDITION_FAILED}" />
             </map>
         </property>
     </bean>

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -174,7 +174,7 @@
                 <entry key="org.springframework.http.InvalidMediaTypeException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_UNSUPPORTED_MEDIA_TYPE}" />
                 <entry key="org.alfresco.rest.framework.core.exceptions.ServiceUnavailableException" value="503" />
                 <entry key="org.alfresco.service.cmr.dictionary.InvalidTypeException" value="409" />
-                <entry key="org.alfresco.service.cmr.repository.ArchivedIOException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_PRECONDITION_FAILED}" />
+                <entry key="org.alfresco.rest.framework.core.exceptions.ArchivedContentException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_PRECONDITION_FAILED}" />
             </map>
         </property>
     </bean>

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -174,6 +174,7 @@
                 <entry key="org.springframework.http.InvalidMediaTypeException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_UNSUPPORTED_MEDIA_TYPE}" />
                 <entry key="org.alfresco.rest.framework.core.exceptions.ServiceUnavailableException" value="503" />
                 <entry key="org.alfresco.service.cmr.dictionary.InvalidTypeException" value="409" />
+                <entry key="org.alfresco.rest.framework.core.exceptions.ArchivedIOException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_PRECONDITION_FAILED}" />
             </map>
         </property>
     </bean>

--- a/repository/src/main/java/org/alfresco/repo/content/AbstractContentReader.java
+++ b/repository/src/main/java/org/alfresco/repo/content/AbstractContentReader.java
@@ -47,6 +47,7 @@ import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.content.filestore.FileContentWriter;
 import org.alfresco.repo.content.transform.TransformerDebug;
+import org.alfresco.service.cmr.repository.ArchivedIOException;
 import org.alfresco.service.cmr.repository.ContentAccessor;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
@@ -429,6 +430,7 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
         }
         catch (Throwable e)
         {
+            if (e instanceof ArchivedIOException) throw e;
             throw new ContentIOException("Failed to open stream onto channel: \n" +
                     "   accessor: " + this,
                     e);


### PR DESCRIPTION
Adds a Precondition Failed (412) error response when attempting the get content that is Archived.

Discovered a bug:
When an error is thrown while attempting to access content the Content-Length header is set but no content is returned (obviously we've had a error so there shouldn't be any 😄). This causes requesting clients to hang until they timeout, as they are expecting content to be there when none will be returned.