### PR TITLE
Solr: Add missing flag mapping for NodesMetaDataGet

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/NodesMetaDataGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/NodesMetaDataGet.java
@@ -167,6 +167,10 @@ public class NodesMetaDataGet extends DeclarativeWebScript
             {
                 filter.setIncludeType(o.getBoolean("includeType"));
             }
+            if(o.has("includeChildAssociations"))
+            {
+                filter.setIncludeChildAssociations(o.getBoolean("includeChildAssociations"));
+            }
             if(o.has("includeParentAssociations"))
             {
                 filter.setIncludeParentAssociations(o.getBoolean("includeParentAssociations"));


### PR DESCRIPTION
In https://github.com/Alfresco/SearchServices/commit/943fafcca383a995db221805fed2cd9036ec66e2 @aborroy explicitly set the flag for SOLR not to load child associations from the ACS repository for regular update / creation indexing, as child associations and child ids are not relevant for this processing step. This PR adds the missing parameter flag mapping in the repository-tier web script to actually make this change take effect. Without this, the repository will always load child associations regardless of what the SOLR request specifies, as the default value for that flag if not mapped / set is `true`. In repositories with folders that contain potentially thousands or (against sane advice) millions of items, this can cause extreme pressure on the system.