### PR TITLE
Content-services - Veracode Scan Detected Vulnerabilities in Component Netty/Codec in Application ACS_EXT_MASTER

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.keycloak.version>15.0.2</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.4.2.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>3.7.4</dependency.camel.version>
+        <dependency.camel.version>3.7.4</dependency.camel.version> <!-- If you are going to bump dependency.camel.version, please check if nested netty-codec-http version is higher than the one used in dependencyManagmenet section-->
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
         <dependency.apache-compress.version>1.21</dependency.apache-compress.version>
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>
@@ -790,6 +790,12 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>4.1.71.Final</version>
+            </dependency>
+            <dependency>
+                <!--  If you are going to bump dependency.camel.version, please check if the netty-codec-http has higher version that the one above.-->
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-amqp</artifactId>
                 <version>${dependency.camel.version}</version>


### PR DESCRIPTION
Added netty-codec-http version 4.1.71.Final to fix vulnerability nested in camel-amqp dependency.