### PR TITLE
ACS-2334 improve ArchivedIOException logging

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
@@ -325,12 +325,12 @@ public class RepositoryContainer extends AbstractRuntimeContainer
                     alf = new AlfrescoRuntimeException("WebScript execution failed", e);
                 }
                 String num = alf.getNumericalId();
-                if (alf instanceof ArchivedIOException) //only ArchivedIOException will be logged without stacktrace
+                if (alf instanceof ArchivedIOException) // only ArchivedIOException will be logged differently
                 {
-                    if (logger.isDebugEnabled()) {
+                    if (logger.isDebugEnabled()) { // log with stack trace at debug level
                         logger.debug("ArchivedIOException error(" + num + ")", e);
                     }
-                    else if (logger.isInfoEnabled())
+                    else if (logger.isInfoEnabled()) // log without stack trace at info level
                     {
                         logger.error("ArchivedIOException error. Message: " + alf.getMessage());
                     }

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
@@ -56,7 +56,6 @@ import org.alfresco.service.transaction.TransactionService;
 import org.alfresco.util.TempFileProvider;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.math3.geometry.spherical.oned.Arc;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -627,12 +626,13 @@ public class RepositoryContainer extends AbstractRuntimeContainer
 
     private void handleArchivedIOException(ArchivedIOException e)
     {
-        if (logger.isDebugEnabled()) { // log with stack trace at debug level
+        if (logger.isDebugEnabled()) // log with stack trace at debug level
+        {
             logger.debug("ArchivedIOException error ", e);
         }
         else if (logger.isInfoEnabled()) // log without stack trace at info level
         {
-            logger.error("ArchivedIOException error. Message: " + e.getMessage());
+            logger.info("ArchivedIOException error. Message: " + e.getMessage());
         }
         throw new WebScriptException(HttpServletResponse.SC_PRECONDITION_FAILED, "Content is archived and not accessible.");
     }

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/RepositoryContainer.java
@@ -47,6 +47,7 @@ import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.repo.transaction.TooBusyException;
 import org.alfresco.repo.web.scripts.bean.LoginPost;
+import org.alfresco.service.cmr.repository.ArchivedIOException;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.TemplateService;
 import org.alfresco.service.cmr.security.AuthorityService;
@@ -324,7 +325,20 @@ public class RepositoryContainer extends AbstractRuntimeContainer
                     alf = new AlfrescoRuntimeException("WebScript execution failed", e);
                 }
                 String num = alf.getNumericalId();
-                logger.error("Server error (" + num + ")", e);
+                if (alf instanceof ArchivedIOException) //only ArchivedIOException will be logged without stacktrace
+                {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("ArchivedIOException error(" + num + ")", e);
+                    }
+                    else if (logger.isInfoEnabled())
+                    {
+                        logger.error("ArchivedIOException error. Message: " + alf.getMessage());
+                    }
+                }
+                else //all other exceptions are logged with stacktrace - we may want to think about logging only message here.
+                {
+                    logger.error("Server error (" + num + ")", e);
+                }
                 throw new RuntimeException("Server error (" + num + ").  Details can be found in the server logs.");
             }
             else


### PR DESCRIPTION
To minimize log pollution, full stack trace of ArchivedIOException (content is archived) will be logged only when debug enabled. 
Exception is re-thrown as WebscriptException with error code 412 to allow similar handling in surf-webscripts (see [PR#135](https://github.com/Alfresco/surf-webscripts/pull/135))