### PR TITLE
ACS-2216: Fix incorrect ContentService Java Interface - should accept content propQName

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -3420,7 +3420,7 @@ public class NodesImpl implements Nodes
     @Override
     public DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment, Long validFor)
     {
-        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(nodeRef, attachment, validFor);
+        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(nodeRef, ContentModel.PROP_CONTENT, attachment, validFor);
         if (directAccessUrl == null)
         {
             throw new DisabledServiceException("Direct access url isn't available.");

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -592,7 +592,8 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      */
     @Override
     @Deprecated
-    public boolean isContentDirectUrlEnabled(NodeRef nodeRef) {
+    public boolean isContentDirectUrlEnabled(NodeRef nodeRef)
+    {
         return isContentDirectUrlEnabled(nodeRef, ContentModel.PROP_CONTENT);
     }
 

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software.
- * If the software was purchased under a paid Alfresco license, the terms of
- * the paid license agreement will prevail.  Otherwise, the software is
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
  * provided under the following open source license terms:
- *
+ * 
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * 
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -79,14 +79,14 @@ import org.springframework.extensions.surf.util.I18NUtil;
  * Note: This class was formerly the {@link RoutingContentService} but the
  * 'routing' functionality has been pushed into the {@link AbstractRoutingContentStore store}
  * implementations.
- *
+ * 
  * @author Derek Hulley
  * @since 3.2
  */
 public class ContentServiceImpl implements ContentService, ApplicationContextAware
 {
     private static final Log logger = LogFactory.getLog(ContentServiceImpl.class);
-
+    
     private DictionaryService dictionaryService;
     private NodeService nodeService;
     private MimetypeService mimetypeService;
@@ -108,29 +108,29 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * The policy component
      */
     private PolicyComponent policyComponent;
-
+    
     /*
      * Policies delegates
      */
     ClassPolicyDelegate<ContentServicePolicies.OnContentUpdatePolicy> onContentUpdateDelegate;
     ClassPolicyDelegate<ContentServicePolicies.OnContentPropertyUpdatePolicy> onContentPropertyUpdateDelegate;
     ClassPolicyDelegate<ContentServicePolicies.OnContentReadPolicy> onContentReadDelegate;
-
+    
     public void setRetryingTransactionHelper(RetryingTransactionHelper helper)
     {
         this.transactionHelper = helper;
     }
-
+    
     public void setDictionaryService(DictionaryService dictionaryService)
     {
         this.dictionaryService = dictionaryService;
     }
-
+    
     public void setNodeService(NodeService nodeService)
     {
         this.nodeService = nodeService;
     }
-
+    
     public void setMimetypeService(MimetypeService mimetypeService)
     {
         this.mimetypeService = mimetypeService;
@@ -185,16 +185,16 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 NodeServicePolicies.OnUpdatePropertiesPolicy.QNAME,
                 this,
                 new JavaBehaviour(this, "onUpdateProperties"));
-
+        
         // Register on content update policy
         this.onContentUpdateDelegate = this.policyComponent.registerClassPolicy(OnContentUpdatePolicy.class);
         this.onContentPropertyUpdateDelegate = this.policyComponent.registerClassPolicy(OnContentPropertyUpdatePolicy.class);
         this.onContentReadDelegate = this.policyComponent.registerClassPolicy(OnContentReadPolicy.class);
     }
-
+    
     /**
      * Update properties policy behaviour
-     *
+     * 
      * @param nodeRef    the node reference
      * @param before    the before values of the properties
      * @param after        the after values of the properties
@@ -209,7 +209,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         {
             return;
         }
-
+    	
         // Don't duplicate work when firing multiple policies
         Set<QName> types = null;
         OnContentPropertyUpdatePolicy propertyPolicy = null;            // Doesn't change for the node instance
@@ -236,7 +236,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 // We don't fire notifications for multi-valued content properties
                 continue;
             }
-
+            
             try
             {
                 ContentData beforeValue = (ContentData) before.get(propertyQName);
@@ -245,7 +245,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                         && (!ignoreEmptyContent || beforeValue.getSize() > 0);
                 boolean hasContentAfter = ContentData.hasContent(afterValue)
                         && (!ignoreEmptyContent || afterValue.getSize() > 0);
-
+                
                 // There are some shortcuts here
                 if (!hasContentBefore && !hasContentAfter)
                 {
@@ -257,10 +257,10 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                     // Still, nothing happening
                     continue;
                 }
-
+                
                 // Check for new content
                 isNewContent = isNewContent || !hasContentBefore && hasContentAfter;
-
+                
                 // Make it clear when there's no content before or after
                 if (!hasContentBefore)
                 {
@@ -277,13 +277,13 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                     String name = (String) nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
                     logger.debug(
                             "Content property updated: \n" +
-                                    "   Node Name:   " + name + "\n" +
-                                    "   Property:    " + propertyQName + "\n" +
-                                    "   Is new:      " + isNewContent + "\n" +
-                                    "   Before:      " + beforeValue + "\n" +
-                                    "   After:       " + afterValue);
+                            "   Node Name:   " + name + "\n" +
+                            "   Property:    " + propertyQName + "\n" +
+                            "   Is new:      " + isNewContent + "\n" +
+                            "   Before:      " + beforeValue + "\n" +
+                            "   After:       " + afterValue);
                 }
-
+                
                 // Fire specific policy
                 types = getTypes(nodeRef, types);
                 if (propertyPolicy == null)
@@ -291,7 +291,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                     propertyPolicy = onContentPropertyUpdateDelegate.get(nodeRef, types);
                 }
                 propertyPolicy.onContentPropertyUpdate(nodeRef, propertyQName, beforeValue, afterValue);
-
+                
                 // We also fire an event if *any* content property is changed
                 fire = true;
             }
@@ -310,11 +310,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             policy.onContentUpdate(nodeRef, isNewContent);
         }
     }
-
-
+    
+        
     /**
      * Helper method to lazily populate the types associated with a node
-     *
+     * 
      * @param nodeRef           the node
      * @param types             any existing types
      * @return                  the types - either newly populated or just what was passed in
@@ -363,14 +363,14 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         reader.setMimetype(MimetypeMap.MIMETYPE_BINARY);
         reader.setEncoding("UTF-8");
         reader.setLocale(I18NUtil.getLocale());
-
+        
         // Done
         if (logger.isDebugEnabled())
         {
             logger.debug(
                     "Direct request for reader: \n" +
-                            "   Content URL: " + contentUrl + "\n" +
-                            "   Reader:      " + reader);
+                    "   Content URL: " + contentUrl + "\n" +
+                    "   Reader:      " + reader);
         }
         return reader;
     }
@@ -379,7 +379,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     {
         return getReader(nodeRef, propertyQName, true);
     }
-
+        
     @SuppressWarnings("unchecked")
     private ContentReader getReader(NodeRef nodeRef, QName propertyQName, boolean fireContentReadPolicy)
     {
@@ -389,22 +389,22 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         if (contentData == null || contentData.getContentUrl() == null)
         {
             // there is no URL - the interface specifies that this is not an error condition
-            return null;
+            return null;                                
         }
         String contentUrl = contentData.getContentUrl();
-
+        
         // The context of the read is entirely described by the URL
         ContentReader reader = store.getReader(contentUrl);
         if (reader == null)
         {
             throw new AlfrescoRuntimeException("ContentStore implementations may not return null ContentReaders");
         }
-
+        
         // set extra data on the reader
         reader.setMimetype(contentData.getMimetype());
         reader.setEncoding(contentData.getEncoding());
         reader.setLocale(contentData.getLocale());
-
+        
         // Fire the content read policy
         if (reader != null && fireContentReadPolicy == true)
         {
@@ -414,7 +414,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             OnContentReadPolicy policy = this.onContentReadDelegate.get(nodeRef, types);
             policy.onContentRead(nodeRef);
         }
-
+        
         // we don't listen for anything
         // result may be null - but interface contract says we may return null
         return reader;
@@ -441,11 +441,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         if (contentData == null)
         {
             PropertyDefinition contentPropDef = dictionaryService.getProperty(propertyQName);
-
+            
             // if no value or a value other content, and a property definition has been provided, ensure that it's CONTENT or ANY            
-            if (contentPropDef != null &&
-                    (!(contentPropDef.getDataType().getName().equals(DataTypeDefinition.CONTENT) ||
-                            contentPropDef.getDataType().getName().equals(DataTypeDefinition.ANY))))
+            if (contentPropDef != null && 
+                (!(contentPropDef.getDataType().getName().equals(DataTypeDefinition.CONTENT) ||
+                   contentPropDef.getDataType().getName().equals(DataTypeDefinition.ANY))))
             {
                 throw new InvalidTypeException("The node property must be of type content: \n" +
                         "   node: " + nodeRef + "\n" +
@@ -469,10 +469,10 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             // done
             return writer;
         }
-
+        
         // check for an existing URL - the get of the reader will perform type checking
         ContentReader existingContentReader = getReader(nodeRef, propertyQName, false);
-
+        
         // get the content using the (potentially) existing content - the new content
         // can be wherever the store decides.
         ContentContext ctx = new NodeContentContext(existingContentReader, null, nodeRef, propertyQName);
@@ -490,7 +490,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             writer.setEncoding(contentData.getEncoding());
             writer.setLocale(contentData.getLocale());
         }
-
+        
         // attach a listener if required
         if (update)
         {
@@ -498,15 +498,15 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             WriteStreamListener listener = new WriteStreamListener(nodeService, nodeRef, propertyQName, writer);
             listener.setRetryingTransactionHelper(transactionHelper);
             writer.addListener(listener);
-
+            
         }
-
+        
         // supply the writer with a copy of the mimetype service if needed
         if (writer instanceof MimetypeServiceAware)
         {
             ((MimetypeServiceAware)writer).setMimetypeService(mimetypeService);
         }
-
+        
         // give back to the client
         return writer;
     }
@@ -524,7 +524,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * Ensures that, upon closure of the output stream, the node is updated with
      * the latest URL of the content to which it refers.
      * <p>
-     *
+     * 
      * @author Derek Hulley
      */
     private static class WriteStreamListener extends AbstractContentStreamListener
@@ -533,7 +533,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         private NodeRef nodeRef;
         private QName propertyQName;
         private ContentWriter writer;
-
+        
         public WriteStreamListener(
                 NodeService nodeService,
                 NodeRef nodeRef,
@@ -545,7 +545,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             this.propertyQName = propertyQName;
             this.writer = writer;
         }
-
+        
         public void contentStreamClosedImpl() throws ContentIOException
         {
             try
@@ -571,7 +571,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 throw new ContentIOException("Failed to set content property on stream closure: \n" +
                         "   node: " + nodeRef + "\n" +
                         "   property: " + propertyQName + "\n" +
-                        "   writer: " + writer + "\n" +
+                        "   writer: " + writer + "\n" + 
                         e.toString(),
                         e);
             }
@@ -708,6 +708,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         {
             validFor = systemWideDirectUrlConfig.getDefaultExpiryTimeInSec();
         }
-        return validFor;
+         return validFor;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -79,14 +79,14 @@ import org.springframework.extensions.surf.util.I18NUtil;
  * Note: This class was formerly the {@link RoutingContentService} but the
  * 'routing' functionality has been pushed into the {@link AbstractRoutingContentStore store}
  * implementations.
- * 
+ *
  * @author Derek Hulley
  * @since 3.2
  */
 public class ContentServiceImpl implements ContentService, ApplicationContextAware
 {
     private static final Log logger = LogFactory.getLog(ContentServiceImpl.class);
-    
+
     private DictionaryService dictionaryService;
     private NodeService nodeService;
     private MimetypeService mimetypeService;
@@ -108,29 +108,29 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * The policy component
      */
     private PolicyComponent policyComponent;
-    
+
     /*
      * Policies delegates
      */
     ClassPolicyDelegate<ContentServicePolicies.OnContentUpdatePolicy> onContentUpdateDelegate;
     ClassPolicyDelegate<ContentServicePolicies.OnContentPropertyUpdatePolicy> onContentPropertyUpdateDelegate;
     ClassPolicyDelegate<ContentServicePolicies.OnContentReadPolicy> onContentReadDelegate;
-    
+
     public void setRetryingTransactionHelper(RetryingTransactionHelper helper)
     {
         this.transactionHelper = helper;
     }
-    
+
     public void setDictionaryService(DictionaryService dictionaryService)
     {
         this.dictionaryService = dictionaryService;
     }
-    
+
     public void setNodeService(NodeService nodeService)
     {
         this.nodeService = nodeService;
     }
-    
+
     public void setMimetypeService(MimetypeService mimetypeService)
     {
         this.mimetypeService = mimetypeService;
@@ -185,16 +185,16 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 NodeServicePolicies.OnUpdatePropertiesPolicy.QNAME,
                 this,
                 new JavaBehaviour(this, "onUpdateProperties"));
-        
+
         // Register on content update policy
         this.onContentUpdateDelegate = this.policyComponent.registerClassPolicy(OnContentUpdatePolicy.class);
         this.onContentPropertyUpdateDelegate = this.policyComponent.registerClassPolicy(OnContentPropertyUpdatePolicy.class);
         this.onContentReadDelegate = this.policyComponent.registerClassPolicy(OnContentReadPolicy.class);
     }
-    
+
     /**
      * Update properties policy behaviour
-     * 
+     *
      * @param nodeRef    the node reference
      * @param before    the before values of the properties
      * @param after        the after values of the properties
@@ -209,7 +209,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         {
             return;
         }
-    	
+
         // Don't duplicate work when firing multiple policies
         Set<QName> types = null;
         OnContentPropertyUpdatePolicy propertyPolicy = null;            // Doesn't change for the node instance
@@ -236,7 +236,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 // We don't fire notifications for multi-valued content properties
                 continue;
             }
-            
+
             try
             {
                 ContentData beforeValue = (ContentData) before.get(propertyQName);
@@ -245,7 +245,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                         && (!ignoreEmptyContent || beforeValue.getSize() > 0);
                 boolean hasContentAfter = ContentData.hasContent(afterValue)
                         && (!ignoreEmptyContent || afterValue.getSize() > 0);
-                
+
                 // There are some shortcuts here
                 if (!hasContentBefore && !hasContentAfter)
                 {
@@ -257,10 +257,10 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                     // Still, nothing happening
                     continue;
                 }
-                
+
                 // Check for new content
                 isNewContent = isNewContent || !hasContentBefore && hasContentAfter;
-                
+
                 // Make it clear when there's no content before or after
                 if (!hasContentBefore)
                 {
@@ -277,13 +277,13 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                     String name = (String) nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
                     logger.debug(
                             "Content property updated: \n" +
-                            "   Node Name:   " + name + "\n" +
-                            "   Property:    " + propertyQName + "\n" +
-                            "   Is new:      " + isNewContent + "\n" +
-                            "   Before:      " + beforeValue + "\n" +
-                            "   After:       " + afterValue);
+                                    "   Node Name:   " + name + "\n" +
+                                    "   Property:    " + propertyQName + "\n" +
+                                    "   Is new:      " + isNewContent + "\n" +
+                                    "   Before:      " + beforeValue + "\n" +
+                                    "   After:       " + afterValue);
                 }
-                
+
                 // Fire specific policy
                 types = getTypes(nodeRef, types);
                 if (propertyPolicy == null)
@@ -291,7 +291,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                     propertyPolicy = onContentPropertyUpdateDelegate.get(nodeRef, types);
                 }
                 propertyPolicy.onContentPropertyUpdate(nodeRef, propertyQName, beforeValue, afterValue);
-                
+
                 // We also fire an event if *any* content property is changed
                 fire = true;
             }
@@ -310,11 +310,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             policy.onContentUpdate(nodeRef, isNewContent);
         }
     }
-    
-        
+
+
     /**
      * Helper method to lazily populate the types associated with a node
-     * 
+     *
      * @param nodeRef           the node
      * @param types             any existing types
      * @return                  the types - either newly populated or just what was passed in
@@ -363,14 +363,14 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         reader.setMimetype(MimetypeMap.MIMETYPE_BINARY);
         reader.setEncoding("UTF-8");
         reader.setLocale(I18NUtil.getLocale());
-        
+
         // Done
         if (logger.isDebugEnabled())
         {
             logger.debug(
                     "Direct request for reader: \n" +
-                    "   Content URL: " + contentUrl + "\n" +
-                    "   Reader:      " + reader);
+                            "   Content URL: " + contentUrl + "\n" +
+                            "   Reader:      " + reader);
         }
         return reader;
     }
@@ -379,7 +379,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     {
         return getReader(nodeRef, propertyQName, true);
     }
-        
+
     @SuppressWarnings("unchecked")
     private ContentReader getReader(NodeRef nodeRef, QName propertyQName, boolean fireContentReadPolicy)
     {
@@ -389,22 +389,22 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         if (contentData == null || contentData.getContentUrl() == null)
         {
             // there is no URL - the interface specifies that this is not an error condition
-            return null;                                
+            return null;
         }
         String contentUrl = contentData.getContentUrl();
-        
+
         // The context of the read is entirely described by the URL
         ContentReader reader = store.getReader(contentUrl);
         if (reader == null)
         {
             throw new AlfrescoRuntimeException("ContentStore implementations may not return null ContentReaders");
         }
-        
+
         // set extra data on the reader
         reader.setMimetype(contentData.getMimetype());
         reader.setEncoding(contentData.getEncoding());
         reader.setLocale(contentData.getLocale());
-        
+
         // Fire the content read policy
         if (reader != null && fireContentReadPolicy == true)
         {
@@ -414,7 +414,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             OnContentReadPolicy policy = this.onContentReadDelegate.get(nodeRef, types);
             policy.onContentRead(nodeRef);
         }
-        
+
         // we don't listen for anything
         // result may be null - but interface contract says we may return null
         return reader;
@@ -441,11 +441,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         if (contentData == null)
         {
             PropertyDefinition contentPropDef = dictionaryService.getProperty(propertyQName);
-            
+
             // if no value or a value other content, and a property definition has been provided, ensure that it's CONTENT or ANY            
-            if (contentPropDef != null && 
-                (!(contentPropDef.getDataType().getName().equals(DataTypeDefinition.CONTENT) ||
-                   contentPropDef.getDataType().getName().equals(DataTypeDefinition.ANY))))
+            if (contentPropDef != null &&
+                    (!(contentPropDef.getDataType().getName().equals(DataTypeDefinition.CONTENT) ||
+                            contentPropDef.getDataType().getName().equals(DataTypeDefinition.ANY))))
             {
                 throw new InvalidTypeException("The node property must be of type content: \n" +
                         "   node: " + nodeRef + "\n" +
@@ -469,10 +469,10 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             // done
             return writer;
         }
-        
+
         // check for an existing URL - the get of the reader will perform type checking
         ContentReader existingContentReader = getReader(nodeRef, propertyQName, false);
-        
+
         // get the content using the (potentially) existing content - the new content
         // can be wherever the store decides.
         ContentContext ctx = new NodeContentContext(existingContentReader, null, nodeRef, propertyQName);
@@ -490,7 +490,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             writer.setEncoding(contentData.getEncoding());
             writer.setLocale(contentData.getLocale());
         }
-        
+
         // attach a listener if required
         if (update)
         {
@@ -498,15 +498,15 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             WriteStreamListener listener = new WriteStreamListener(nodeService, nodeRef, propertyQName, writer);
             listener.setRetryingTransactionHelper(transactionHelper);
             writer.addListener(listener);
-            
+
         }
-        
+
         // supply the writer with a copy of the mimetype service if needed
         if (writer instanceof MimetypeServiceAware)
         {
             ((MimetypeServiceAware)writer).setMimetypeService(mimetypeService);
         }
-        
+
         // give back to the client
         return writer;
     }
@@ -524,7 +524,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * Ensures that, upon closure of the output stream, the node is updated with
      * the latest URL of the content to which it refers.
      * <p>
-     * 
+     *
      * @author Derek Hulley
      */
     private static class WriteStreamListener extends AbstractContentStreamListener
@@ -533,7 +533,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         private NodeRef nodeRef;
         private QName propertyQName;
         private ContentWriter writer;
-        
+
         public WriteStreamListener(
                 NodeService nodeService,
                 NodeRef nodeRef,
@@ -545,7 +545,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             this.propertyQName = propertyQName;
             this.writer = writer;
         }
-        
+
         public void contentStreamClosedImpl() throws ContentIOException
         {
             try
@@ -571,7 +571,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 throw new ContentIOException("Failed to set content property on stream closure: \n" +
                         "   node: " + nodeRef + "\n" +
                         "   property: " + propertyQName + "\n" +
-                        "   writer: " + writer + "\n" + 
+                        "   writer: " + writer + "\n" +
                         e.toString(),
                         e);
             }
@@ -591,14 +591,23 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * {@inheritDoc}
      */
     @Override
-    public boolean isContentDirectUrlEnabled(NodeRef nodeRef)
+    @Deprecated
+    public boolean isContentDirectUrlEnabled(NodeRef nodeRef) {
+        return isContentDirectUrlEnabled(nodeRef, ContentModel.PROP_CONTENT);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isContentDirectUrlEnabled(NodeRef nodeRef, QName propertyQName)
     {
         boolean contentDirectUrlEnabled = false;
 
         // TODO: update this
         if (systemWideDirectUrlConfig.isEnabled())
         {
-            ContentData contentData = getContentData(nodeRef, ContentModel.PROP_CONTENT);
+            ContentData contentData = getContentData(nodeRef, propertyQName);
 
             // check that the URL is available
             if (contentData == null || contentData.getContentUrl() == null)
@@ -615,14 +624,25 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     /**
      * {@inheritDoc}
      */
+    @Override
+    @Deprecated
     public DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment, Long validFor)
+    {
+        return requestContentDirectUrl(nodeRef, ContentModel.PROP_CONTENT, attachment, validFor);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, QName propertyQName, boolean attachment, Long validFor)
     {
         if (!systemWideDirectUrlConfig.isEnabled())
         {
             throw new DirectAccessUrlDisabledException("Direct access url isn't available.");
         }
 
-        ContentData contentData = getContentData(nodeRef, ContentModel.PROP_CONTENT);
+        ContentData contentData = getContentData(nodeRef, propertyQName);
         // check that the content & URL is available
         if (contentData == null || contentData.getContentUrl() == null)
         {
@@ -688,6 +708,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         {
             validFor = systemWideDirectUrlConfig.getDefaultExpiryTimeInSec();
         }
-         return validFor;
+        return validFor;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -591,16 +591,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * {@inheritDoc}
      */
     @Override
-    @Deprecated
-    public boolean isContentDirectUrlEnabled(NodeRef nodeRef)
-    {
-        return isContentDirectUrlEnabled(nodeRef, ContentModel.PROP_CONTENT);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean isContentDirectUrlEnabled(NodeRef nodeRef, QName propertyQName)
     {
         boolean contentDirectUrlEnabled = false;
@@ -620,16 +610,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         }
 
         return contentDirectUrlEnabled;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @Deprecated
-    public DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment, Long validFor)
-    {
-        return requestContentDirectUrl(nodeRef, ContentModel.PROP_CONTENT, attachment, validFor);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software.
- * If the software was purchased under a paid Alfresco license, the terms of
- * the paid license agreement will prevail.  Otherwise, the software is
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
  * provided under the following open source license terms:
- *
+ * 
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * 
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -49,11 +49,11 @@ import java.util.Map;
  * Whereas the content stores have no knowledge of nodes other than their
  * references, the <code>ContentService</code> <b>is</b> responsible for
  * ensuring that all the relevant node-content relationships are maintained.
- *
+ * 
  * @see org.alfresco.repo.content.ContentStore
  * @see org.alfresco.service.cmr.repository.ContentReader
  * @see org.alfresco.service.cmr.repository.ContentWriter
- *
+ * 
  * @author Derek Hulley
  */
 @AlfrescoPublicApi
@@ -61,26 +61,26 @@ public interface ContentService
 {
     /**
      * Gets the total space of the underlying content store (not exclusively Alfresco-controlled binaries).
-     *
+     * 
      * @return
      *      Returns the total, possibly approximate, size (in bytes) of of the store
      *      or <tt>-1</tt> if no size data is available.
-     *
+     * 
      * @since 3.3.3
      */
     public long getStoreTotalSpace();
-
+    
     /**
      * Gets the remaing <i>available</i> space in the underlying content store.
-     *
+     * 
      * @return
      *      Returns the total, possibly approximate, remaining space (in bytes) available to store content
      *      or <tt>-1</tt> if no size data is available.
-     *
+     * 
      * @since 3.3.3
      */
     public long getStoreFreeSpace();
-
+    
     /**
      * Fetch content from the low-level stores using a content URL.  None of the
      * metadata associated with the content will be populated.  This method should
@@ -89,27 +89,27 @@ public interface ContentService
      * <p>
      * <tt>null</tt> is never returned, but the reader should always be checked for
      * {@link ContentReader#exists() existence}.
-     *
+     * 
      * @param contentUrl        a content store URL
      * @return                  Returns a reader for the URL that needs to be checked.
      */
     @Auditable(parameters = {"contentUrl"})
     public ContentReader getRawReader(String contentUrl);
-
+    
     /**
      * Gets a reader for the content associated with the given node property.
      * <p>
      * If a content URL is present for the given node then a reader <b>must</b>
      * be returned.  The {@link ContentReader#exists() exists} method should then
      * be used to detect 'missing' content.
-     *
+     * 
      * @param nodeRef a reference to a node having a content property
      * @param propertyQName the name of the property, which must be of type <b>content</b>
      * @return Returns a reader for the content associated with the node property,
      *      or null if no content has been written for the property
      * @throws InvalidNodeRefException if the node doesn't exist
      * @throws InvalidTypeException if the node is not of type <b>content</b>
-     *
+     * 
      * @see org.alfresco.repo.content.filestore.FileContentReader#getSafeContentReader(ContentReader, String, Object[])
      */
     @Auditable(parameters = {"nodeRef", "propertyQName"})
@@ -134,7 +134,7 @@ public interface ContentService
      * will not be cleaned up subsequently.  The recommended pattern is to group calls to retrieve
      * the writer in the same transaction as the calls to subsequently update and close the
      * write stream - including setting of the related content properties.
-     *
+     * 
      * @param nodeRef a reference to a node having a content property, or <tt>null</tt>
      *      to just get a valid writer into a backing content store.
      * @param propertyQName the name of the property, which must be of type <b>content</b>
@@ -147,12 +147,12 @@ public interface ContentService
      */
     @Auditable(parameters = {"nodeRef", "propertyQName", "update"})
     public ContentWriter getWriter(NodeRef nodeRef, QName propertyQName, boolean update)
-            throws InvalidNodeRefException, InvalidTypeException;
+                throws InvalidNodeRefException, InvalidTypeException;
 
     /**
      * Gets a writer to a temporary location.  The longevity of the stored
      * temporary content is determined by the system.
-     *
+     * 
      * @return Returns a writer onto a temporary location
      */
     @Auditable

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -27,6 +27,7 @@ package org.alfresco.service.cmr.repository;
 
 
 import org.alfresco.api.AlfrescoPublicApi;
+import org.alfresco.model.ContentModel;
 import org.alfresco.service.Auditable;
 import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.dictionary.InvalidTypeException;
@@ -227,7 +228,10 @@ public interface ContentService
      */
     @Auditable(parameters = {"nodeRef", "validFor"})
     @Deprecated
-    DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment, Long validFor);
+    default public DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment, Long validFor)
+    {
+        return requestContentDirectUrl(nodeRef, ContentModel.PROP_CONTENT, attachment, validFor);
+    }
 
 
     /**

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -49,11 +49,11 @@ import java.util.Map;
  * Whereas the content stores have no knowledge of nodes other than their
  * references, the <code>ContentService</code> <b>is</b> responsible for
  * ensuring that all the relevant node-content relationships are maintained.
- * 
+ *
  * @see org.alfresco.repo.content.ContentStore
  * @see org.alfresco.service.cmr.repository.ContentReader
  * @see org.alfresco.service.cmr.repository.ContentWriter
- * 
+ *
  * @author Derek Hulley
  */
 @AlfrescoPublicApi
@@ -61,26 +61,26 @@ public interface ContentService
 {
     /**
      * Gets the total space of the underlying content store (not exclusively Alfresco-controlled binaries).
-     * 
+     *
      * @return
      *      Returns the total, possibly approximate, size (in bytes) of of the store
      *      or <tt>-1</tt> if no size data is available.
-     * 
+     *
      * @since 3.3.3
      */
     public long getStoreTotalSpace();
-    
+
     /**
      * Gets the remaing <i>available</i> space in the underlying content store.
-     * 
+     *
      * @return
      *      Returns the total, possibly approximate, remaining space (in bytes) available to store content
      *      or <tt>-1</tt> if no size data is available.
-     * 
+     *
      * @since 3.3.3
      */
     public long getStoreFreeSpace();
-    
+
     /**
      * Fetch content from the low-level stores using a content URL.  None of the
      * metadata associated with the content will be populated.  This method should
@@ -89,27 +89,27 @@ public interface ContentService
      * <p>
      * <tt>null</tt> is never returned, but the reader should always be checked for
      * {@link ContentReader#exists() existence}.
-     * 
+     *
      * @param contentUrl        a content store URL
      * @return                  Returns a reader for the URL that needs to be checked.
      */
     @Auditable(parameters = {"contentUrl"})
     public ContentReader getRawReader(String contentUrl);
-    
+
     /**
      * Gets a reader for the content associated with the given node property.
      * <p>
      * If a content URL is present for the given node then a reader <b>must</b>
      * be returned.  The {@link ContentReader#exists() exists} method should then
      * be used to detect 'missing' content.
-     * 
+     *
      * @param nodeRef a reference to a node having a content property
      * @param propertyQName the name of the property, which must be of type <b>content</b>
      * @return Returns a reader for the content associated with the node property,
      *      or null if no content has been written for the property
      * @throws InvalidNodeRefException if the node doesn't exist
      * @throws InvalidTypeException if the node is not of type <b>content</b>
-     * 
+     *
      * @see org.alfresco.repo.content.filestore.FileContentReader#getSafeContentReader(ContentReader, String, Object[])
      */
     @Auditable(parameters = {"nodeRef", "propertyQName"})
@@ -134,7 +134,7 @@ public interface ContentService
      * will not be cleaned up subsequently.  The recommended pattern is to group calls to retrieve
      * the writer in the same transaction as the calls to subsequently update and close the
      * write stream - including setting of the related content properties.
-     * 
+     *
      * @param nodeRef a reference to a node having a content property, or <tt>null</tt>
      *      to just get a valid writer into a backing content store.
      * @param propertyQName the name of the property, which must be of type <b>content</b>
@@ -147,12 +147,12 @@ public interface ContentService
      */
     @Auditable(parameters = {"nodeRef", "propertyQName", "update"})
     public ContentWriter getWriter(NodeRef nodeRef, QName propertyQName, boolean update)
-                throws InvalidNodeRefException, InvalidTypeException;
+            throws InvalidNodeRefException, InvalidTypeException;
 
     /**
      * Gets a writer to a temporary location.  The longevity of the stored
      * temporary content is determined by the system.
-     * 
+     *
      * @return Returns a writer onto a temporary location
      */
     @Auditable
@@ -170,7 +170,17 @@ public interface ContentService
      *
      * @return {@code true} if direct access URLs retrieving is supported for the node, {@code false} otherwise
      */
+    @Deprecated
     boolean isContentDirectUrlEnabled(NodeRef nodeRef);
+
+    /**
+     * Checks if the system and store supports the retrieving of a direct access {@code URL} for the given node.
+     *
+     * @param nodeRef a reference to a node having a content property
+     * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @return {@code true} if direct access URLs retrieving is supported for the node, {@code false} otherwise
+     */
+    boolean isContentDirectUrlEnabled(NodeRef nodeRef, QName propertyQName);
 
     /**
      * Gets a presigned URL to directly access the content. It is up to the actual store
@@ -181,9 +191,25 @@ public interface ContentService
      * @return A direct access {@code URL} object for the content.
      * @throws UnsupportedOperationException if the store is unable to provide the information.
      */
+    @Deprecated
     default DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment)
     {
         return requestContentDirectUrl(nodeRef, attachment, null);
+    }
+
+    /**
+     * Gets a presigned URL to directly access the content. It is up to the actual store
+     * implementation if it can fulfil this request with an expiry time or not.
+     *
+     * @param nodeRef Node ref for which to obtain the direct access {@code URL}.
+     * @param attachment {@code true} if an attachment URL is requested, {@code false} for an embedded {@code URL}.
+     * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @return A direct access {@code URL} object for the content.
+     * @throws UnsupportedOperationException if the store is unable to provide the information.
+     */
+    default DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, QName propertyQName, boolean attachment)
+    {
+        return requestContentDirectUrl(nodeRef, propertyQName, attachment, null);
     }
 
     /**
@@ -197,7 +223,23 @@ public interface ContentService
      * @throws UnsupportedOperationException if the store is unable to provide the information.
      */
     @Auditable(parameters = {"nodeRef", "validFor"})
+    @Deprecated
     DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, boolean attachment, Long validFor);
+
+
+    /**
+     * Gets a presigned URL to directly access the content. It is up to the actual store
+     * implementation if it can fulfil this request with an expiry time or not.
+     *
+     * @param nodeRef Node ref for which to obtain the direct access {@code URL}.
+     * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @param attachment {@code true} if an attachment URL is requested, {@code false} for an embedded {@code URL}.
+     * @param validFor The time at which the direct access {@code URL} will expire.
+     * @return A direct access {@code URL} object for the content.
+     * @throws UnsupportedOperationException if the store is unable to provide the information.
+     */
+    @Auditable(parameters = {"nodeRef", "validFor"})
+    DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, QName propertyQName, boolean attachment, Long validFor);
 
     /**
      * Gets a key-value (String-String) collection of storage headers/properties with their respective values for a specific node reference.

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -244,7 +244,7 @@ public interface ContentService
      * @return A direct access {@code URL} object for the content.
      * @throws UnsupportedOperationException if the store is unable to provide the information.
      */
-    @Auditable(parameters = {"nodeRef", "validFor"})
+    @Auditable(parameters = {"nodeRef", "propertyQName", "validFor"})
     DirectAccessUrl requestContentDirectUrl(NodeRef nodeRef, QName propertyQName, boolean attachment, Long validFor);
 
     /**

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -171,7 +171,10 @@ public interface ContentService
      * @return {@code true} if direct access URLs retrieving is supported for the node, {@code false} otherwise
      */
     @Deprecated
-    boolean isContentDirectUrlEnabled(NodeRef nodeRef);
+    default boolean isContentDirectUrlEnabled(NodeRef nodeRef)
+    {
+        return isContentDirectUrlEnabled(nodeRef, ContentModel.PROP_CONTENT);
+    }
 
     /**
      * Checks if the system and store supports the retrieving of a direct access {@code URL} for the given node.

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -206,8 +206,8 @@ public interface ContentService
      * implementation if it can fulfil this request with an expiry time or not.
      *
      * @param nodeRef Node ref for which to obtain the direct access {@code URL}.
-     * @param attachment {@code true} if an attachment URL is requested, {@code false} for an embedded {@code URL}.
      * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @param attachment {@code true} if an attachment URL is requested, {@code false} for an embedded {@code URL}.
      * @return A direct access {@code URL} object for the content.
      * @throws UnsupportedOperationException if the store is unable to provide the information.
      */
@@ -232,7 +232,6 @@ public interface ContentService
     {
         return requestContentDirectUrl(nodeRef, ContentModel.PROP_CONTENT, attachment, validFor);
     }
-
 
     /**
      * Gets a presigned URL to directly access the content. It is up to the actual store

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -48,6 +48,7 @@ import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.DirectAccessUrl;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.namespace.QName;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -77,6 +78,8 @@ public class ContentServiceImplUnitTest
     private static final String VALUE_1 = "value1";
     private static final String X_AMZ_HEADER_2 = "x-amz-header-2";
     private static final String VALUE_2 = "value2";
+
+    private static final QName  QNAME = QName.createQName("{test}MyNoContentNode");
 
     @InjectMocks
     private ContentServiceImpl contentService;
@@ -134,6 +137,21 @@ public class ContentServiceImplUnitTest
         try
         {
             contentService.requestContentDirectUrl(NODE_REF, true, 20L);
+            fail("Expected DirectAccessUrlDisabledException");
+        }
+        catch (DirectAccessUrlDisabledException ex)
+        {
+            verify(mockContentStore, never()).isContentDirectUrlEnabled();
+        }
+    }
+
+    @Test
+    public void testRequestContentDirectUrl_SystemWideIsDisabledwithQname()
+    {
+        setupSystemWideDirectAccessConfig(DISABLED);
+        try
+        {
+            contentService.requestContentDirectUrl(NODE_REF, QNAME, true);
             fail("Expected DirectAccessUrlDisabledException");
         }
         catch (DirectAccessUrlDisabledException ex)

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -79,7 +79,7 @@ public class ContentServiceImplUnitTest
     private static final String X_AMZ_HEADER_2 = "x-amz-header-2";
     private static final String VALUE_2 = "value2";
 
-    private static final QName QNAME = ContentModel.PROP_CONTENT;
+    private static final QName PROP_CONTENT_QNAME = ContentModel.PROP_CONTENT;
 
     @InjectMocks
     private ContentServiceImpl contentService;
@@ -136,7 +136,7 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(DISABLED);
         try
         {
-            contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
+            contentService.requestContentDirectUrl(NODE_REF, PROP_CONTENT_QNAME, true, 20L);
             fail("Expected DirectAccessUrlDisabledException");
         }
         catch (DirectAccessUrlDisabledException ex)
@@ -151,7 +151,7 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(ENABLED);
         when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(DISABLED);
 
-        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME,true, 20L);
+        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, PROP_CONTENT_QNAME,true, 20L);
         assertNull(directAccessUrl);
         verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
     }
@@ -162,7 +162,7 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(ENABLED);
         when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(ENABLED);
 
-        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
+        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, PROP_CONTENT_QNAME, true, 20L);
         assertNull(directAccessUrl);
         verify(mockContentStore, times(1)).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
     }

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -134,15 +134,11 @@ public class ContentServiceImplUnitTest
     public void testRequestContentDirectUrl_SystemWideIsDisabled()
     {
         setupSystemWideDirectAccessConfig(DISABLED);
-        try
-        {
+        assertThrows(DirectAccessUrlDisabledException.class, () -> {
             contentService.requestContentDirectUrl(NODE_REF, PROP_CONTENT_QNAME, true, 20L);
             fail("Expected DirectAccessUrlDisabledException");
-        }
-        catch (DirectAccessUrlDisabledException ex)
-        {
-            verify(mockContentStore, never()).isContentDirectUrlEnabled();
-        }
+        });
+        verify(mockContentStore, never()).isContentDirectUrlEnabled();
     }
 
     @Test

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -146,12 +146,12 @@ public class ContentServiceImplUnitTest
     }
 
     @Test
-    public void testRequestContentDirectUrl_SystemWideIsDisabledwithQname()
+    public void testRequestContentDirectUrlwithQname_SystemWideIsDisabled()
     {
         setupSystemWideDirectAccessConfig(DISABLED);
         try
         {
-            contentService.requestContentDirectUrl(NODE_REF, QNAME, true);
+            contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
             fail("Expected DirectAccessUrlDisabledException");
         }
         catch (DirectAccessUrlDisabledException ex)
@@ -172,12 +172,34 @@ public class ContentServiceImplUnitTest
     }
 
     @Test
+    public void testRequestContentDirectUrlwithQname_SystemWideIsEnabledButStoreIsDisabled()
+    {
+        setupSystemWideDirectAccessConfig(ENABLED);
+        when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(DISABLED);
+
+        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
+        assertNull(directAccessUrl);
+        verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
+    }
+
+    @Test
     public void testRequestContentDirectUrl_StoreIsEnabledButNotImplemented()
     {
         setupSystemWideDirectAccessConfig(ENABLED);
         when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(ENABLED);
 
         DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, true, 20L);
+        assertNull(directAccessUrl);
+        verify(mockContentStore, times(1)).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    public void testRequestContentDirectUrlwithQname_StoreIsEnabledButNotImplemented()
+    {
+        setupSystemWideDirectAccessConfig(ENABLED);
+        when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(ENABLED);
+
+        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
         assertNull(directAccessUrl);
         verify(mockContentStore, times(1)).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
     }

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -136,21 +136,6 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(DISABLED);
         try
         {
-            contentService.requestContentDirectUrl(NODE_REF, true, 20L);
-            fail("Expected DirectAccessUrlDisabledException");
-        }
-        catch (DirectAccessUrlDisabledException ex)
-        {
-            verify(mockContentStore, never()).isContentDirectUrlEnabled();
-        }
-    }
-
-    @Test
-    public void testRequestContentDirectUrlwithQname_SystemWideIsDisabled()
-    {
-        setupSystemWideDirectAccessConfig(DISABLED);
-        try
-        {
             contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
             fail("Expected DirectAccessUrlDisabledException");
         }
@@ -166,17 +151,6 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(ENABLED);
         when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(DISABLED);
 
-        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, true, 20L);
-        assertNull(directAccessUrl);
-        verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
-    }
-
-    @Test
-    public void testRequestContentDirectUrlwithQname_SystemWideIsEnabledButStoreIsDisabled()
-    {
-        setupSystemWideDirectAccessConfig(ENABLED);
-        when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(DISABLED);
-
         DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME,true, 20L);
         assertNull(directAccessUrl);
         verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
@@ -184,17 +158,6 @@ public class ContentServiceImplUnitTest
 
     @Test
     public void testRequestContentDirectUrl_StoreIsEnabledButNotImplemented()
-    {
-        setupSystemWideDirectAccessConfig(ENABLED);
-        when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(ENABLED);
-
-        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, true, 20L);
-        assertNull(directAccessUrl);
-        verify(mockContentStore, times(1)).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
-    }
-
-    @Test
-    public void testRequestContentDirectUrlwithQname_StoreIsEnabledButNotImplemented()
     {
         setupSystemWideDirectAccessConfig(ENABLED);
         when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(ENABLED);

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -79,7 +79,7 @@ public class ContentServiceImplUnitTest
     private static final String X_AMZ_HEADER_2 = "x-amz-header-2";
     private static final String VALUE_2 = "value2";
 
-    private static final QName  QNAME = QName.createQName("{test}MyNoContentNode");
+    private static final QName QNAME = ContentModel.PROP_CONTENT;
 
     @InjectMocks
     private ContentServiceImpl contentService;
@@ -177,7 +177,7 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(ENABLED);
         when(mockContentStore.isContentDirectUrlEnabled()).thenReturn(DISABLED);
 
-        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME, true, 20L);
+        DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, QNAME,true, 20L);
         assertNull(directAccessUrl);
         verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
     }

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -136,7 +136,6 @@ public class ContentServiceImplUnitTest
         setupSystemWideDirectAccessConfig(DISABLED);
         assertThrows(DirectAccessUrlDisabledException.class, () -> {
             contentService.requestContentDirectUrl(NODE_REF, PROP_CONTENT_QNAME, true, 20L);
-            fail("Expected DirectAccessUrlDisabledException");
         });
         verify(mockContentStore, never()).isContentDirectUrlEnabled();
     }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -63,6 +63,7 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
      * Test content data
      */
     private final static String UPDATED_CONTENT = "This content has been updated with a new value.";
+    private static final QName  QNAME = QName.createQName("{test}MyNoContentNode");
     
     /**
      * The version content store
@@ -186,5 +187,49 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
 
         assertNull(contentService.requestContentDirectUrl(nodeRef, true, null));
         assertNull(contentService.requestContentDirectUrl(nodeRef, true, validFor));
+    }
+
+    @Test
+    public void testwithQnameWhenRequestContentDirectUrlIsNotSupported()
+    {
+        openMocks(this);
+        when(mockSystemWideDirectUrlConfig.isEnabled()).thenReturn(ENABLED);
+        when(mockSystemWideDirectUrlConfig.getDefaultExpiryTimeInSec()).thenReturn(30L);
+        when(mockSystemWideDirectUrlConfig.getMaxExpiryTimeInSec()).thenReturn(300L);
+
+        assertFalse(contentStore.isContentDirectUrlEnabled());
+
+        // Set the presigned URL to expire after one minute.
+        Long validFor = 60L;
+
+        try
+        {
+            // Create a node without content
+            NodeRef nodeRef = this.dbNodeService
+                    .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
+
+            assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
+            fail("nodeRef has no content");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
+
+        try
+        {
+            assertNull(contentService.requestContentDirectUrl(null, QNAME, true, null));
+            fail("nodeRef is null");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
+
+        // Create a node with content
+        NodeRef nodeRef = createNewVersionableNode();
+
+        assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, null));
+        assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -159,27 +159,24 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
         // Set the presigned URL to expire after one minute.
         Long validFor = 60L;
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows("nodeRef has no content", IllegalArgumentException.class, () -> {
             // Create a node without content
             NodeRef nodeRef = this.dbNodeService
                     .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
 
             assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
-            fail("nodeRef has no content");
         });
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows("nodeRef is null", IllegalArgumentException.class, () -> {
             assertNull(contentService.requestContentDirectUrl(null, null, true, null));
-            fail("nodeRef is null");
         });
 
-        assertThrows(NullPointerException.class, () -> {
+        assertThrows("propertyQName has no content", NullPointerException.class, () -> {
             // Create a node without content
             NodeRef nodeRef = this.dbNodeService
                     .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
 
             contentService.requestContentDirectUrl(nodeRef, null, true, validFor);
-            fail("propertyQName has no content");
         });
 
         // Create a node with content

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -181,6 +181,19 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
         {
             // Expected exception
         }
+        try
+        {
+            // Create a node without content
+            NodeRef nodeRef = this.dbNodeService
+                    .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
+
+            assertNull(contentService.requestContentDirectUrl(nodeRef, null, true, validFor));
+            fail("propertyQName has no content");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
 
         // Create a node with content
         NodeRef nodeRef = createNewVersionableNode();

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -63,7 +63,6 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
      * Test content data
      */
     private final static String UPDATED_CONTENT = "This content has been updated with a new value.";
-    private static final QName  QNAME = QName.createQName("{test}MyNoContentNode");
     
     /**
      * The version content store
@@ -187,49 +186,5 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
 
         assertNull(contentService.requestContentDirectUrl(nodeRef, true, null));
         assertNull(contentService.requestContentDirectUrl(nodeRef, true, validFor));
-    }
-
-    @Test
-    public void testwithQnameWhenRequestContentDirectUrlIsNotSupported()
-    {
-        openMocks(this);
-        when(mockSystemWideDirectUrlConfig.isEnabled()).thenReturn(ENABLED);
-        when(mockSystemWideDirectUrlConfig.getDefaultExpiryTimeInSec()).thenReturn(30L);
-        when(mockSystemWideDirectUrlConfig.getMaxExpiryTimeInSec()).thenReturn(300L);
-
-        assertFalse(contentStore.isContentDirectUrlEnabled());
-
-        // Set the presigned URL to expire after one minute.
-        Long validFor = 60L;
-
-        try
-        {
-            // Create a node without content
-            NodeRef nodeRef = this.dbNodeService
-                    .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
-
-            assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
-            fail("nodeRef has no content");
-        }
-        catch (IllegalArgumentException e)
-        {
-            // Expected exception
-        }
-
-        try
-        {
-            assertNull(contentService.requestContentDirectUrl(null, QNAME, true, null));
-            fail("nodeRef is null");
-        }
-        catch (IllegalArgumentException e)
-        {
-            // Expected exception
-        }
-
-        // Create a node with content
-        NodeRef nodeRef = createNewVersionableNode();
-
-        assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, null));
-        assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -164,50 +164,6 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
             NodeRef nodeRef = this.dbNodeService
                     .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
 
-            assertNull(contentService.requestContentDirectUrl(nodeRef, true, validFor));
-            fail("nodeRef has no content");
-        }
-        catch (IllegalArgumentException e)
-        {
-            // Expected exception
-        }
-
-        try
-        {
-            assertNull(contentService.requestContentDirectUrl(null, true, null));
-            fail("nodeRef is null");
-        }
-        catch (IllegalArgumentException e)
-        {
-            // Expected exception
-        }
-
-        // Create a node with content
-        NodeRef nodeRef = createNewVersionableNode();
-
-        assertNull(contentService.requestContentDirectUrl(nodeRef, true, null));
-        assertNull(contentService.requestContentDirectUrl(nodeRef, true, validFor));
-    }
-
-    @Test
-    public void testwithQnameWhenRequestContentDirectUrlIsNotSupported()
-    {
-        openMocks(this);
-        when(mockSystemWideDirectUrlConfig.isEnabled()).thenReturn(ENABLED);
-        when(mockSystemWideDirectUrlConfig.getDefaultExpiryTimeInSec()).thenReturn(30L);
-        when(mockSystemWideDirectUrlConfig.getMaxExpiryTimeInSec()).thenReturn(300L);
-
-        assertFalse(contentStore.isContentDirectUrlEnabled());
-
-        // Set the presigned URL to expire after one minute.
-        Long validFor = 60L;
-
-        try
-        {
-            // Create a node without content
-            NodeRef nodeRef = this.dbNodeService
-                    .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
-
             assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
             fail("nodeRef has no content");
         }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -190,7 +190,7 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
             assertNull(contentService.requestContentDirectUrl(nodeRef, null, true, validFor));
             fail("propertyQName has no content");
         }
-        catch (IllegalArgumentException e)
+        catch (NullPointerException e)
         {
             // Expected exception
         }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -63,6 +63,7 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
      * Test content data
      */
     private final static String UPDATED_CONTENT = "This content has been updated with a new value.";
+    private static final QName QNAME = ContentModel.PROP_CONTENT;
     
     /**
      * The version content store
@@ -186,5 +187,49 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
 
         assertNull(contentService.requestContentDirectUrl(nodeRef, true, null));
         assertNull(contentService.requestContentDirectUrl(nodeRef, true, validFor));
+    }
+
+    @Test
+    public void testwithQnameWhenRequestContentDirectUrlIsNotSupported()
+    {
+        openMocks(this);
+        when(mockSystemWideDirectUrlConfig.isEnabled()).thenReturn(ENABLED);
+        when(mockSystemWideDirectUrlConfig.getDefaultExpiryTimeInSec()).thenReturn(30L);
+        when(mockSystemWideDirectUrlConfig.getMaxExpiryTimeInSec()).thenReturn(300L);
+
+        assertFalse(contentStore.isContentDirectUrlEnabled());
+
+        // Set the presigned URL to expire after one minute.
+        Long validFor = 60L;
+
+        try
+        {
+            // Create a node without content
+            NodeRef nodeRef = this.dbNodeService
+                    .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
+
+            assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
+            fail("nodeRef has no content");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
+
+        try
+        {
+            assertNull(contentService.requestContentDirectUrl(null, null, true, null));
+            fail("nodeRef is null");
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Expected exception
+        }
+
+        // Create a node with content
+        NodeRef nodeRef = createNewVersionableNode();
+
+        assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, null));
+        assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.version;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -158,42 +159,28 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
         // Set the presigned URL to expire after one minute.
         Long validFor = 60L;
 
-        try
-        {
+        assertThrows(IllegalArgumentException.class, () -> {
             // Create a node without content
             NodeRef nodeRef = this.dbNodeService
                     .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
 
             assertNull(contentService.requestContentDirectUrl(nodeRef, QNAME, true, validFor));
             fail("nodeRef has no content");
-        }
-        catch (IllegalArgumentException e)
-        {
-            // Expected exception
-        }
+        });
 
-        try
-        {
+        assertThrows(IllegalArgumentException.class, () -> {
             assertNull(contentService.requestContentDirectUrl(null, null, true, null));
             fail("nodeRef is null");
-        }
-        catch (IllegalArgumentException e)
-        {
-            // Expected exception
-        }
-        try
-        {
+        });
+
+        assertThrows(NullPointerException.class, () -> {
             // Create a node without content
             NodeRef nodeRef = this.dbNodeService
                     .createNode(rootNodeRef, ContentModel.ASSOC_CHILDREN, QName.createQName("{test}MyNoContentNode"), TEST_TYPE_QNAME, this.nodeProperties).getChildRef();
 
-            assertNull(contentService.requestContentDirectUrl(nodeRef, null, true, validFor));
+            contentService.requestContentDirectUrl(nodeRef, null, true, validFor);
             fail("propertyQName has no content");
-        }
-        catch (NullPointerException e)
-        {
-            // Expected exception
-        }
+        });
 
         // Create a node with content
         NodeRef nodeRef = createNewVersionableNode();


### PR DESCRIPTION
-  Added  new methods to use propQName instead of PROP_CONTENT to be consistent with the rest of the project. 
-  Also added their corresponding tests.
-  Deprecated methods that use PROP_CONTENT