### PR TITLE
ACS-2276: Add missing indexControl on hidden nodes to avoid ElasticSearch indexing

### DIFF
--- a/repository/src/main/resources/alfresco/bootstrap/sitesSpace.xml
+++ b/repository/src/main/resources/alfresco/bootstrap/sitesSpace.xml
@@ -33,9 +33,12 @@
                      <view:properties>
                         <cm:description></cm:description>
                         <cm:name>extensions</cm:name>
+                        <cm:isIndexed>false</cm:isIndexed>
+                        <cm:isContentIndexed>false</cm:isContentIndexed>
                      </view:properties>
                      <view:aspects>
                         <sys:hidden/>
+                        <cm:indexControl/>
                     </view:aspects>
                   </cm:folder>
                </cm:contains>
@@ -50,9 +53,12 @@
                      <view:properties>
                         <cm:description></cm:description>
                         <cm:name>module-deployments</cm:name>
+                        <cm:isIndexed>false</cm:isIndexed>
+                        <cm:isContentIndexed>false</cm:isContentIndexed>
                      </view:properties>
                      <view:aspects>
                         <sys:hidden/>
+                        <cm:indexControl/>
                     </view:aspects>
                   </cm:folder>
                </cm:contains>

--- a/repository/src/test/java/org/alfresco/repo/importer/ImporterComponentTest.java
+++ b/repository/src/test/java/org/alfresco/repo/importer/ImporterComponentTest.java
@@ -56,6 +56,7 @@ import org.alfresco.util.BaseSpringTest;
 import org.alfresco.util.debug.NodeStoreInspector;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -112,6 +113,31 @@ public class ImporterComponentTest extends BaseSpringTest
         Location location = new Location(storeRef);
         importerService.importView(testReader, location, null, new ImportTimerProgress());
         System.out.println(NodeStoreInspector.dumpNodeStore(nodeService, storeRef));
+    }
+
+    @Test
+    public void testImportNotIndexedSubfolder() throws Exception
+    {
+        InputStream test = getClass().getClassLoader().getResourceAsStream(
+            "org/alfresco/repo/importer/import_not_indexed_subfolder.xml");
+
+        try (InputStreamReader testReader = new InputStreamReader(test, "UTF-8"))
+        {
+            Location location = new Location(storeRef);
+            importerService.importView(testReader, location, null, new ImportTimerProgress());
+            NodeRef rootNodeRef = nodeService.getRootNode(storeRef);
+            NodeRef testParentFolderRef = nodeService.getChildAssocs(rootNodeRef).get(0).getChildRef();
+            NodeRef testSubfolderRef = nodeService.getChildAssocs(testParentFolderRef).get(0).getChildRef();
+
+            assertFalse("The node's isIndexed property should be false.",
+                DefaultTypeConverter.INSTANCE.convert(Boolean.class,
+                    nodeService.getProperty(testSubfolderRef, ContentModel.PROP_IS_INDEXED)));
+            assertFalse("The node's isContentIndexed property should be false.",
+                DefaultTypeConverter.INSTANCE.convert(Boolean.class,
+                    nodeService.getProperty(testSubfolderRef, ContentModel.PROP_IS_CONTENT_INDEXED)));
+            assertTrue("The node should be marked with the indexControl aspect.",
+                nodeService.getAspects(testSubfolderRef).contains(ContentModel.ASPECT_INDEX_CONTROL));
+        }
     }
     
     @Test

--- a/repository/src/test/java/org/alfresco/repo/importer/ImporterComponentTest.java
+++ b/repository/src/test/java/org/alfresco/repo/importer/ImporterComponentTest.java
@@ -56,7 +56,6 @@ import org.alfresco.util.BaseSpringTest;
 import org.alfresco.util.debug.NodeStoreInspector;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/repository/src/test/resources/org/alfresco/repo/importer/import_not_indexed_subfolder.xml
+++ b/repository/src/test/resources/org/alfresco/repo/importer/import_not_indexed_subfolder.xml
@@ -1,0 +1,25 @@
+<view:view xmlns:view="http://www.alfresco.org/view/repository/1.0" xmlns:cm="http://www.alfresco.org/model/content/1.0" xmlns:sys="http://www.alfresco.org/model/system/1.0">
+   <cm:folder view:childName="cm:test-parent-folder">
+      <view:properties>
+         <cm:description>Test Parent Folder</cm:description>
+         <cm:name>test-parent-folder</cm:name>
+      </view:properties>
+      <view:aspects>
+         <sys:hidden />
+      </view:aspects>
+      <cm:contains>
+         <cm:folder view:childName="cm:test-not-indexed-subfolder">
+            <view:properties>
+               <cm:description>Test Subfolder</cm:description>
+               <cm:name>test-not-indexed-subfolder</cm:name>
+               <cm:isIndexed>false</cm:isIndexed>
+               <cm:isContentIndexed>false</cm:isContentIndexed>
+            </view:properties>
+            <view:aspects>
+               <sys:hidden />
+               <cm:indexControl />
+            </view:aspects>
+         </cm:folder>
+      </cm:contains>
+   </cm:folder>
+</view:view>


### PR DESCRIPTION
Added the required `indexControl` aspect and related properties to make sure that hidden nodes created at bootstrap time won't be indexed in ElasticSearch.