### PR TITLE
ACS-2200: Java API for archive/archive-restore content

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/content/ContentRestoreParams.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentRestoreParams.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.content;
+
+import org.alfresco.service.Experimental;
+
+/**
+ * Enumeration with values for archive-restore parameter keys.
+ * Values of this enum should be used as keys when requesting for content restore from archive.
+ * Subject to expand/change.
+ *
+ * @author mpichura
+ */
+@Experimental
+public enum ContentRestoreParams
+{
+    /**
+     * Restore expiry in days. Corresponding value should be integer.
+     */
+    EXPIRY_DAYS,
+    /**
+     * Priority for restore from archive. Corresponding value should one of Standard/High
+     */
+    RESTORE_PRIORITY
+}

--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -34,6 +34,7 @@ import org.alfresco.service.cmr.repository.ContentStreamListener;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.DirectAccessUrl;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -343,5 +344,39 @@ public interface ContentStore
     default Map<String, String> getStorageProperties(String contentUrl)
     {
         return Collections.emptyMap();
+    }
+
+    /**
+     * Submit a request to send content to archive (offline) state.
+     * If no connector is present or connector is not supporting sending to archive, then {@code false} will be returned.
+     * Specific connector will decide which storage class/tier will be set for content.
+     * This method is experimental and subject to changes.
+     *
+     * @param contentUrl the URL of the content which is to be archived.
+     * @return true when request successful, false when unsuccessful.
+     */
+    @Experimental
+    default boolean requestSendContentToArchive(String contentUrl)
+    {
+        throw new UnsupportedOperationException("Request to archive content is not supported by this content store.");
+    }
+
+    /**
+     * Submit a request to restore content from archive (offline) state.
+     * If no connector is present or connector is not supporting restoring fom archive, then {@code false} will be returned.
+     * One of input parameters of this method is a map (String-Serializable) of Storage Provider specific input needed to perform proper restore.
+     * Keys of this map should be restricted to {@code ContentRestoreParams} enumeration.
+     * For AWS S3 map can indicating expiry days, Glacier restore tier.
+     * For Azure Blob map can indicate rehydrate priority.
+     * This method is experimental and subject to changes.
+     *
+     * @param contentUrl    the URL of the content which is to be archived.
+     * @param restoreParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
+     * @return true when request successful, false when unsuccessful.
+     */
+    @Experimental
+    default boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
+    {
+        throw new UnsupportedOperationException("Request to restore content from archive is not supported by this content store.");
     }
 }

--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -348,12 +348,13 @@ public interface ContentStore
 
     /**
      * Submit a request to send content to archive (offline) state.
-     * If no connector is present or connector is not supporting sending to archive, then {@code false} will be returned.
+     * If no connector is present or connector is not supporting sending to archive, then {@link UnsupportedOperationException} will be returned.
      * Specific connector will decide which storage class/tier will be set for content.
      * This method is experimental and subject to changes.
      *
      * @param contentUrl the URL of the content which is to be archived.
      * @return true when request successful, false when unsuccessful.
+     * @throws UnsupportedOperationException when store is unable to handle request.
      */
     @Experimental
     default boolean requestSendContentToArchive(String contentUrl)
@@ -363,7 +364,7 @@ public interface ContentStore
 
     /**
      * Submit a request to restore content from archive (offline) state.
-     * If no connector is present or connector is not supporting restoring fom archive, then {@code false} will be returned.
+     * If no connector is present or connector is not supporting restoring fom archive, then {@link UnsupportedOperationException} will be returned.
      * One of input parameters of this method is a map (String-Serializable) of Storage Provider specific input needed to perform proper restore.
      * Keys of this map should be restricted to {@code ContentRestoreParams} enumeration.
      * For AWS S3 map can indicating expiry days, Glacier restore tier.
@@ -373,6 +374,7 @@ public interface ContentStore
      * @param contentUrl    the URL of the content which is to be archived.
      * @param restoreParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
      * @return true when request successful, false when unsuccessful.
+     * @throws UnsupportedOperationException when store is unable to handle request.
      */
     @Experimental
     default boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)

--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -353,11 +353,12 @@ public interface ContentStore
      * This method is experimental and subject to changes.
      *
      * @param contentUrl the URL of the content which is to be archived.
+     * @param archiveParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
      * @return true when request successful, false when unsuccessful.
      * @throws UnsupportedOperationException when store is unable to handle request.
      */
     @Experimental
-    default boolean requestSendContentToArchive(String contentUrl)
+    default boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
         throw new UnsupportedOperationException("Request to archive content is not supported by this content store.");
     }

--- a/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
@@ -446,17 +446,17 @@ public abstract class AbstractRoutingContentStore implements ContentStore
      */
     @Override
     @Experimental
-    public boolean requestSendContentToArchive(String contentUrl)
+    public boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
         final ContentStore contentStore = selectReadStore(contentUrl);
         if (contentStore == null)
         {
             logNoContentStore(contentUrl);
-            return ContentStore.super.requestSendContentToArchive(contentUrl);
+            return ContentStore.super.requestSendContentToArchive(contentUrl, archiveParams);
         }
         final String message = "Sending content to archive: ";
         logExecution(contentUrl, contentStore, message);
-        return contentStore.requestSendContentToArchive(contentUrl);
+        return contentStore.requestSendContentToArchive(contentUrl, archiveParams);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.content;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -420,23 +421,71 @@ public abstract class AbstractRoutingContentStore implements ContentStore
         return deleted;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Experimental
     public Map<String, String> getStorageProperties(String contentUrl) {
         ContentStore contentStore = selectReadStore(contentUrl);
 
         if (contentStore == null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Storage properties not found for content URL: " + contentUrl);
-            }
+            logNoContentStore(contentUrl);
             return Collections.emptyMap();
         }
