### PR TITLE
ACS-2270 Read T-Engine config in alphabetical order

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
@@ -26,7 +26,6 @@
 package org.alfresco.repo.content.transform;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -34,6 +33,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.alfresco.service.cmr.repository.MimetypeService;
 import org.alfresco.transform.client.model.config.TransformOptionGroup;
@@ -134,7 +134,7 @@ public class LocalTransformServiceRegistry extends TransformServiceRegistryImpl 
     public boolean readConfig() throws IOException
     {
         CombinedConfig combinedConfig = new CombinedConfig(getLog(), this);
-        List<String> urls = getTEngineUrls();
+        List<String> urls = getTEngineUrlsSortedByName();
         boolean successReadingConfig = combinedConfig.addRemoteConfig(urls, "T-Engine");
         successReadingConfig &= combinedConfig.addLocalConfig("alfresco/transforms");
         if (pipelineConfigDir != null && !pipelineConfigDir.isBlank())
@@ -321,30 +321,21 @@ public class LocalTransformServiceRegistry extends TransformServiceRegistryImpl 
         return log;
     }
 
-    private List<String> getTEngineUrls()
+    /**
+     * @return urls from System or Alfresco global properties that match of localTransform.<name>.url=<url> sorted
+     *         in <name> order.
+     */
+    List<String> getTEngineUrlsSortedByName()
     {
-        List<String> urls = new ArrayList<>();
-        for (Object o : getKeySet())
-        {
-            if (o instanceof String)
-            {
-                String key = (String)o;
-                if (key.startsWith(LOCAL_TRANSFORMER) && key.endsWith(URL))
-                {
-                    Object url = getProperty(key, null);
-                    if (url instanceof String)
-                    {
-                        String urlStr = ((String)url).trim();
-                        if (!urlStr.isEmpty())
-                        {
-                            urls.add((String) url);
-                        }
-                    }
-                }
-            }
-        }
-
-        return urls;
+        return getKeySet().stream()
+                .filter(key -> key instanceof String)
+                .filter(key -> key.startsWith(LOCAL_TRANSFORMER) && key.endsWith(URL))
+                .sorted()
+                .map(key -> getProperty(key, null))
+                .filter(url -> url instanceof String)
+                .map(url -> url.trim())
+                .filter(url -> !url.isEmpty())
+                .collect(Collectors.toList());
     }
 
     private int getStartupRetryPeriodSeconds(String name)

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
@@ -327,6 +327,8 @@ public class LocalTransformServiceRegistry extends TransformServiceRegistryImpl 
      */
     List<String> getTEngineUrlsSortedByName()
     {
+        // T-Engines are sorted by name so they are in the same order as in the all-in-one transformer and the
+        // T-Router. See AIOCustomConfig#getTEnginesSortedByName and TransformersConfigRegistry#retrieveRemoteConfig.
         return getKeySet().stream()
                 .filter(key -> key instanceof String)
                 .filter(key -> key.startsWith(LOCAL_TRANSFORMER) && key.endsWith(URL))

--- a/repository/src/test/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistryTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistryTest.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.content.transform;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.StringJoiner;
+
+import static org.alfresco.repo.content.transform.LocalTransformServiceRegistry.LOCAL_TRANSFORMER;
+import static org.alfresco.repo.content.transform.LocalTransformServiceRegistry.URL;
+import static org.junit.Assert.assertEquals;
+
+public class LocalTransformServiceRegistryTest
+{
+    @Spy
+    private Properties properties = new Properties();
+
+    @InjectMocks
+    LocalTransformServiceRegistry registry = new LocalTransformServiceRegistry();
+
+    @Rule
+    public MockitoRule initRule = MockitoJUnit.rule();
+
+    @Test
+    public void testGetTEngineUrlsSortedByName() throws IOException
+    {
+        properties.put(LOCAL_TRANSFORMER+"aa"+URL,      "aa");
+        properties.put(LOCAL_TRANSFORMER+"engine1"+URL, "http_xxxx1");
+        properties.put(LOCAL_TRANSFORMER+"engine3"+URL, "http3");
+        properties.put(LOCAL_TRANSFORMER+"engine2"+URL, "http_xx2");
+        properties.put(LOCAL_TRANSFORMER+"bb"+URL,      "bb");
+        properties.put(LOCAL_TRANSFORMER+"b"+URL,       "b");
+
+        StringJoiner orderEngineConfigRead = new StringJoiner(",");
+        registry.getTEngineUrlsSortedByName().forEach(name -> orderEngineConfigRead.add(name));
+        assertEquals("aa,b,bb,http_xxxx1,http_xx2,http3", orderEngineConfigRead.toString());
+    }
+}

--- a/repository/src/test/java/org/alfresco/repo/content/transform/TransformerConfigTestSuite.java
+++ b/repository/src/test/java/org/alfresco/repo/content/transform/TransformerConfigTestSuite.java
@@ -44,16 +44,15 @@ import org.junit.runners.Suite.SuiteClasses;
     TransformerLogTest.class,
     TransformerDebugLogTest.class,
 
+    LocalTransformServiceRegistryTest.class,
+
     TransformerConfigMBeanImplTest.class})
 
 /**
  * Test classes in the Transformers subsystem
  * 
  * @author Alan Davis
- *
- * @deprecated The transformations code is being moved out of the codebase and replaced by the new async RenditionService2 or other external libraries.
  */
-@Deprecated
 public class TransformerConfigTestSuite
 {
 }


### PR DESCRIPTION
* T-Engines config need to be combined in the same predefined order in the all-in-one transformer,
T-Router and the Content Repository with individual T-Engines.