### PR TITLE
ACS-2151 Get StorageProps endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 
         <alfresco.googledrive.version>3.2.1.3</alfresco.googledrive.version>
         <alfresco.aos-module.version>1.4.0.1</alfresco.aos-module.version>
-        <alfresco.api-explorer.version>7.1.0.1</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
+        <alfresco.api-explorer.version>7.2.0-SNAPSHOT</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
         <alfresco.maven-plugin.version>2.2.0</alfresco.maven-plugin.version>
 
         <dependency.postgresql.version>42.2.24</dependency.postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 
         <alfresco.googledrive.version>3.2.1.3</alfresco.googledrive.version>
         <alfresco.aos-module.version>1.4.0.1</alfresco.aos-module.version>
-        <alfresco.api-explorer.version>7.2.0-SNAPSHOT</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
+        <alfresco.api-explorer.version>7.1.0.1</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
         <alfresco.maven-plugin.version>2.2.0</alfresco.maven-plugin.version>
 
         <dependency.postgresql.version>42.2.24</dependency.postgresql.version>

--- a/remote-api/src/main/java/org/alfresco/rest/api/ContentStorageInformation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/ContentStorageInformation.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api;
+
+import org.alfresco.rest.api.model.ContentStorageInfo;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+
+/**
+ * Storage information for content API
+ *
+ * @author mpichura
+ */
+
+public interface ContentStorageInformation
+{
+    /**
+     * @param nodeId          Identifier of the node
+     * @param contentPropName Qualified name of content property (e.g. 'cm_content')
+     * @param parameters      {@link Parameters} object to get the parameters passed into the request
+     * @return {@link ContentStorageInfo} object consisting of qualified name of content property and a map of storage properties
+     */
+    ContentStorageInfo getStorageInfo(String nodeId, String contentPropName, Parameters parameters);
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/ContentStorageInformation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/ContentStorageInformation.java
@@ -28,20 +28,24 @@ package org.alfresco.rest.api;
 
 import org.alfresco.rest.api.model.ContentStorageInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.service.Experimental;
 
 /**
- * Storage information for content API
+ * Storage information for content API.
+ * Note: Currently marked as experimental and subject to change.
  *
  * @author mpichura
  */
-
+@Experimental
 public interface ContentStorageInformation
 {
     /**
+     * Note: Currently marked as experimental and subject to change.
      * @param nodeId          Identifier of the node
      * @param contentPropName Qualified name of content property (e.g. 'cm_content')
      * @param parameters      {@link Parameters} object to get the parameters passed into the request
      * @return {@link ContentStorageInfo} object consisting of qualified name of content property and a map of storage properties
      */
+    @Experimental
     ContentStorageInfo getStorageInfo(String nodeId, String contentPropName, Parameters parameters);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/ContentStorageInformationImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/ContentStorageInformationImpl.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.impl;
+
+import org.alfresco.rest.api.ContentStorageInformation;
+import org.alfresco.rest.api.model.ContentStorageInfo;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.service.cmr.repository.ContentService;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.namespace.DynamicNamespacePrefixResolver;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.service.namespace.QName;
+
+import java.util.Map;
+
+public class ContentStorageInformationImpl implements ContentStorageInformation
+{
+
+    public static final char PREFIX_SPLITTER = '_';
+
+    private final ContentService contentService;
+
+    public ContentStorageInformationImpl(ContentService contentService)
+    {
+        this.contentService = contentService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContentStorageInfo getStorageInfo(String nodeId, String contentPropName, Parameters parameters)
+    {
+        final NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, nodeId);
+        //FIXME: figure out how to properly and neatly convert contentPropName param into QName
+        final QName propQName = getQName(contentPropName);
+        final Map<String, String> storageProperties = contentService.getStorageProperties(nodeRef, propQName);
+        final ContentStorageInfo storageInfo = new ContentStorageInfo();
+        storageInfo.setId(propQName.toString());
+        storageInfo.setStorageProperties(storageProperties);
+        return storageInfo;
+    }
+
+    private QName getQName(final String contentPropName)
+    {
+        final DynamicNamespacePrefixResolver namespacePrefixResolver = new DynamicNamespacePrefixResolver();
+        //for now there is only single content namespace being registered - this may be extended to more
+        namespacePrefixResolver.registerNamespace(NamespaceService.CONTENT_MODEL_PREFIX,
+                NamespaceService.CONTENT_MODEL_1_0_URI);
+
+        //following may be removed if it is aligned that endpoint will take contentPropName in a format of prefix:localName
+        //instead of prefix_localName which is assumed at the moment
+        final String properContentPropName = contentPropName.replace(PREFIX_SPLITTER, QName.NAMESPACE_PREFIX);
+        return QName.resolveToQName(namespacePrefixResolver, properContentPropName);
+    }
+
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/ContentStorageInformationImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/ContentStorageInformationImpl.java
@@ -76,7 +76,6 @@ public class ContentStorageInformationImpl implements ContentStorageInformation
 
     private QName getQName(final String contentPropName)
     {
-        //this splitting may be gone when we decide to use colon as prefix separatot
         final String properContentPropName = contentPropName.replace(PREFIX_SEPARATOR, QName.NAMESPACE_PREFIX);
         return QName.resolveToQName(namespaceService, properContentPropName);
     }

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/ContentStorageInfo.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/ContentStorageInfo.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of storage information for content.
+ *
+ * @author mpichura
+ */
+public class ContentStorageInfo
+{
+
+    /**
+     * Qualified name of content property
+     */
+    private String id;
+    /**
+     * Key-value (String-String) collection representing storage properties of given content
+     */
+    private Map<String, String> storageProperties;
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public void setId(String id)
+    {
+        this.id = id;
+    }
+
+    public Map<String, String> getStorageProperties()
+    {
+        if (storageProperties == null) {
+            storageProperties = new HashMap<>();
+        }
+        return storageProperties;
+    }
+
+    public void setStorageProperties(Map<String, String> storageProperties)
+    {
+        this.storageProperties = storageProperties;
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeStorageInfoRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeStorageInfoRelation.java
@@ -28,12 +28,12 @@ package org.alfresco.rest.api.nodes;
 
 import org.alfresco.rest.api.ContentStorageInformation;
 import org.alfresco.rest.api.model.ContentStorageInfo;
-import org.alfresco.rest.framework.Operation;
 import org.alfresco.rest.framework.WebApiDescription;
 import org.alfresco.rest.framework.core.exceptions.RelationshipResourceNotFoundException;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.service.Experimental;
 import org.alfresco.util.PropertyCheck;
 import org.springframework.beans.factory.InitializingBean;
 
@@ -41,9 +41,11 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Node storage information.
+ * Note: Currently marked as experimental and subject to change.
  *
  * @author mpichura
  */
+@Experimental
 @RelationshipResource(name = "storage-info", entityResource = NodesEntityResource.class, title = "Node's content storage information")
 public class NodeStorageInfoRelation implements RelationshipResourceAction.ReadById<ContentStorageInfo>, InitializingBean
 {

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeStorageInfoRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeStorageInfoRelation.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.nodes;
+
+import org.alfresco.rest.api.ContentStorageInformation;
+import org.alfresco.rest.api.model.ContentStorageInfo;
+import org.alfresco.rest.framework.Operation;
+import org.alfresco.rest.framework.WebApiDescription;
+import org.alfresco.rest.framework.core.exceptions.RelationshipResourceNotFoundException;
+import org.alfresco.rest.framework.resource.RelationshipResource;
+import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.util.PropertyCheck;
+import org.springframework.beans.factory.InitializingBean;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Node storage information.
+ *
+ * @author mpichura
+ */
+@RelationshipResource(name = "storage-info", entityResource = NodesEntityResource.class, title = "Node's content storage information")
+public class NodeStorageInfoRelation implements RelationshipResourceAction.ReadById<ContentStorageInfo>, InitializingBean
+{
+
+    private final ContentStorageInformation storageInformation;
+
+    public NodeStorageInfoRelation(ContentStorageInformation storageInformation)
+    {
+        this.storageInformation = storageInformation;
+    }
+
+    @WebApiDescription(title = "Get storage properties",
+            description = "Retrieves storage properties for given node's content",
+            successStatus = HttpServletResponse.SC_OK)
+    @Override
+    public ContentStorageInfo readById(String entityResourceId, String id, Parameters parameters)
+            throws RelationshipResourceNotFoundException
+    {
+        return storageInformation.getStorageInfo(entityResourceId, id, parameters);
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception
+    {
+        PropertyCheck.mandatory(this, "storageInformation", storageInformation);
+    }
+}

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -1001,7 +1001,7 @@
     <bean class="org.alfresco.rest.api.nodes.NodeStorageInfoRelation">
         <constructor-arg name="storageInformation" ref="ContentStorageInformation" />
     </bean>
-    
+
     <bean class="org.alfresco.rest.api.nodes.NodeSecondaryChildrenRelation" parent="baseNodeRelation"/>
 
     <bean class="org.alfresco.rest.api.nodes.NodeParentsRelation" parent="baseNodeRelation"/>

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -606,6 +606,25 @@
             </list>
         </property>
     </bean>
+
+    <bean id="contentStorageInformation" class="org.alfresco.rest.api.impl.ContentStorageInformationImpl">
+        <constructor-arg name="contentService" ref="contentService"/>
+    </bean>
+
+    <bean id="ContentStorageInformation" class="org.springframework.aop.framework.ProxyFactoryBean">
+        <property name="proxyInterfaces">
+            <value>org.alfresco.rest.api.ContentStorageInformation</value>
+        </property>
+        <property name="target">
+            <ref bean="contentStorageInformation" />
+        </property>
+        <property name="interceptorNames">
+            <list>
+                <idref bean="legacyExceptionInterceptor" />
+            </list>
+        </property>
+    </bean>
+
     <bean id="deletedNodes" class="org.alfresco.rest.api.impl.DeletedNodesImpl">
         <property name="nodes" ref="Nodes" />
         <property name="nodeService" ref="NodeService" />
@@ -976,6 +995,10 @@
     <bean id="nodeVersionsRelation" class="org.alfresco.rest.api.nodes.NodeVersionsRelation" parent="baseNodeRelation">
         <property name="behaviourFilter" ref="policyBehaviourFilter"/>
         <property name="directAccessUrlHelper" ref="directAccessUrlHelper" />
+    </bean>
+
+    <bean class="org.alfresco.rest.api.nodes.NodeStorageInfoRelation">
+        <constructor-arg name="storageInformation" ref="ContentStorageInformation" />
     </bean>
     
     <bean class="org.alfresco.rest.api.nodes.NodeSecondaryChildrenRelation" parent="baseNodeRelation"/>

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -608,7 +608,8 @@
     </bean>
 
     <bean id="contentStorageInformation" class="org.alfresco.rest.api.impl.ContentStorageInformationImpl">
-        <constructor-arg name="contentService" ref="contentService"/>
+        <constructor-arg name="contentService" ref="ContentService"/>
+        <constructor-arg name="namespaceService" ref="NamespaceService"/>
     </bean>
 
     <bean id="ContentStorageInformation" class="org.springframework.aop.framework.ProxyFactoryBean">

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/ContentStorageInformationImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/ContentStorageInformationImplTest.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.impl;
+
+import org.alfresco.rest.api.model.ContentStorageInfo;
+import org.alfresco.service.cmr.repository.ContentService;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.namespace.NamespaceService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContentStorageInformationImplTest
+{
+    @Mock
+    private ContentService contentService;
+    @Mock
+    private NamespaceService namespaceService;
+
+    @InjectMocks
+    private ContentStorageInformationImpl objectUnderTest;
+
+    @Test
+    public void shouldReturnStorageInfoResponseWithNonEmptyStorageProps()
+    {
+
+        final String nodeId = "dummy-node-id";
+        final NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, nodeId);
+        final String contentPropName = "cm:content";
+
+        final Map<String, String> storageProps = Map.of("x-amz-storage-class", "INTELLIGENT_TIERING", "x-alf-archived", "false");
+        Mockito.when(contentService.getStorageProperties(Mockito.eq(nodeRef), Mockito.any())).thenReturn(storageProps);
+        Mockito.when(namespaceService.getNamespaceURI(NamespaceService.CONTENT_MODEL_PREFIX))
+                .thenReturn(NamespaceService.CONTENT_MODEL_1_0_URI);
+        Mockito.when(namespaceService.getPrefixes(NamespaceService.CONTENT_MODEL_1_0_URI))
+                .thenReturn(List.of(NamespaceService.CONTENT_MODEL_PREFIX));
+
+        final ContentStorageInfo storageInfo = objectUnderTest.getStorageInfo(nodeId, contentPropName, null);
+
+        Assert.assertEquals(storageProps, storageInfo.getStorageProperties());
+        Assert.assertEquals(storageInfo.getId(), contentPropName);
+    }
+
+    @Test
+    public void shouldReturnStorageInfoResponseWithEmptyStorageProps()
+    {
+        final String nodeId = "dummy-node-id";
+        final NodeRef nodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, nodeId);
+        final String contentPropName = "cm:content";
+
+        Mockito.when(contentService.getStorageProperties(Mockito.eq(nodeRef), Mockito.any())).thenCallRealMethod();
+        Mockito.when(namespaceService.getNamespaceURI(NamespaceService.CONTENT_MODEL_PREFIX))
+                .thenReturn(NamespaceService.CONTENT_MODEL_1_0_URI);
+        Mockito.when(namespaceService.getPrefixes(NamespaceService.CONTENT_MODEL_1_0_URI))
+                .thenReturn(List.of(NamespaceService.CONTENT_MODEL_PREFIX));
+
+        final ContentStorageInfo storageInfo = objectUnderTest.getStorageInfo(nodeId, contentPropName, null);
+
+        Assert.assertEquals(Collections.emptyMap(), storageInfo.getStorageProperties());
+        Assert.assertEquals(storageInfo.getId(), contentPropName);
+    }
+}


### PR DESCRIPTION
This PR is still work in progress.
All below changes are annotated `@Experimental` as they are subject to change.

- Added `NodeStorageInfoRelation` to handle REST request for get StorageProps 
- Added `ContentStorageInfo` model class to expose StorageProps iin REST response
- Added `ContentStorageInformation` interface and its implementation (along with unit test) as a proxy to get StorageProps