### PR TITLE
ACS-2104: Changing apache.camel and netty-codec-http dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.keycloak.version>15.0.2</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.4.3.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>3.7.4</dependency.camel.version> <!-- If you are going to bump dependency.camel.version, please check if nested netty-codec-http version is higher than the one used in dependencyManagmenet section-->
+        <dependency.camel.version>3.7.7</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
         <dependency.apache-compress.version>1.21</dependency.apache-compress.version>
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>
@@ -792,7 +792,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.71.Final</version>
+                <version>4.1.72.Final</version>
             </dependency>
             <dependency>
                 <!--  If you are going to bump dependency.camel.version, please check if the netty-codec-http has higher version that the one above.-->


### PR DESCRIPTION
Due to dependency conflicts (in Azure Connector AMP) and vulnerabilities apache.camel and netty-codec-http dependency versions have to be changed. 
This PR is mostly dealing with netty.io related version bumps (due to vulnerability found in netty-codec-http library). 
Community-repo is providing these libraries in AMPs and there (combined with AMP specific dependencies) a dependency conflict is very likely to happen.
A follow up PR will be created in Azure Connector AMP project to properly handle provided dependencies and exclude conflicting Azure libraries.