### PR TITLE
Should be using TRAVIS_ACCESS_TOKEN rather than TRAVIS_ACCESS_TOKEN_T… 

### DIFF
--- a/scripts/travis/trigger_travis.sh
+++ b/scripts/travis/trigger_travis.sh
@@ -28,7 +28,7 @@ curl -s -X POST \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -H "Travis-API-Version: 3" \
-  -H "Authorization: token ${TRAVIS_ACCESS_TOKEN_TEMP}" \
+  -H "Authorization: token ${TRAVIS_ACCESS_TOKEN}" \
   -d "${BODY}" \
   "${URL}" \
  | tee /tmp/travis-request-output.txt


### PR DESCRIPTION
…EMP to trigger downstream project builds

(cherry picked from commit aeea303)