### PR TITLE
ACS-2104: Remove Camel exclusion from DependABot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,27 +38,6 @@ updates:
   - dependency-name: org.activiti:activiti-spring
     versions:
     - ">= 7.1.a, < 7.2"
-  - dependency-name: org.apache.camel:camel-activemq
-    versions:
-    - "> 3.7.1"
-  - dependency-name: org.apache.camel:camel-amqp
-    versions:
-    - "> 3.7.1"
-  - dependency-name: org.apache.camel:camel-direct
-    versions:
-    - "> 3.7.1"
-  - dependency-name: org.apache.camel:camel-directvm
-    versions:
-    - "> 3.7.1"
-  - dependency-name: org.apache.camel:camel-jackson
-    versions:
-    - "> 3.7.1"
-  - dependency-name: org.apache.camel:camel-mock
-    versions:
-    - "> 3.7.1"
-  - dependency-name: org.apache.camel:camel-spring
-    versions:
-    - "> 3.7.1"
   - dependency-name: org.apache.chemistry.opencmis:chemistry-opencmis-client-impl
     versions:
     - "> 1.0.0"


### PR DESCRIPTION
- we're now at Camel 3.7.7 ( hence remove Camel exclusion of > 3.7.1 )
- to enable future suggestions, eg. should prompt with 3.7.7 to 3.14.0 (or maybe 3.14.1)
- also logged ACS-2476 (in case of compile-time/run-time incompatibilities and aligning with Netty)