### PR TITLE
Add nodeRef (node) to alfresco-access audit log

### DIFF
--- a/repository/src/main/resources/alfresco/audit/alfresco-audit-access.xml
+++ b/repository/src/main/resources/alfresco/audit/alfresco-audit-access.xml
@@ -54,7 +54,7 @@
             <RecordValue key="action" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/action" dataTrigger="/alfresco-access/transaction/action" />  
             <RecordValue key="sub-actions" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/sub-actions" dataTrigger="/alfresco-access/transaction/sub-actions" />  
             <RecordValue key="user" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/user" dataTrigger="/alfresco-access/transaction/user" />  
-
+            <RecordValue key="node" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/node" dataTrigger="/alfresco-access/transaction/node" />
             <RecordValue key="path" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/path" dataTrigger="/alfresco-access/transaction/path" />
             <RecordValue key="type" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/type" dataTrigger="/alfresco-access/transaction/type" />  
             <RecordValue key="version" dataExtractor="simpleValue" dataSource="/alfresco-access/transaction/cm:versionLabel" dataTrigger="/alfresco-access/transaction/cm:versionLabel" />  


### PR DESCRIPTION
Add nodeRef (node) to the default audit log (alfresco-access).
This way the audit entries can be associated with the actual nodes.

There are several tickets on this topic in the "Alfresco Hub". Some examples:

1. https://hub.alfresco.com/t5/alfresco-content-services-forum/how-to-get-audit-trail-of-existing-documents-with-new-audit/td-p/196663
2. https://hub.alfresco.com/t5/alfresco-content-services-forum/alfresco-access-get-noderef-nodeid-or-nodeuuid/td-p/311175

IMHO this is quite useful, as the currently used "path" alone is not sufficient to establish a unambiguous relation between node and audit record. After all, the "path" can change (move/delete) and thus a relation is no longer feasible without further ado.