### PR TITLE
ATS-969 Upgrade tika (not poi)

### DIFF
--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -230,13 +230,9 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
+            <artifactId>tika-parsers-standard-package</artifactId>
             <version>${dependency.tika.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>com.tdunning</groupId>
-                    <artifactId>json</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
@@ -244,39 +240,6 @@
                 <exclusion>
                     <groupId>asm</groupId>
                     <artifactId>asm</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta.jws:jakarta.jws-api -->
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta.transaction:jakarta.transaction-api -->
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jta_1.1_spec</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta.annotation:jakarta.annotation-api -->
-                <exclusion>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from com.sun.activation:jakarta.activation -->
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>javax.activation</artifactId>
-                </exclusion>
-                <!-- Duplicates classes from jakarta -->
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>activation</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
                 </exclusion>
                 <!-- No longer needed -->
                 <exclusion>
@@ -289,21 +252,22 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>preflight</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>jempbox</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>xmpbox</artifactId>
+                    <artifactId>fontbox</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.pdfbox</groupId>
                     <artifactId>jbig2-imageio</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -243,20 +243,8 @@
                 </exclusion>
                 <!-- No longer needed -->
                 <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>pdfbox</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>pdfbox-tools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>fontbox</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.pdfbox</groupId>
-                    <artifactId>jbig2-imageio</artifactId>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>tika-parser-pdf-module</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/data-model/pom.xml
+++ b/data-model/pom.xml
@@ -243,8 +243,20 @@
                 </exclusion>
                 <!-- No longer needed -->
                 <exclusion>
-                    <groupId>org.apache.tika</groupId>
-                    <artifactId>tika-parser-pdf-module</artifactId>
+                    <groupId>org.apache.pdfbox</groupId>
+                    <artifactId>pdfbox</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.pdfbox</groupId>
+                    <artifactId>pdfbox-tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.pdfbox</groupId>
+                    <artifactId>jempbox</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.pdfbox</groupId>
+                    <artifactId>jbig2-imageio</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/data-model/src/main/java/org/alfresco/repo/content/MimetypeMap.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/MimetypeMap.java
@@ -42,6 +42,7 @@ import org.apache.tika.detect.DefaultDetector;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.quartz.CronExpression;
 import org.springframework.extensions.config.Config;
@@ -938,7 +939,8 @@ public class MimetypeMap implements MimetypeService
         Metadata metadata = new Metadata();
         if (filename != null)
         {
-            metadata.add(Metadata.RESOURCE_NAME_KEY, filename);
+            //"resourceName"
+            metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, filename);
         }
 
         InputStream inp = null;

--- a/data-model/src/main/java/org/alfresco/repo/content/MimetypeMap.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/MimetypeMap.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Data model classes
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/data-model/src/test/java/org/alfresco/repo/dictionary/DiffModelTest.java
+++ b/data-model/src/test/java/org/alfresco/repo/dictionary/DiffModelTest.java
@@ -26,7 +26,6 @@
 package org.alfresco.repo.dictionary;
 
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.averagingDouble;
 import static java.util.stream.Collectors.toMap;
 
 import static org.alfresco.repo.dictionary.M2ModelDiff.DIFF_CREATED;
@@ -40,30 +39,13 @@ import static org.alfresco.repo.dictionary.M2ModelDiff.TYPE_PROPERTY;
 import static org.alfresco.repo.dictionary.M2ModelDiff.TYPE_TYPE;
 
 import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import com.google.common.collect.Maps;
-
-import junit.framework.TestCase;
 
 import org.alfresco.error.AlfrescoRuntimeException;
-import org.alfresco.repo.tenant.SingleTServiceImpl;
-import org.alfresco.repo.tenant.TenantService;
 import org.alfresco.service.namespace.NamespaceException;
 import org.alfresco.service.namespace.QName;
-import org.alfresco.util.DynamicallySizedThreadPoolExecutor;
 import org.alfresco.util.Pair;
-import org.alfresco.util.TraceableThreadFactory;
-import org.alfresco.util.cache.DefaultAsynchronouslyRefreshedCacheRegistry;
-import org.apache.commons.collections4.map.UnmodifiableMap;
 
 public class DiffModelTest extends AbstractModelTest
 {

--- a/data-model/src/test/java/org/alfresco/repo/dictionary/DiffModelTest.java
+++ b/data-model/src/test/java/org/alfresco/repo/dictionary/DiffModelTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Data model classes
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
         <dependency.gytheio.version>0.12</dependency.gytheio.version>
         <dependency.groovy.version>3.0.9</dependency.groovy.version>
-        <dependency.tika.version>1.27</dependency.tika.version>
+        <dependency.tika.version>2.1.0</dependency.tika.version>
         <dependency.spring-security.version>5.5.2</dependency.spring-security.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>4.1.2</dependency.poi.version>
@@ -390,6 +390,11 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-cache</artifactId>
+                <version>${dependency.httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
                 <version>${dependency.httpclient.version}</version>
             </dependency>
             <dependency>

--- a/remote-api/pom.xml
+++ b/remote-api/pom.xml
@@ -93,6 +93,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${project.version}</version>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
         </dependency>

--- a/repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorResponseImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorResponseImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorResponseImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorResponseImpl.java
@@ -33,7 +33,7 @@ import org.alfresco.service.cmr.remoteconnector.RemoteConnectorRequest;
 import org.alfresco.service.cmr.remoteconnector.RemoteConnectorResponse;
 import org.alfresco.service.cmr.remoteconnector.RemoteConnectorService;
 import org.apache.commons.httpclient.Header;
-import org.apache.tika.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 
 
 /**

--- a/repository/src/main/resources/alfresco/tika/tika-config.xml
+++ b/repository/src/main/resources/alfresco/tika/tika-config.xml
@@ -2,5 +2,5 @@
 <properties>
     <!-- This property, when set, will hide the start up warnings of tika for libraries are missing. -->
     <!-- See https://issues.apache.org/jira/browse/TIKA-2490 -->
-    <service-loader initializableProblemHandler="ignore"/>
+    <service-loader loadErrorHandler="warn" initializableProblemHandler="ignore"/>
 </properties>


### PR DESCRIPTION
### Noticeable changes:
1. Tika 2.x (parsers to be precise) doesn't bring the same transitive dependencies as Tika 1.x
    * Explicitly included needed dependencies for projects depending on transitive ones.
    * Removed excludes which are no longer needed.
2. New configuration option `loadErrorHandler` not possible to set to `IGNORE` the only option which allows us to run in case of misconfigured classpath) is to set it to `WARN`.
### What about POI?
Tika 2.1.0 still depend on the POI 4.1.2 so we shouldn't upgrade it.