### PR TITLE
MNT-22668: missing encoded characters for some characters like ‘(’ and ‘)’

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/content/ContentStreamer.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/content/ContentStreamer.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -58,7 +60,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.extensions.surf.util.URLEncoder;
 import org.springframework.extensions.webscripts.Cache;
 import org.springframework.extensions.webscripts.WebScriptException;
 import org.springframework.extensions.webscripts.WebScriptRequest;
@@ -481,7 +482,7 @@ public class ContentStreamer implements ResourceLoaderAware
 
                 if (req == null)
                 {
-                    headerValue += "; filename*=UTF-8''" + URLEncoder.encode(attachFileName)
+                    headerValue += "; filename*=UTF-8''" + URLEncoder.encode(attachFileName, StandardCharsets.UTF_8)
                             + "; filename=\"" + filterNameForQuotedString(attachFileName) + "\"";
                 }
                 else
@@ -490,12 +491,12 @@ public class ContentStreamer implements ResourceLoaderAware
                     boolean isLegacy = (null != userAgent) && (userAgent.contains("MSIE 8") || userAgent.contains("MSIE 7"));
                     if (isLegacy)
                     {
-                        headerValue += "; filename=\"" + URLEncoder.encode(attachFileName);
+                        headerValue += "; filename=\"" + URLEncoder.encode(attachFileName, StandardCharsets.UTF_8);
                     }
                     else
                     {
                         headerValue += "; filename=\"" + filterNameForQuotedString(attachFileName) + "\"; filename*=UTF-8''"
-                                + URLEncoder.encode(attachFileName);
+                                + URLEncoder.encode(attachFileName, StandardCharsets.UTF_8);
                     }
                 }
             }


### PR DESCRIPTION
Replaced org.springframework.extensions.surf.util.URLEncoder with the java.net.URLEncoder for encoding filenames containing characters like ")" and "(" in the content-disposition response header.