### PR TITLE
MNT-22715 - Document Version Issue

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/version/RecordableVersionServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/version/RecordableVersionServiceImpl.java
@@ -434,6 +434,7 @@ public class RecordableVersionServiceImpl extends    Version2ServiceImpl
                         QName.createQName(Version2Model.NAMESPACE_URI, Version2Model.CHILD_VERSIONS + "-" + versionNumber),
                         sourceTypeRef,
                         null);
+                nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
                 versionNodeRef = childAssocRef.getChildRef();
 
                 // add aspect with the standard version properties to the 'version' node
@@ -808,6 +809,7 @@ public class RecordableVersionServiceImpl extends    Version2ServiceImpl
                         QName.createQName(Version2Model.NAMESPACE_URI, Version2Model.CHILD_VERSIONS + "-" + versionNumber),
                         sourceTypeRef,
                         null);
+                nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
                 NodeRef versionNodeRef = childAssocRef.getChildRef();
 
                 // add aspect with the standard version properties to the 'version' node

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/version/RecordableVersionServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/version/RecordableVersionServiceImpl.java
@@ -434,7 +434,11 @@ public class RecordableVersionServiceImpl extends    Version2ServiceImpl
                         QName.createQName(Version2Model.NAMESPACE_URI, Version2Model.CHILD_VERSIONS + "-" + versionNumber),
                         sourceTypeRef,
                         null);
-                nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
+
+                if (isUseVersionAssocIndex())
+                {
+                    nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
+                }
                 versionNodeRef = childAssocRef.getChildRef();
 
                 // add aspect with the standard version properties to the 'version' node
@@ -809,7 +813,11 @@ public class RecordableVersionServiceImpl extends    Version2ServiceImpl
                         QName.createQName(Version2Model.NAMESPACE_URI, Version2Model.CHILD_VERSIONS + "-" + versionNumber),
                         sourceTypeRef,
                         null);
-                nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
+
+                if (isUseVersionAssocIndex())
+                {
+                    nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
+                }
                 NodeRef versionNodeRef = childAssocRef.getChildRef();
 
                 // add aspect with the standard version properties to the 'version' node

--- a/repository/src/main/java/org/alfresco/repo/version/Version2ServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/version/Version2ServiceImpl.java
@@ -508,6 +508,7 @@ public class Version2ServiceImpl extends VersionServiceImpl implements VersionSe
                     nodeDetails.getProperties());
 
             versionNodeRef = childAssocRef.getChildRef();
+            nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
             
             // NOTE: special ML case - see also MultilingualContentServiceImpl.makeMLContainer
             if (sourceTypeRef.equals(ContentModel.TYPE_MULTILINGUAL_CONTAINER))

--- a/repository/src/main/java/org/alfresco/repo/version/Version2ServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/version/Version2ServiceImpl.java
@@ -84,6 +84,7 @@ public class Version2ServiceImpl extends VersionServiceImpl implements VersionSe
     private static Log logger = LogFactory.getLog(Version2ServiceImpl.class);
     
     private PermissionService permissionService;
+    private boolean useVersionAssocIndex = false;
 
     private ExtendedTrait<VersionServiceTrait> versionServiceTrait;
     
@@ -96,7 +97,23 @@ public class Version2ServiceImpl extends VersionServiceImpl implements VersionSe
     {
         this.permissionService = permissionService;
     }
-    
+
+    /**
+     * Set to use child association index on versions. This helps ordering versions when sequential IDs are not
+     * guaranteed by the DBMS.
+     *
+     * @param useVersionAssocIndex
+     */
+    public void setUseVersionAssocIndex(boolean useVersionAssocIndex)
+    {
+        this.useVersionAssocIndex = useVersionAssocIndex;
+    }
+
+    public boolean isUseVersionAssocIndex()
+    {
+        return useVersionAssocIndex;
+    }
+
     /**
      * Initialise method
      */
@@ -506,10 +523,12 @@ public class Version2ServiceImpl extends VersionServiceImpl implements VersionSe
                     QName.createQName(Version2Model.NAMESPACE_URI, Version2Model.CHILD_VERSIONS+"-"+versionNumber), // TODO - testing - note: all children (of a versioned node) will have the same version number, maybe replace with a version sequence of some sort 001-...00n
                     sourceTypeRef, 
                     nodeDetails.getProperties());
-
+            if (isUseVersionAssocIndex())
+            {
+                nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
+            }
             versionNodeRef = childAssocRef.getChildRef();
-            nodeService.setChildAssociationIndex(childAssocRef, getAllVersions(versionHistoryRef).size());
-            
+
             // NOTE: special ML case - see also MultilingualContentServiceImpl.makeMLContainer
             if (sourceTypeRef.equals(ContentModel.TYPE_MULTILINGUAL_CONTAINER))
             {

--- a/repository/src/main/resources/alfresco/core-services-context.xml
+++ b/repository/src/main/resources/alfresco/core-services-context.xml
@@ -488,6 +488,9 @@
         <property name="versionComparatorClass">
             <value>${version.store.versionComparatorClass}</value>
         </property>
+        <property name="useVersionAssocIndex">
+            <value>${version.store.useVersionAssocIndex}</value>
+        </property>
     </bean>
 
     <bean id="versionNodeService" class="org.alfresco.repo.version.Node2ServiceImpl">

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -382,6 +382,14 @@ version.store.version2Store=workspace://version2Store
 # if upgrading from a version that used unordered sequences in a cluster. 
 version.store.versionComparatorClass=
 
+# Optional to set the child association index when creating a new version. 
+# This helps ordering versions when sequential IDs are not guaranteed by the DBMS.
+# Not compatible with AGS < 7.1.1
+# Once enabled, it should not be disabled again or new versions will go back
+# to have index -1 and you will get the wrong order in version history.
+# Please, see MNT-22715 for details.
+version.store.useVersionAssocIndex=false
+
 # Folders for storing people
 system.system_container.childname=sys:system
 system.people_container.childname=sys:people


### PR DESCRIPTION
* Set association index on new version creation
* Unit test to verify the child assoc index is set on versions
* Set association index on new version creation on AGS create record from version

(cherry picked from commit c9e98b4)

* Added configuration to use child association index on version creation - disabled by default
* Added unit test to verify both cenarios
* Included configuration in AGS

(cherry picked from commit d729443)