+        final String message = "Getting storage properties from store: ";
+        logExecution(contentUrl, contentStore, message);
+
+        return contentStore.getStorageProperties(contentUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Experimental
+    public boolean requestSendContentToArchive(String contentUrl)
+    {
+        final ContentStore contentStore = selectReadStore(contentUrl);
+        if (contentStore == null) {
+            logNoContentStore(contentUrl);
+            return ContentStore.super.requestSendContentToArchive(contentUrl);
+        }
+        final String message = "Sending content to archive: ";
+        logExecution(contentUrl, contentStore, message);
+        return contentStore.requestSendContentToArchive(contentUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Experimental
+    public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
+    {
+        final ContentStore contentStore = selectReadStore(contentUrl);
+        if (contentStore == null) {
+            logNoContentStore(contentUrl);
+            return ContentStore.super.requestRestoreContentFromArchive(contentUrl, restoreParams);
+        }
+        final String message = "Restoring content from archive: ";
+        logExecution(contentUrl, contentStore, message);
+        return ContentStore.super.requestRestoreContentFromArchive(contentUrl, restoreParams);
+    }
+
+    private void logExecution(final String contentUrl, final ContentStore contentStore, final String message)
+    {
         if (logger.isTraceEnabled()) {
-            logger.trace("Getting storage properties from store: \n" +
+            logger.trace(message + "\n" +
                     "   Content URL: " + contentUrl + "\n" +
                     "   Store:       " + contentStore);
         }
+    }
 
-        return contentStore.getStorageProperties(contentUrl);
+    private void logNoContentStore(String contentUrl)
+    {
+        if (logger.isTraceEnabled()) {
+            logger.trace("Content Store not found for content URL: " + contentUrl);
+        }
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
@@ -426,10 +426,12 @@ public abstract class AbstractRoutingContentStore implements ContentStore
      */
     @Override
     @Experimental
-    public Map<String, String> getStorageProperties(String contentUrl) {
+    public Map<String, String> getStorageProperties(String contentUrl)
+    {
         ContentStore contentStore = selectReadStore(contentUrl);
 
-        if (contentStore == null) {
+        if (contentStore == null)
+        {
             logNoContentStore(contentUrl);
             return Collections.emptyMap();
         }
@@ -447,7 +449,8 @@ public abstract class AbstractRoutingContentStore implements ContentStore
     public boolean requestSendContentToArchive(String contentUrl)
     {
         final ContentStore contentStore = selectReadStore(contentUrl);
-        if (contentStore == null) {
+        if (contentStore == null)
+        {
             logNoContentStore(contentUrl);
             return ContentStore.super.requestSendContentToArchive(contentUrl);
         }
@@ -464,7 +467,8 @@ public abstract class AbstractRoutingContentStore implements ContentStore
     public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
     {
         final ContentStore contentStore = selectReadStore(contentUrl);
-        if (contentStore == null) {
+        if (contentStore == null)
+        {
             logNoContentStore(contentUrl);
             return ContentStore.super.requestRestoreContentFromArchive(contentUrl, restoreParams);
         }
@@ -475,7 +479,8 @@ public abstract class AbstractRoutingContentStore implements ContentStore
 
     private void logExecution(final String contentUrl, final ContentStore contentStore, final String message)
     {
-        if (logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled())
+        {
             logger.trace(message + "\n" +
                     "   Content URL: " + contentUrl + "\n" +
                     "   Store:       " + contentStore);
@@ -484,7 +489,8 @@ public abstract class AbstractRoutingContentStore implements ContentStore
 
     private void logNoContentStore(String contentUrl)
     {
-        if (logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled())
+        {
             logger.trace("Content Store not found for content URL: " + contentUrl);
         }
     }

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -679,10 +679,11 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * {@inheritDoc}
      */
     @Override
-    public boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName)
+    public boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName,
+                                               Map<String, Serializable> archiveParams)
     {
         final ContentData contentData = getContentDataOrThrowError(nodeRef, propertyQName);
-        return store.requestSendContentToArchive(contentData.getContentUrl());
+        return store.requestSendContentToArchive(contentData.getContentUrl(), archiveParams);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -104,7 +104,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     private boolean ignoreEmptyContent;
 
     private SystemWideDirectUrlConfig systemWideDirectUrlConfig;
-    
+
     /** pre-configured allow list of media/mime types, eg. specific types of images & also pdf */
     private Set<String> nonAttachContentTypes = Collections.emptySet();
 
@@ -155,7 +155,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         this.systemWideDirectUrlConfig = systemWideDirectUrlConfig;
     }
 
-    public void setNonAttachContentTypes(String nonAttachAllowListStr) 
+    public void setNonAttachContentTypes(String nonAttachAllowListStr)
     {
         if ((nonAttachAllowListStr != null) && (! nonAttachAllowListStr.isEmpty()))
         {
@@ -671,14 +671,28 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     @Experimental
     public Map<String, String> getStorageProperties(NodeRef nodeRef, QName propertyQName)
     {
-        final ContentData contentData = getContentData(nodeRef, propertyQName);
-
-        if (contentData == null || contentData.getContentUrl() == null)
-        {
-            throw new IllegalArgumentException("The supplied nodeRef " + nodeRef + " and property name: " + propertyQName + " has no content.");
-        }
-
+        final ContentData contentData = getContentDataOrThrowError(nodeRef, propertyQName);
         return store.getStorageProperties(contentData.getContentUrl());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName)
+    {
+        final ContentData contentData = getContentDataOrThrowError(nodeRef, propertyQName);
+        return store.requestSendContentToArchive(contentData.getContentUrl());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean requestRestoreContentFromArchive(NodeRef nodeRef, QName propertyQName, Map<String, Serializable> restoreParams)
+    {
+        final ContentData contentData = getContentDataOrThrowError(nodeRef, propertyQName);
+        return store.requestRestoreContentFromArchive(contentData.getContentUrl(), restoreParams);
     }
 
     protected String getFileName(NodeRef nodeRef)
@@ -720,5 +734,16 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             }
         }
         return attachment;
+    }
+
+    private ContentData getContentDataOrThrowError(NodeRef nodeRef, QName propertyQName)
+    {
+        final ContentData contentData = getContentData(nodeRef, propertyQName);
+
+        if (contentData == null || contentData.getContentUrl() == null)
+        {
+            throw new IllegalArgumentException("The supplied nodeRef " + nodeRef + " and property name: " + propertyQName + " has no content.");
+        }
+        return contentData;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.content.caching;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -382,11 +383,34 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Experimental
     public Map<String, String> getStorageProperties(final String contentUrl)
     {
         return backingStore.getStorageProperties(contentUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Experimental
+    public boolean requestSendContentToArchive(String contentUrl)
+    {
+        return backingStore.requestSendContentToArchive(contentUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Experimental
+    public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
+    {
+        return backingStore.requestRestoreContentFromArchive(contentUrl, restoreParams);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
@@ -398,9 +398,9 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
      */
     @Override
     @Experimental
-    public boolean requestSendContentToArchive(String contentUrl)
+    public boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
-        return backingStore.requestSendContentToArchive(contentUrl);
+        return backingStore.requestSendContentToArchive(contentUrl, archiveParams);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.content.replication;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,8 @@ public class AggregatingContentStore extends AbstractContentStore
 {
     private static final Log logger = LogFactory.getLog(AggregatingContentStore.class);
     public static final String REPLICATING_CONTENT_STORE_NOT_INITIALISED = "ReplicatingContentStore not initialised";
+    public static final String SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL = "Secondary store %s could not handle content URL: %s";
+    public static final String PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL = "Primary store could not handle content URL: %s";
 
     private ContentStore primaryStore;
     private List<ContentStore> secondaryStores;
@@ -136,11 +139,8 @@ public class AggregatingContentStore extends AbstractContentStore
      */
     public ContentReader getReader(String contentUrl) throws ContentIOException
     {
-        if (primaryStore == null)
-        {
-            throw new AlfrescoRuntimeException(REPLICATING_CONTENT_STORE_NOT_INITIALISED);
-        }
-        
+        checkPrimaryStore();
+
         // get a read lock so that we are sure that no replication is underway
         readLock.lock();
         try
@@ -175,10 +175,7 @@ public class AggregatingContentStore extends AbstractContentStore
 
     public boolean exists(String contentUrl)
     {
-        if (primaryStore == null)
-        {
-            throw new AlfrescoRuntimeException(REPLICATING_CONTENT_STORE_NOT_INITIALISED);
-        }
+        checkPrimaryStore();
 
         // get a read lock so that we are sure that no replication is underway
         readLock.lock();
@@ -323,10 +320,7 @@ public class AggregatingContentStore extends AbstractContentStore
 
     public DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, String mimetype, Long validFor)
     {
-        if (primaryStore == null)
-        {
-            throw new AlfrescoRuntimeException(REPLICATING_CONTENT_STORE_NOT_INITIALISED);
-        }
+        checkPrimaryStore();
 
         // get a read lock so that we are sure that no replication is underway
         readLock.lock();
@@ -405,13 +399,14 @@ public class AggregatingContentStore extends AbstractContentStore
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Experimental
     public Map<String, String> getStorageProperties(String contentUrl)
     {
-        if (primaryStore == null) {
-            throw new AlfrescoRuntimeException(REPLICATING_CONTENT_STORE_NOT_INITIALISED);
-        }
+        checkPrimaryStore();
 
         // get a read lock so that we are sure that no replication is underway
         readLock.lock();
@@ -421,19 +416,18 @@ public class AggregatingContentStore extends AbstractContentStore
             try {
                 objectStoragePropertiesMap = Optional.of(primaryStore.getStorageProperties(contentUrl));
             } catch (UnsupportedContentUrlException e) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Primary store could not handle content URL: " + contentUrl);
-                }
+                final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
+                logTrace(message);
             }
 
-            if (objectStoragePropertiesMap.isEmpty()) {// the content is not in the primary store so we have to go looking for it
+            if (objectStoragePropertiesMap.isEmpty() || objectStoragePropertiesMap.get().isEmpty())
+            {// the content is not in the primary store so we have to go looking for it
                 for (ContentStore store : secondaryStores) {
                     try {
                         objectStoragePropertiesMap = Optional.of(store.getStorageProperties(contentUrl));
                     } catch (UnsupportedContentUrlException e) {
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Secondary store " + store + " could not handle content URL: " + contentUrl);
-                        }
+                        final String message = String.format(SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, store, contentUrl);
+                        logTrace(message);
                     }
 
                     if (objectStoragePropertiesMap.isPresent()) {
@@ -446,6 +440,99 @@ public class AggregatingContentStore extends AbstractContentStore
 
         } finally {
             readLock.unlock();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Experimental
+    @Override
+    public boolean requestSendContentToArchive(final String contentUrl)
+    {
+        return callContentArchiveRequest(contentUrl, Collections.emptyMap(), false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Experimental
+    @Override
+    public boolean requestRestoreContentFromArchive(final String contentUrl, final Map<String, Serializable> restoreParams)
+    {
+        return callContentArchiveRequest(contentUrl, restoreParams, true);
+    }
+
+    private boolean callContentArchiveRequest(final String contentUrl, final Map<String, Serializable> restoreParams, final boolean restore)
+    {
+        checkPrimaryStore();
+        // get a read lock so that we are sure that no replication is underway
+        readLock.lock();
+        boolean archiveRequestSucceeded = false;
+        boolean primaryContentUrlUnsupported = false;
+        boolean secondaryContentUrlUnsupported = false;
+        try {
+            // Check the primary store
+            try {
+                archiveRequestSucceeded = hasArchiveRequestSucceeded(contentUrl, restoreParams, restore, primaryStore);
+            } catch (UnsupportedOperationException e) {
+                final String message = String.format("Primary store does not handle this operation for content URL: %s", contentUrl);
+                logTrace(message);
+            } catch (UnsupportedContentUrlException e) {
+                final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
+                logTrace(message);
+                primaryContentUrlUnsupported = true;
+            }
+
+            if (archiveRequestSucceeded) {
+                return true;
+            } else { // the content is not in the primary store so we have to go looking for it
+                for (ContentStore store : secondaryStores) {
+                    try {
+                        archiveRequestSucceeded = hasArchiveRequestSucceeded(contentUrl, restoreParams, restore, store);
+                    } catch (UnsupportedOperationException e) {
+                        final String message =
+                                String.format("Secondary store %s does not handle this operation for content URL: %s", store,
+                                        contentUrl);
+                        logTrace(message);
+                    } catch (UnsupportedContentUrlException e) {
+                        secondaryContentUrlUnsupported = true;
+                        final String message = String.format(SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, store, contentUrl);
+                        logTrace(message);
+                    }
+                }
+            }
+            if (archiveRequestSucceeded) {
+                return true;
+            } else if (primaryContentUrlUnsupported || secondaryContentUrlUnsupported) {
+                return super.requestSendContentToArchive(contentUrl);
+            }
+
+            return super.requestSendContentToArchive(contentUrl);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    private boolean hasArchiveRequestSucceeded(String contentUrl, Map<String, Serializable> restoreParams, boolean restore,
+                                               ContentStore primaryStore)
+    {
+        return restore ?
+                primaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams) :
+                primaryStore.requestSendContentToArchive(contentUrl);
+    }
+
+    private void logTrace(final String message)
+    {
+        if (logger.isTraceEnabled()) {
+            logger.trace(message);
+        }
+    }
+
+    private void checkPrimaryStore()
+    {
+        if (primaryStore == null) {
+            throw new AlfrescoRuntimeException(REPLICATING_CONTENT_STORE_NOT_INITIALISED);
         }
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -417,7 +417,7 @@ public class AggregatingContentStore extends AbstractContentStore
                 objectStoragePropertiesMap = Optional.of(primaryStore.getStorageProperties(contentUrl));
             } catch (UnsupportedContentUrlException e) {
                 final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
-                logTrace(message);
+                logger.trace(message);
             }
 
             if (objectStoragePropertiesMap.isEmpty() || objectStoragePropertiesMap.get().isEmpty())
@@ -427,7 +427,8 @@ public class AggregatingContentStore extends AbstractContentStore
                         objectStoragePropertiesMap = Optional.of(store.getStorageProperties(contentUrl));
                     } catch (UnsupportedContentUrlException e) {
                         final String message = String.format(SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, store, contentUrl);
-                        logTrace(message);
+                        logger.trace(message);
+                        logger.trace(message);
                     }
 
                     if (objectStoragePropertiesMap.isPresent()) {
@@ -477,10 +478,10 @@ public class AggregatingContentStore extends AbstractContentStore
                 archiveRequestSucceeded = hasArchiveRequestSucceeded(contentUrl, restoreParams, restore, primaryStore);
             } catch (UnsupportedOperationException e) {
                 final String message = String.format("Primary store does not handle this operation for content URL: %s", contentUrl);
-                logTrace(message);
+                logger.trace(message);
             } catch (UnsupportedContentUrlException e) {
                 final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
-                logTrace(message);
+                logger.trace(message);
                 primaryContentUrlUnsupported = true;
             }
 
@@ -494,11 +495,11 @@ public class AggregatingContentStore extends AbstractContentStore
                         final String message =
                                 String.format("Secondary store %s does not handle this operation for content URL: %s", store,
                                         contentUrl);
-                        logTrace(message);
+                        logger.trace(message);
                     } catch (UnsupportedContentUrlException e) {
                         secondaryContentUrlUnsupported = true;
                         final String message = String.format(SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, store, contentUrl);
-                        logTrace(message);
+                        logger.trace(message);
                     }
                 }
             }
@@ -520,13 +521,6 @@ public class AggregatingContentStore extends AbstractContentStore
         return restore ?
                 primaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams) :
                 primaryStore.requestSendContentToArchive(contentUrl);
-    }
-
-    private void logTrace(final String message)
-    {
-        if (logger.isTraceEnabled()) {
-            logger.trace(message);
-        }
     }
 
     private void checkPrimaryStore()

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -410,28 +410,36 @@ public class AggregatingContentStore extends AbstractContentStore
 
         // get a read lock so that we are sure that no replication is underway
         readLock.lock();
-        try {
+        try
+        {
             Optional<Map<String, String>> objectStoragePropertiesMap = Optional.empty();
             // Check the primary store
-            try {
+            try
+            {
                 objectStoragePropertiesMap = Optional.of(primaryStore.getStorageProperties(contentUrl));
-            } catch (UnsupportedContentUrlException e) {
+            }
+            catch (UnsupportedContentUrlException e)
+            {
                 final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
                 logger.trace(message);
             }
 
-            if (objectStoragePropertiesMap.isEmpty() || objectStoragePropertiesMap.get().isEmpty())
-            {// the content is not in the primary store so we have to go looking for it
-                for (ContentStore store : secondaryStores) {
-                    try {
+            if (objectStoragePropertiesMap.isEmpty() ||
+                    objectStoragePropertiesMap.get().isEmpty()) {// the content is not in the primary store so we have to go looking for it
+                for (ContentStore store : secondaryStores)
+                {
+                    try
+                    {
                         objectStoragePropertiesMap = Optional.of(store.getStorageProperties(contentUrl));
-                    } catch (UnsupportedContentUrlException e) {
+                    }
+                    catch (UnsupportedContentUrlException e)
+                    {
                         final String message = String.format(SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, store, contentUrl);
-                        logger.trace(message);
                         logger.trace(message);
                     }
 
-                    if (objectStoragePropertiesMap.isPresent()) {
+                    if (objectStoragePropertiesMap.isPresent())
+                    {
                         return objectStoragePropertiesMap.get();
                     }
                 }
@@ -439,7 +447,9 @@ public class AggregatingContentStore extends AbstractContentStore
             }
             return objectStoragePropertiesMap.orElse(Collections.emptyMap());
 
-        } finally {
+        }
+        finally
+        {
             readLock.unlock();
         }
     }
@@ -472,45 +482,63 @@ public class AggregatingContentStore extends AbstractContentStore
         boolean archiveRequestSucceeded = false;
         boolean primaryContentUrlUnsupported = false;
         boolean secondaryContentUrlUnsupported = false;
-        try {
+        try
+        {
             // Check the primary store
-            try {
+            try
+            {
                 archiveRequestSucceeded = hasArchiveRequestSucceeded(contentUrl, restoreParams, restore, primaryStore);
-            } catch (UnsupportedOperationException e) {
+            }
+            catch (UnsupportedOperationException e)
+            {
                 final String message = String.format("Primary store does not handle this operation for content URL: %s", contentUrl);
                 logger.trace(message);
-            } catch (UnsupportedContentUrlException e) {
+            }
+            catch (UnsupportedContentUrlException e) {
                 final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
                 logger.trace(message);
                 primaryContentUrlUnsupported = true;
             }
 
-            if (archiveRequestSucceeded) {
+            if (archiveRequestSucceeded)
+            {
                 return true;
-            } else { // the content is not in the primary store so we have to go looking for it
-                for (ContentStore store : secondaryStores) {
-                    try {
+            }
+            else
+            { // the content is not in the primary store so we have to go looking for it
+                for (ContentStore store : secondaryStores)
+                {
+                    try
+                    {
                         archiveRequestSucceeded = hasArchiveRequestSucceeded(contentUrl, restoreParams, restore, store);
-                    } catch (UnsupportedOperationException e) {
+                    } catch (UnsupportedOperationException e)
+                    {
                         final String message =
                                 String.format("Secondary store %s does not handle this operation for content URL: %s", store,
                                         contentUrl);
                         logger.trace(message);
-                    } catch (UnsupportedContentUrlException e) {
+                    }
+                    catch (UnsupportedContentUrlException e)
+                    {
                         secondaryContentUrlUnsupported = true;
                         final String message = String.format(SECONDARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, store, contentUrl);
                         logger.trace(message);
                     }
                 }
             }
-            if (archiveRequestSucceeded) {
+            if (archiveRequestSucceeded)
+            {
                 return true;
-            } else if (primaryContentUrlUnsupported || secondaryContentUrlUnsupported) {
+            }
+            else if (primaryContentUrlUnsupported || secondaryContentUrlUnsupported)
+            {
                 return super.requestSendContentToArchive(contentUrl);
             }
 
             return super.requestSendContentToArchive(contentUrl);
-        } finally {
+        }
+        finally
+        {
             readLock.unlock();
         }
     }
@@ -525,7 +553,8 @@ public class AggregatingContentStore extends AbstractContentStore
 
     private void checkPrimaryStore()
     {
-        if (primaryStore == null) {
+        if (primaryStore == null)
+        {
             throw new AlfrescoRuntimeException(REPLICATING_CONTENT_STORE_NOT_INITIALISED);
         }
     }

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -421,7 +421,7 @@ public class AggregatingContentStore extends AbstractContentStore
             catch (UnsupportedContentUrlException e)
             {
                 final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
-                logger.trace(message);
+                logTrace(message);
             }
 
             if (objectStoragePropertiesMap.isEmpty() ||

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -421,7 +421,7 @@ public class AggregatingContentStore extends AbstractContentStore
             catch (UnsupportedContentUrlException e)
             {
                 final String message = String.format(PRIMARY_STORE_COULD_NOT_HANDLE_CONTENT_URL, contentUrl);
-                logTrace(message);
+                logger.trace(message);
             }
 
             if (objectStoragePropertiesMap.isEmpty() ||

--- a/repository/src/main/java/org/alfresco/repo/tenant/AbstractTenantRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/tenant/AbstractTenantRoutingContentStore.java
@@ -288,9 +288,9 @@ public abstract class AbstractTenantRoutingContentStore extends AbstractRoutingC
      */
     @Override
     @Experimental
-    public boolean requestSendContentToArchive(String contentUrl)
+    public boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
-        return getTenantContentStore().requestSendContentToArchive(contentUrl);
+        return getTenantContentStore().requestSendContentToArchive(contentUrl, archiveParams);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/tenant/AbstractTenantRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/tenant/AbstractTenantRoutingContentStore.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.tenant;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -272,11 +273,34 @@ public abstract class AbstractTenantRoutingContentStore extends AbstractRoutingC
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Experimental
     @Override
     public Map<String, String> getStorageProperties(String contentUrl)
     {
         return getTenantContentStore().getStorageProperties(contentUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Experimental
+    public boolean requestSendContentToArchive(String contentUrl)
+    {
+        return getTenantContentStore().requestSendContentToArchive(contentUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Experimental
+    public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
+    {
+        return getTenantContentStore().requestRestoreContentFromArchive(contentUrl, restoreParams);
     }
 
     protected abstract ContentStore initContentStore(ApplicationContext ctx, String contentRoot);

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -33,6 +33,7 @@ import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.dictionary.InvalidTypeException;
 import org.alfresco.service.namespace.QName;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -258,10 +259,48 @@ public interface ContentService
      * @param propertyQName the name of the property, which must be of type <b>content</b>
      * @return Returns a key-value (String-String) collection of storage headers/properties with their respective values for a given {@link NodeRef}.
      */
-    @Auditable
+    @Auditable(parameters = {"nodeRef", "propertyQName"})
     @Experimental
     default Map<String, String> getStorageProperties(NodeRef nodeRef, QName propertyQName)
     {
         return Collections.emptyMap();
+    }
+
+    /**
+     * Submit a request to send content to archive (offline) state.
+     * If no connector is present or connector is not supporting sending to archive, then {@code false} will be returned.
+     * Specific connector will decide which storage class/tier will be set for content.
+     * This method is experimental and subject to changes.
+     *
+     * @param nodeRef a reference to a node having a content property
+     * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @return true when request successful, false when unsuccessful.
+     */
+    @Auditable(parameters = {"nodeRef", "propertyQName"})
+    @Experimental
+    default boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName)
+    {
+        throw new UnsupportedOperationException("Request to archive content is not supported by this content store.");
+    }
+
+    /**
+     * Submit a request to restore content from archive (offline) state.
+     * If no connector is present or connector is not supporting restoring fom archive, then {@code false} will be returned.
+     * One of input parameters of this method is a map (String-Serializable) of Storage Provider specific input needed to perform proper restore.
+     * Keys of this map should be restricted to {@code ContentRestoreParams} enumeration.
+     * For AWS S3 map can indicating expiry days, Glacier restore tier.
+     * For Azure Blob map can indicate rehydrate priority.
+     * This method is experimental and subject to changes.
+     *
+     * @param nodeRef a reference to a node having a content property
+     * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @param restoreParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
+     * @return true when request successful, false when unsuccessful.
+     */
+    @Auditable(parameters = {"nodeRef", "propertyQName", "restoreParams"})
+    @Experimental
+    default boolean requestRestoreContentFromArchive(NodeRef nodeRef, QName propertyQName, Map<String, Serializable> restoreParams)
+    {
+        throw new UnsupportedOperationException("Request to restore content from archive is not supported by this content store.");
     }
 }

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -268,24 +268,25 @@ public interface ContentService
 
     /**
      * Submit a request to send content to archive (offline) state.
-     * If no connector is present or connector is not supporting sending to archive, then {@code false} will be returned.
+     * If no connector is present or connector is not supporting sending to archive, then {@link UnsupportedOperationException} will be returned.
      * Specific connector will decide which storage class/tier will be set for content.
      * This method is experimental and subject to changes.
      *
      * @param nodeRef a reference to a node having a content property
      * @param propertyQName the name of the property, which must be of type <b>content</b>
      * @return true when request successful, false when unsuccessful.
+     * @throws UnsupportedOperationException when method not implemented
      */
     @Auditable(parameters = {"nodeRef", "propertyQName"})
     @Experimental
     default boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName)
     {
-        throw new UnsupportedOperationException("Request to archive content is not supported by this content store.");
+        throw new UnsupportedOperationException("Request to archive content is not supported by content service.");
     }
 
     /**
      * Submit a request to restore content from archive (offline) state.
-     * If no connector is present or connector is not supporting restoring fom archive, then {@code false} will be returned.
+     * If no connector is present or connector is not supporting restoring fom archive, then {@link UnsupportedOperationException} will be returned.
      * One of input parameters of this method is a map (String-Serializable) of Storage Provider specific input needed to perform proper restore.
      * Keys of this map should be restricted to {@code ContentRestoreParams} enumeration.
      * For AWS S3 map can indicating expiry days, Glacier restore tier.
@@ -296,11 +297,12 @@ public interface ContentService
      * @param propertyQName the name of the property, which must be of type <b>content</b>
      * @param restoreParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
      * @return true when request successful, false when unsuccessful.
+     * @throws UnsupportedOperationException when method not implemented
      */
     @Auditable(parameters = {"nodeRef", "propertyQName", "restoreParams"})
     @Experimental
     default boolean requestRestoreContentFromArchive(NodeRef nodeRef, QName propertyQName, Map<String, Serializable> restoreParams)
     {
-        throw new UnsupportedOperationException("Request to restore content from archive is not supported by this content store.");
+        throw new UnsupportedOperationException("Request to restore content from archive is not supported by content service.");
     }
 }

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -274,12 +274,14 @@ public interface ContentService
      *
      * @param nodeRef a reference to a node having a content property
      * @param propertyQName the name of the property, which must be of type <b>content</b>
+     * @param archiveParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
      * @return true when request successful, false when unsuccessful.
      * @throws UnsupportedOperationException when method not implemented
      */
     @Auditable(parameters = {"nodeRef", "propertyQName"})
     @Experimental
-    default boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName)
+    default boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName,
+                                                Map<String, Serializable> archiveParams)
     {
         throw new UnsupportedOperationException("Request to archive content is not supported by content service.");
     }

--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -499,7 +499,7 @@
                org.alfresco.service.cmr.repository.ContentService.isContentDirectUrlEnabled=ACL_ALLOW
                org.alfresco.service.cmr.repository.ContentService.getStorageProperties=ACL_NODE.0.sys:base.ReadContent
                org.alfresco.service.cmr.repository.ContentService.requestSendContentToArchive=ACL_NODE.0.sys:base.WriteContent
-                org.alfresco.service.cmr.repository.ContentService.requestRestoreContentFromArchive=ACL_NODE.0.sys:base.WriteContent
+               org.alfresco.service.cmr.repository.ContentService.requestRestoreContentFromArchive=ACL_NODE.0.sys:base.WriteContent
                org.alfresco.service.cmr.repository.ContentService.*=ACL_DENY
             </value>
         </property>

--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -498,6 +498,8 @@
                org.alfresco.service.cmr.repository.ContentService.requestContentDirectUrl=ACL_NODE.0.sys:base.ReadContent
                org.alfresco.service.cmr.repository.ContentService.isContentDirectUrlEnabled=ACL_ALLOW
                org.alfresco.service.cmr.repository.ContentService.getStorageProperties=ACL_NODE.0.sys:base.ReadContent
+               org.alfresco.service.cmr.repository.ContentService.requestSendContentToArchive=ACL_NODE.0.sys:base.WriteContent
+                org.alfresco.service.cmr.repository.ContentService.requestRestoreContentFromArchive=ACL_NODE.0.sys:base.WriteContent
                org.alfresco.service.cmr.repository.ContentService.*=ACL_DENY
             </value>
         </property>

--- a/repository/src/test/java/org/alfresco/AllUnitTestsSuite.java
+++ b/repository/src/test/java/org/alfresco/AllUnitTestsSuite.java
@@ -187,6 +187,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.content.filestore.FileIOTest.class,
     org.alfresco.repo.content.filestore.SpoofedTextContentReaderTest.class,
     org.alfresco.repo.content.ContentDataTest.class,
+    org.alfresco.repo.content.replication.AggregatingContentStoreUnitTest.class,
     org.alfresco.service.cmr.repository.TransformationOptionLimitsTest.class,
     org.alfresco.service.cmr.repository.TransformationOptionPairTest.class,
     org.alfresco.repo.content.transform.TransformerConfigTestSuite.class,

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -210,17 +209,19 @@ public class ContentServiceImplUnitTest
     public void shouldRequestSendContentToArchiveSucceed()
     {
         final boolean expectedResult = true;
-        when(mockContentStore.requestSendContentToArchive(SOME_CONTENT_URL)).thenReturn(expectedResult);
-        boolean sendContentToArchive = contentService.requestSendContentToArchive(NODE_REF, ContentModel.PROP_CONTENT);
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
+        when(mockContentStore.requestSendContentToArchive(SOME_CONTENT_URL, archiveParams)).thenReturn(expectedResult);
+        boolean sendContentToArchive = contentService.requestSendContentToArchive(NODE_REF, ContentModel.PROP_CONTENT, archiveParams);
         assertEquals(expectedResult, sendContentToArchive);
     }
 
     @Test
     public void requestSendContentToArchiveThrowsExceptionWhenNotImplemented()
     {
-        when(mockContentStore.requestSendContentToArchive(SOME_CONTENT_URL)).thenCallRealMethod();
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
+        when(mockContentStore.requestSendContentToArchive(SOME_CONTENT_URL, archiveParams)).thenCallRealMethod();
         assertThrows(UnsupportedOperationException.class, () -> {
-            contentService.requestSendContentToArchive(NODE_REF, ContentModel.PROP_CONTENT);
+            contentService.requestSendContentToArchive(NODE_REF, ContentModel.PROP_CONTENT, archiveParams);
         });
     }
 
@@ -228,11 +229,12 @@ public class ContentServiceImplUnitTest
     public void requestSendContentToArchiveThrowsExceptionWhenContentNotFound()
     {
         final String dummyContentProperty = "dummy";
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
         when(mockNodeService.getProperty(NODE_REF_2, ContentModel.PROP_CONTENT)).thenReturn(dummyContentProperty);
         when(mockDictionaryService.getProperty(ContentModel.PROP_CONTENT)).thenReturn(null);
 
         assertThrows(IllegalArgumentException.class, () -> {
-            contentService.requestSendContentToArchive(NODE_REF_2, ContentModel.PROP_CONTENT);
+            contentService.requestSendContentToArchive(NODE_REF_2, ContentModel.PROP_CONTENT, archiveParams);
         });
     }
 
@@ -259,6 +261,7 @@ public class ContentServiceImplUnitTest
         boolean restoreContentFromArchive =
                 contentService.requestRestoreContentFromArchive(NODE_REF, ContentModel.PROP_CONTENT, restoreParams);
 
+        assertEquals(expectedResult, restoreContentFromArchive);
     }
 
     @Test

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -202,6 +203,71 @@ public class ContentServiceImplUnitTest
 
         assertThrows(IllegalArgumentException.class, () -> {
             contentService.getStorageProperties(NODE_REF_2, ContentModel.PROP_CONTENT);
+        });
+    }
+
+    @Test
+    public void shouldRequestSendContentToArchiveSucceed()
+    {
+        final boolean expectedResult = true;
+        when(mockContentStore.requestSendContentToArchive(SOME_CONTENT_URL)).thenReturn(expectedResult);
+        boolean sendContentToArchive = contentService.requestSendContentToArchive(NODE_REF, ContentModel.PROP_CONTENT);
+        assertEquals(expectedResult, sendContentToArchive);
+    }
+
+    @Test
+    public void requestSendContentToArchiveThrowsExceptionWhenNotImplemented()
+    {
+        when(mockContentStore.requestSendContentToArchive(SOME_CONTENT_URL)).thenCallRealMethod();
+        assertThrows(UnsupportedOperationException.class, () -> {
+            contentService.requestSendContentToArchive(NODE_REF, ContentModel.PROP_CONTENT);
+        });
+    }
+
+    @Test
+    public void requestSendContentToArchiveThrowsExceptionWhenContentNotFound()
+    {
+        final String dummyContentProperty = "dummy";
+        when(mockNodeService.getProperty(NODE_REF_2, ContentModel.PROP_CONTENT)).thenReturn(dummyContentProperty);
+        when(mockDictionaryService.getProperty(ContentModel.PROP_CONTENT)).thenReturn(null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            contentService.requestSendContentToArchive(NODE_REF_2, ContentModel.PROP_CONTENT);
+        });
+    }
+
+    @Test
+    public void requestRestoreContentFromArchiveThrowsExceptionWhenContentNotFound()
+    {
+        final String dummyContentProperty = "dummy";
+        when(mockNodeService.getProperty(NODE_REF_2, ContentModel.PROP_CONTENT)).thenReturn(dummyContentProperty);
+        when(mockDictionaryService.getProperty(ContentModel.PROP_CONTENT)).thenReturn(null);
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            contentService.requestRestoreContentFromArchive(NODE_REF_2, ContentModel.PROP_CONTENT, restoreParams);
+        });
+    }
+
+    @Test
+    public void shouldRequestRestoreContentFromArchiveSucceed()
+    {
+        final boolean expectedResult = true;
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+        when(mockContentStore.requestRestoreContentFromArchive(SOME_CONTENT_URL, restoreParams)).thenReturn(expectedResult);
+
+        boolean restoreContentFromArchive =
+                contentService.requestRestoreContentFromArchive(NODE_REF, ContentModel.PROP_CONTENT, restoreParams);
+
+    }
+
+    @Test
+    public void requestRestoreContentFromArchiveThrowsExceptionWhenNotImplemented()
+    {
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+        when(mockContentStore.requestRestoreContentFromArchive(SOME_CONTENT_URL, restoreParams)).thenCallRealMethod();
+        assertThrows(UnsupportedOperationException.class, () -> {
+            contentService.requestRestoreContentFromArchive(NODE_REF, ContentModel.PROP_CONTENT, restoreParams);
         });
     }
 

--- a/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 
@@ -549,9 +550,10 @@ public class CachingContentStoreTest
     {
         final boolean expectedResult = true;
         final String contentUrl = "url";
-        when(backingStore.requestSendContentToArchive(contentUrl)).thenReturn(expectedResult);
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
+        when(backingStore.requestSendContentToArchive(contentUrl, archiveParams)).thenReturn(expectedResult);
 
-        final boolean sendContentToArchive = cachingStore.requestSendContentToArchive(contentUrl);
+        final boolean sendContentToArchive = cachingStore.requestSendContentToArchive(contentUrl, archiveParams);
 
         assertEquals(expectedResult, sendContentToArchive);
     }
@@ -560,10 +562,11 @@ public class CachingContentStoreTest
     public void shouldThrowExceptionOnArchiveContentRequest()
     {
         final String contentUrl = "url";
-        when(backingStore.requestSendContentToArchive(contentUrl)).thenCallRealMethod();
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
+        when(backingStore.requestSendContentToArchive(contentUrl, archiveParams)).thenCallRealMethod();
 
         assertThrows(UnsupportedOperationException.class, () -> {
-            cachingStore.requestSendContentToArchive(contentUrl);
+            cachingStore.requestSendContentToArchive(contentUrl, archiveParams);
         });
     }
 

--- a/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -29,6 +29,7 @@ package org.alfresco.repo.content.caching;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import static org.junit.Assert.fail;
@@ -45,10 +46,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 
 import org.alfresco.repo.content.ContentContext;
+import org.alfresco.repo.content.ContentRestoreParams;
 import org.alfresco.repo.content.ContentStore;
 import org.alfresco.repo.content.caching.quota.QuotaManagerStrategy;
 import org.alfresco.repo.content.caching.quota.UnlimitedQuotaStrategy;
@@ -539,5 +542,53 @@ public class CachingContentStoreTest
     {
         Map<String, String> storageProperties = cachingStore.getStorageProperties("url");
         assertTrue(storageProperties.isEmpty());
+    }
+
+    @Test
+    public void shouldCompleteArchiveContentRequest()
+    {
+        final boolean expectedResult = true;
+        final String contentUrl = "url";
+        when(backingStore.requestSendContentToArchive(contentUrl)).thenReturn(expectedResult);
+
+        final boolean sendContentToArchive = cachingStore.requestSendContentToArchive(contentUrl);
+
+        assertEquals(expectedResult, sendContentToArchive);
+    }
+
+    @Test
+    public void shouldThrowExceptionOnArchiveContentRequest()
+    {
+        final String contentUrl = "url";
+        when(backingStore.requestSendContentToArchive(contentUrl)).thenCallRealMethod();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            cachingStore.requestSendContentToArchive(contentUrl);
+        });
+    }
+
+    @Test
+    public void shouldCompleteRestoreContentFromArchiveRequest()
+    {
+        final String contentUrl = "url";
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+        final boolean expectedResult = true;
+        when(backingStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenReturn(expectedResult);
+
+        final boolean sendContentToArchive = cachingStore.requestRestoreContentFromArchive(contentUrl, restoreParams);
+
+        assertEquals(expectedResult, sendContentToArchive);
+    }
+
+    @Test
+    public void shouldThrowExceptionOnRestoreContentFromArchiveRequest()
+    {
+        final String contentUrl = "url";
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+        when(backingStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenCallRealMethod();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            cachingStore.requestRestoreContentFromArchive(contentUrl, restoreParams);
+        });
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
@@ -27,9 +27,7 @@ package org.alfresco.repo.content.replication;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.alfresco.repo.content.AbstractWritableContentStoreTest;
 import org.alfresco.repo.content.ContentContext;
@@ -60,8 +58,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * Tests read and write functionality for the aggregating store.
@@ -314,50 +310,6 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
         assertNotNull(directAccessUrl);
         directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
-    }
-
-    @Test
-    public void shouldReturnStoragePropertiesFromPrimaryStore()
-    {
-        final String contentUrl = "url";
-        final Map<String, String> primaryStorePropertiesMap = Map.of(X_AMZ_HEADER_1, VALUE_1, X_AMZ_HEADER_2, VALUE_2);;
-        when(primaryStoreMock.getStorageProperties(contentUrl)).thenReturn(primaryStorePropertiesMap);
-
-        final Map<String, String> storageProperties = aggregatingStore.getStorageProperties(contentUrl);
-
-        assertFalse(storageProperties.isEmpty());
-        assertEquals(primaryStorePropertiesMap, storageProperties);
-        verify(secondaryStoreMock, times(0)).getStorageProperties(contentUrl);
-    }
-
-    @Test
-    public void shouldReturnStoragePropertiesFromSecondaryStore()
-    {
-        final String contentUrl = "url";
-        final Map<String, String> secondaryStorePropertiesMap = Map.of(X_AMZ_HEADER_1, VALUE_1, X_AMZ_HEADER_2, VALUE_2);;
-        when(primaryStoreMock.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
-        when(secondaryStoreMock.getStorageProperties(contentUrl)).thenReturn(secondaryStorePropertiesMap);
-
-        final Map<String, String> storageProperties = aggregatingStore.getStorageProperties(contentUrl);
-
-        assertFalse(storageProperties.isEmpty());
-        assertEquals(secondaryStorePropertiesMap, storageProperties);
-        verify(secondaryStoreMock, times(1)).getStorageProperties(contentUrl);
-        verify(primaryStoreMock, times(1)).getStorageProperties(contentUrl);
-    }
-
-    @Test
-    public void shouldReturnEmptyStorageProperties()
-    {
-        final String contentUrl = "url";
-        when(primaryStoreMock.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
-        when(secondaryStoreMock.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
-
-        final Map<String, String> storageProperties = aggregatingStore.getStorageProperties(contentUrl);
-
-        assertTrue(storageProperties.isEmpty());
-        verify(secondaryStoreMock, times(1)).getStorageProperties(contentUrl);
-        verify(primaryStoreMock, times(1)).getStorageProperties(contentUrl);
     }
 
 }

--- a/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreUnitTest.java
@@ -1,0 +1,217 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.content.replication;
+
+import org.alfresco.repo.content.ContentRestoreParams;
+import org.alfresco.repo.content.ContentStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests class for {@code AggregatingContentStore}
+ * 
+ * Currently does not cover all methods.
+ * 
+ * @author mpichura
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AggregatingContentStoreUnitTest
+{
+    private static final String X_AMZ_HEADER_1 = "x-amz-header1";
+    private static final String VALUE_1 = "value1";
+    private static final String X_AMZ_HEADER_2 = "x-amz-header2";
+    private static final String VALUE_2 = "value2";
+    
+    private List<ContentStore> secondaryStores;    
+    @Mock
+    ContentStore primaryStore;
+    @Mock
+    ContentStore secondaryStore;
+    
+    @InjectMocks
+    private AggregatingContentStore objectUnderTest;
+    
+    @Before
+    public void setUp() {
+        secondaryStores = List.of(secondaryStore);
+        objectUnderTest.setSecondaryStores(secondaryStores);
+    }
+
+
+    @Test
+    public void shouldReturnStoragePropertiesFromPrimaryStore()
+    {
+        final String contentUrl = "url";
+        final Map<String, String> primaryStorePropertiesMap = Map.of(X_AMZ_HEADER_1, VALUE_1, X_AMZ_HEADER_2, VALUE_2);;
+        when(primaryStore.getStorageProperties(contentUrl)).thenReturn(primaryStorePropertiesMap);
+
+        final Map<String, String> storageProperties = objectUnderTest.getStorageProperties(contentUrl);
+
+        assertFalse(storageProperties.isEmpty());
+        assertEquals(primaryStorePropertiesMap, storageProperties);
+        verify(secondaryStore, times(0)).getStorageProperties(contentUrl);
+    }
+
+    @Test
+    public void shouldReturnStoragePropertiesFromSecondaryStore()
+    {
+        final String contentUrl = "url";
+        final Map<String, String> secondaryStorePropertiesMap = Map.of(X_AMZ_HEADER_1, VALUE_1, X_AMZ_HEADER_2, VALUE_2);;
+        when(primaryStore.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
+        when(secondaryStore.getStorageProperties(contentUrl)).thenReturn(secondaryStorePropertiesMap);
+
+        final Map<String, String> storageProperties = objectUnderTest.getStorageProperties(contentUrl);
+
+        assertFalse(storageProperties.isEmpty());
+        assertEquals(secondaryStorePropertiesMap, storageProperties);
+        verify(secondaryStore, times(1)).getStorageProperties(contentUrl);
+        verify(primaryStore, times(1)).getStorageProperties(contentUrl);
+    }
+
+    @Test
+    public void shouldReturnEmptyStorageProperties()
+    {
+        final String contentUrl = "url";
+        when(primaryStore.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
+        when(secondaryStore.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
+
+        final Map<String, String> storageProperties = objectUnderTest.getStorageProperties(contentUrl);
+
+        assertTrue(storageProperties.isEmpty());
+        verify(primaryStore, times(1)).getStorageProperties(contentUrl);
+    }
+
+    @Test
+    public void shouldRequestContentArchiveThroughPrimaryStore()
+    {
+        final String contentUrl = "url";
+        final boolean expectedResult = true;
+
+        when(primaryStore.requestSendContentToArchive(contentUrl)).thenReturn(expectedResult);
+
+        boolean sendContentToArchive = objectUnderTest.requestSendContentToArchive(contentUrl);
+
+        assertEquals(expectedResult, sendContentToArchive);
+        verify(secondaryStore, never()).requestSendContentToArchive(contentUrl);
+    }
+
+    @Test
+    public void shouldRequestContentArchiveThroughSecondaryStore()
+    {
+        final String contentUrl = "url";
+        final boolean expectedResult = true;
+
+        when(primaryStore.requestSendContentToArchive(contentUrl)).thenThrow(UnsupportedOperationException.class);
+        when(secondaryStore.requestSendContentToArchive(contentUrl)).thenReturn(expectedResult);
+
+        boolean sendContentToArchive = objectUnderTest.requestSendContentToArchive(contentUrl);
+
+        assertEquals(expectedResult, sendContentToArchive);
+        verify(primaryStore, times(1)).requestSendContentToArchive(contentUrl);
+        verify(secondaryStore, times(1)).requestSendContentToArchive(contentUrl);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenRequestContentArchiveNotImplemented()
+    {
+        final String contentUrl = "url";
+        when(primaryStore.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
+        when(secondaryStore.getStorageProperties(contentUrl)).thenReturn(Collections.emptyMap());
+
+        final Map<String, String> storageProperties = objectUnderTest.getStorageProperties(contentUrl);
+
+        assertTrue(storageProperties.isEmpty());
+        verify(primaryStore, times(1)).getStorageProperties(contentUrl);
+    }
+
+    @Test
+    public void shouldRequestRestoreContentFromArchiveThroughPrimaryStore()
+    {
+        final String contentUrl = "url";
+        final boolean expectedResult = true;
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+
+        when(primaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenReturn(expectedResult);
+
+        boolean sendContentToArchive = objectUnderTest.requestRestoreContentFromArchive(contentUrl, restoreParams);
+
+        assertEquals(expectedResult, sendContentToArchive);
+        verify(secondaryStore, never()).requestRestoreContentFromArchive(contentUrl, restoreParams);
+    }
+
+    @Test
+    public void shouldRequestRestoreContentFromArchiveThroughSecondaryStore()
+    {
+        final String contentUrl = "url";
+        final boolean expectedResult = true;
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+
+        when(primaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenThrow(UnsupportedOperationException.class);
+        when(secondaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenReturn(expectedResult);
+
+        boolean sendContentToArchive = objectUnderTest.requestRestoreContentFromArchive(contentUrl, restoreParams);
+
+        assertEquals(expectedResult, sendContentToArchive);
+        verify(primaryStore, times(1)).requestRestoreContentFromArchive(contentUrl, restoreParams);
+        verify(secondaryStore, times(1)).requestRestoreContentFromArchive(contentUrl, restoreParams);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenRequestRestoreContentFromArchiveNotImplemented()
+    {
+        final String contentUrl = "url";
+        final Map<String, Serializable> restoreParams = Map.of(ContentRestoreParams.RESTORE_PRIORITY.name(), "High");
+        when(primaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenCallRealMethod();
+        when(secondaryStore.requestRestoreContentFromArchive(contentUrl, restoreParams)).thenCallRealMethod();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            objectUnderTest.requestRestoreContentFromArchive(contentUrl, restoreParams);
+        });
+
+        verify(primaryStore, times(1)).requestRestoreContentFromArchive(contentUrl, restoreParams);
+        verify(secondaryStore, times(1)).requestRestoreContentFromArchive(contentUrl, restoreParams);
+    }
+
+}

--- a/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreUnitTest.java
@@ -128,13 +128,14 @@ public class AggregatingContentStoreUnitTest
     {
         final String contentUrl = "url";
         final boolean expectedResult = true;
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
 
-        when(primaryStore.requestSendContentToArchive(contentUrl)).thenReturn(expectedResult);
+        when(primaryStore.requestSendContentToArchive(contentUrl, archiveParams)).thenReturn(expectedResult);
 
-        boolean sendContentToArchive = objectUnderTest.requestSendContentToArchive(contentUrl);
+        boolean sendContentToArchive = objectUnderTest.requestSendContentToArchive(contentUrl, archiveParams);
 
         assertEquals(expectedResult, sendContentToArchive);
-        verify(secondaryStore, never()).requestSendContentToArchive(contentUrl);
+        verify(secondaryStore, never()).requestSendContentToArchive(contentUrl,archiveParams);
     }
 
     @Test
@@ -142,15 +143,16 @@ public class AggregatingContentStoreUnitTest
     {
         final String contentUrl = "url";
         final boolean expectedResult = true;
+        final Map<String, Serializable> archiveParams = Collections.emptyMap();
 
-        when(primaryStore.requestSendContentToArchive(contentUrl)).thenThrow(UnsupportedOperationException.class);
-        when(secondaryStore.requestSendContentToArchive(contentUrl)).thenReturn(expectedResult);
+        when(primaryStore.requestSendContentToArchive(contentUrl, archiveParams)).thenThrow(UnsupportedOperationException.class);
+        when(secondaryStore.requestSendContentToArchive(contentUrl, archiveParams)).thenReturn(expectedResult);
 
-        boolean sendContentToArchive = objectUnderTest.requestSendContentToArchive(contentUrl);
+        boolean sendContentToArchive = objectUnderTest.requestSendContentToArchive(contentUrl, archiveParams);
 
         assertEquals(expectedResult, sendContentToArchive);
-        verify(primaryStore, times(1)).requestSendContentToArchive(contentUrl);
-        verify(secondaryStore, times(1)).requestSendContentToArchive(contentUrl);
+        verify(primaryStore, times(1)).requestSendContentToArchive(contentUrl, archiveParams);
+        verify(secondaryStore, times(1)).requestSendContentToArchive(contentUrl, archiveParams);
     }
 
     @Test


### PR DESCRIPTION
- Added new methods in `ContentStore`, `ContentService` and implementations.
- Added unit tests for most implementations.
- Refactored some `ContentStore` implementation due to common code used for existing and newly added methods.
- Moved storage properties related unit tests from `AggregatingContentStoreTest` (which looks to be in "never-run" suite) to newly created `AggregatingContentStoreUnitTest`