### PR TITLE
PRODESC-5780: ACS Repo DAU APIs to also use non-attach allow list

### DIFF
--- a/remote-api/src/main/java/org/alfresco/opencmis/CMISServletDispatcher.java
+++ b/remote-api/src/main/java/org/alfresco/opencmis/CMISServletDispatcher.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Remote API
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -37,6 +37,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterRegistration;
@@ -133,9 +135,12 @@ public abstract class CMISServletDispatcher implements CMISDispatcher
         this.cmisVersion = CmisVersion.fromValue(cmisVersion);
     }
 
-    public void setNonAttachContentTypes(Set<String> nonAttachWhiteList)
+    public void setNonAttachContentTypes(String nonAttachAllowListStr)
     {
-        this.nonAttachContentTypes = nonAttachWhiteList;
+		if (nonAttachAllowListStr != null) 
+		{
+			nonAttachContentTypes = Stream.of(nonAttachAllowListStr.trim().split("\\s*,\\s*")).collect(Collectors.toSet());
+		}
     }
 
     protected synchronized Descriptor getCurrentDescriptor()

--- a/remote-api/src/main/java/org/alfresco/opencmis/CMISServletDispatcher.java
+++ b/remote-api/src/main/java/org/alfresco/opencmis/CMISServletDispatcher.java
@@ -37,8 +37,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterRegistration;
@@ -88,7 +86,8 @@ public abstract class CMISServletDispatcher implements CMISDispatcher
 
 	private boolean allowUnsecureCallbackJSONP;
 
