### PR TITLE
MNT-22136: WebDAV PROPFIND returns 302 instead of 404 (for docker image only)

### DIFF
--- a/packaging/tests/tas-webdav/src/test/java/org/alfresco/webdav/UnlockFileTests.java
+++ b/packaging/tests/tas-webdav/src/test/java/org/alfresco/webdav/UnlockFileTests.java
@@ -198,4 +198,15 @@ public class UnlockFileTests extends WebDavTest
                 .then().unlock()
                     .and().assertThat().hasStatus(HttpStatus.NO_CONTENT.value()).and().assertThat().isUnlocked();
     }
+
+    @TestRail(section={TestGroup.PROTOCOLS, TestGroup.WEBDAV}, executionType= ExecutionType.SANITY,
+            description ="Checks no existent file is not locked (and status 404)")
+    @Test(groups = {TestGroup.PROTOCOLS, TestGroup.WEBDAV, TestGroup.SANITY})
+    public void checkLockStatusForNonExistentFile() throws Exception
+    {
+        testFile = FileModel.getRandomFileModel(FileType.TEXT_PLAIN, content);
+        webDavProtocol.authenticateUser(dataUser.getAdminUser()).
+                usingResource(testFile).
+                assertThat().isUnlocked().assertThat().hasStatus(HttpStatus.NOT_FOUND.value());
+    }
 }

--- a/packaging/war/src/main/webapp/error.jsp
+++ b/packaging/war/src/main/webapp/error.jsp
@@ -2,7 +2,7 @@
   #%L
   Alfresco Repository WAR Community
   %%
-  Copyright (C) 2005 - 2016 Alfresco Software Limited
+  Copyright (C) 2005 - 2021 Alfresco Software Limited
   %%
   This file is part of the Alfresco software.
   If the software was purchased under a paid Alfresco license, the terms of
@@ -34,15 +34,6 @@
 <%@ page import="org.alfresco.service.cmr.module.ModuleDetails" %>
 <%@ page import="org.alfresco.service.cmr.module.ModuleInstallState" %>
 <%@ page import="java.util.Calendar" %>
-
-<!-- Enterprise index-jsp placeholder -->
-<%
-// route WebDAV requests
-if (request.getMethod().equalsIgnoreCase("PROPFIND") || request.getMethod().equalsIgnoreCase("OPTIONS"))
-{
-   response.sendRedirect(request.getContextPath() + "/webdav/");
-}
-%>
 
 <%
 WebApplicationContext context = WebApplicationContextUtils.getRequiredWebApplicationContext(session.getServletContext());

--- a/packaging/war/src/main/webapp/error.jsp
+++ b/packaging/war/src/main/webapp/error.jsp
@@ -2,7 +2,7 @@
   #%L
   Alfresco Repository WAR Community
   %%
-  Copyright (C) 2005 - 2021 Alfresco Software Limited
+  Copyright (C) 2005 - 2016 Alfresco Software Limited
   %%
   This file is part of the Alfresco software.
   If the software was purchased under a paid Alfresco license, the terms of
@@ -34,6 +34,15 @@
 <%@ page import="org.alfresco.service.cmr.module.ModuleDetails" %>
 <%@ page import="org.alfresco.service.cmr.module.ModuleInstallState" %>
 <%@ page import="java.util.Calendar" %>
+
+<!-- Enterprise index-jsp placeholder -->
+<%
+// route WebDAV requests
+if (request.getMethod().equalsIgnoreCase("PROPFIND") || request.getMethod().equalsIgnoreCase("OPTIONS"))
+{
+   response.sendRedirect(request.getContextPath() + "/webdav/");
+}
+%>
 
 <%
 WebApplicationContext context = WebApplicationContextUtils.getRequiredWebApplicationContext(session.getServletContext());


### PR DESCRIPTION
- appears to be regression from REPO-3275 (due to apparent copy & paste from index.jsp)

- added new -ve test added to TAS WebDAV to repeat this specific issue (without fix - fails with 302 instead of 404)
  - see also [WebDavUtil.isLocked()](https://github.com/Alfresco/alfresco-tas-webdav/blob/master/src/main/java/org/alfresco/webdav/dsl/WebDavUtil.java#L359-L376)