### PR TITLE
ACS-222 Add missing ArchivedIOException throw

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/content/AbstractContentReader.java
+++ b/repository/src/main/java/org/alfresco/repo/content/AbstractContentReader.java
@@ -543,6 +543,10 @@ public abstract class AbstractContentReader extends AbstractContentAccessor impl
             // done
             return content;
         }
+        catch (ArchivedIOException e)
+        {
+            throw e;
+        }
         catch (Exception e)
         {
             throw new ContentIOException("Failed to copy content to string: \n" +


### PR DESCRIPTION
The getContentString() method catches all Exceptions and re-throws as a custom ContentIOException. We want ArchivedIOExceptions re-thrown.