-    private Set<String> nonAttachContentTypes = Collections.emptySet(); // pre-configured whitelist, eg. images & pdf
+	// pre-configured allow list of media/mime types, eg. specific types of images & also pdf
+    private Set<String> nonAttachContentTypes = Collections.emptySet();
 
 	public void setTenantAdminService(TenantAdminService tenantAdminService)
 	{
@@ -137,9 +136,9 @@ public abstract class CMISServletDispatcher implements CMISDispatcher
 
     public void setNonAttachContentTypes(String nonAttachAllowListStr)
     {
-		if (nonAttachAllowListStr != null) 
+		if ((nonAttachAllowListStr != null) && (! nonAttachAllowListStr.isEmpty()))
 		{
-			nonAttachContentTypes = Stream.of(nonAttachAllowListStr.trim().split("\\s*,\\s*")).collect(Collectors.toSet());
+			nonAttachContentTypes = Set.of(nonAttachAllowListStr.trim().split("\\s*,\\s*"));
 		}
     }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -46,8 +46,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.alfresco.model.ApplicationModel;
 import org.alfresco.model.ContentModel;
@@ -241,13 +239,14 @@ public class NodesImpl implements Nodes
 
     private ConcurrentHashMap<String,NodeRef> ddCache = new ConcurrentHashMap<>();
 
-    private Set<String> nonAttachContentTypes = Collections.emptySet(); // pre-configured whitelist, eg. images & pdf
+    // pre-configured allow list of media/mime types, eg. specific types of images & also pdf
+    private Set<String> nonAttachContentTypes = Collections.emptySet(); 
 
     public void setNonAttachContentTypes(String nonAttachAllowListStr)
     {
-        if (nonAttachAllowListStr != null)
+        if ((nonAttachAllowListStr != null) && (! nonAttachAllowListStr.isEmpty()))
         {
-            nonAttachContentTypes = Stream.of(nonAttachAllowListStr.trim().split("\\s*,\\s*")).collect(Collectors.toSet());
+            nonAttachContentTypes = Set.of(nonAttachAllowListStr.trim().split("\\s*,\\s*"));
         }
     }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -46,6 +46,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.alfresco.model.ApplicationModel;
 import org.alfresco.model.ContentModel;
@@ -241,9 +243,12 @@ public class NodesImpl implements Nodes
 
     private Set<String> nonAttachContentTypes = Collections.emptySet(); // pre-configured whitelist, eg. images & pdf
 
-    public void setNonAttachContentTypes(Set<String> nonAttachWhiteList)
+    public void setNonAttachContentTypes(String nonAttachAllowListStr)
     {
-        this.nonAttachContentTypes = nonAttachWhiteList;
+        if (nonAttachAllowListStr != null)
+        {
+            nonAttachContentTypes = Stream.of(nonAttachAllowListStr.trim().split("\\s*,\\s*")).collect(Collectors.toSet());
+        }
     }
 
     public void init()

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -509,19 +509,6 @@
         </property>
     </bean>
 
-    <bean id="nodes.nonAttachContentTypes" class="org.springframework.beans.factory.config.SetFactoryBean">
-        <property name="sourceSet">
-            <set>
-                <value>application/pdf</value>
-                <value>image/jpeg</value>
-                <value>image/gif</value>
-                <value>image/png</value>
-                <value>image/tiff</value>
-                <value>image/bmp</value>
-            </set>
-        </property>
-    </bean>
-
     <bean id="nodes.personLookupProperties" class="org.springframework.beans.factory.config.SetFactoryBean">
         <property name="sourceSet">
             <set>
@@ -542,7 +529,7 @@
         <property name="quickShareLinks" ref="QuickShareLinks"/>
         <property name="behaviourFilter" ref="policyBehaviourFilter"/>
         <property name="ignoreTypes" ref="nodes.ignoreTypes"/>
-        <property name="nonAttachContentTypes" ref="nodes.nonAttachContentTypes"/>
+        <property name="nonAttachContentTypes" value="${content.nonAttach.mimetypes}"/>
         <property name="personLookupProperties" ref="nodes.personLookupProperties"/>
         <property name="poster" ref="activitiesPoster" />
         <property name="smartStore" ref="smartStore"/>
@@ -1142,7 +1129,7 @@
         <property name="version"            value="1.0"/>
         <property name="cmisVersion"        value="1.0"/>
         <property name="tenantAdminService" ref="tenantAdminService"/>
-        <property name="nonAttachContentTypes" ref="nodes.nonAttachContentTypes"/>
+        <property name="nonAttachContentTypes" value="${content.nonAttach.mimetypes}"/>
     </bean>
 
     <bean   id="cmisAtomPubDispatcher1.1" class="org.alfresco.opencmis.PublicApiAtomPubCMISDispatcher" init-method="init">
@@ -1154,7 +1141,7 @@
         <property name="version"            value="1.1"/>
         <property name="cmisVersion"        value="1.1"/>
         <property name="tenantAdminService" ref="tenantAdminService"/>
-        <property name="nonAttachContentTypes" ref="nodes.nonAttachContentTypes"/>
+        <property name="nonAttachContentTypes" value="${content.nonAttach.mimetypes}"/>
     </bean>
 
     <bean   id="cmisBrowserDispatcher1.1" class="org.alfresco.opencmis.PublicApiBrowserCMISDispatcher" init-method="init">
@@ -1166,7 +1153,7 @@
         <property name="version"            value="1.1"/>
         <property name="cmisVersion"        value="1.1"/>
         <property name="tenantAdminService" ref="tenantAdminService"/>
-        <property name="nonAttachContentTypes" ref="nodes.nonAttachContentTypes"/>
+        <property name="nonAttachContentTypes" value="${content.nonAttach.mimetypes}"/>
         <property name="allowUnsecureCallbackJSONP" value="${allow.unsecure.callback.jsonp}"/>
     </bean>
 

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -31,8 +31,6 @@ import java.util.HashSet;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.model.ContentModel;
@@ -159,9 +157,9 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
 
     public void setNonAttachContentTypes(String nonAttachAllowListStr) 
     {
-        if (nonAttachAllowListStr != null)
+        if ((nonAttachAllowListStr != null) && (! nonAttachAllowListStr.isEmpty()))
         {
-            nonAttachContentTypes = Stream.of(nonAttachAllowListStr.trim().split("\\s*,\\s*")).collect(Collectors.toSet());
+            nonAttachContentTypes = Set.of(nonAttachAllowListStr.trim().split("\\s*,\\s*"));
         }
     }
 

--- a/repository/src/main/resources/alfresco/content-services-context.xml
+++ b/repository/src/main/resources/alfresco/content-services-context.xml
@@ -164,6 +164,9 @@
       <property name="systemWideDirectUrlConfig" >
          <ref bean="systemWideDirectUrlConfig" />
       </property>
+      <property name="nonAttachContentTypes">
+         <value>${content.nonAttach.mimetypes}</value>
+      </property>
    </bean>
    
    <bean id="contentService" parent="baseContentService">

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1317,3 +1317,6 @@ system.remove-alf_server-table-from-db.ignored=true
 
 # When using JSONP, allows unsecure usage of "callback" functions. Disabled by default for security reasons
 allow.unsecure.callback.jsonp=false
+
+# Used to override attachment param (for content-disposition header)
+content.nonAttach.mimetypes=application/pdf,image/jpeg,image/gif,image/png,image/tiff,image/bmp

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1318,5 +1318,5 @@ system.remove-alf_server-table-from-db.ignored=true
 # When using JSONP, allows unsecure usage of "callback" functions. Disabled by default for security reasons
 allow.unsecure.callback.jsonp=false
 
-# Used to override attachment param (for content-disposition header)
+# pre-configured allow list of media/mime types to allow inline instead of attachment (via Content-Disposition response header)
 content.nonAttach.mimetypes=application/pdf,image/jpeg,image/gif,image/png,image/tiff,image/bmp


### PR DESCRIPTION
- moved existing pre-configured allow list from remote-api to repository layer ("nodes.nonAttachContentTypes" xml -> "content.nonAttach.mimetypes" prop)
- now also used by DAU (as well as existing V1 REST API and CMIS to get/download content)