### PR TITLE
ACS-2498 Add coreVersion to T-Engine config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency.alfresco-log-sanitizer.version>0.2</dependency.alfresco-log-sanitizer.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-model.version>1.4.8</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.9-SNAPSHOT</dependency.alfresco-transform-model.version>
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.13</dependency.acs-event-model.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency.alfresco-log-sanitizer.version>0.2</dependency.alfresco-log-sanitizer.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-model.version>1.4.9-SNAPSHOT</dependency.alfresco-transform-model.version>
+        <dependency.alfresco-transform-model.version>1.4.9</dependency.alfresco-transform-model.version>
         <dependency.alfresco-greenmail.version>6.2</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.13</dependency.acs-event-model.version>
 

--- a/repository/src/main/java/org/alfresco/repo/content/transform/AbstractLocalTransform.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/AbstractLocalTransform.java
@@ -86,6 +86,7 @@ public abstract class AbstractLocalTransform implements LocalTransform
                                           String renditionName, NodeRef sourceNodeRef)
             throws UnsupportedTransformationException, ContentIOException;
 
+    @Override
     public String getName()
     {
         return name;

--- a/repository/src/main/java/org/alfresco/repo/content/transform/DummyTransformServiceRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/DummyTransformServiceRegistry.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2019 Alfresco Software Limited
+ * Copyright (C) 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.content.transform;
 
+import org.alfresco.transform.client.model.config.CoreFunction;
 import org.alfresco.transform.client.registry.TransformServiceRegistry;
 
 import java.util.Map;
@@ -48,5 +49,11 @@ public class DummyTransformServiceRegistry implements TransformServiceRegistry
                                       Map<String, String> actualOptions, String renditionName)
     {
         return null;
+    }
+
+    @Override
+    public boolean isSupported(CoreFunction function, String transformerName)
+    {
+        return true;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransform.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2019 Alfresco Software Limited
+ * Copyright (C) 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -54,4 +54,9 @@ public interface LocalTransform
     void transform(ContentReader reader, ContentWriter writer, Map<String, String> transformOptions,
                    String renditionName, NodeRef sourceNodeRef)
             throws UnsupportedTransformationException, ContentIOException;
+
+    /**
+     * @return the name of the transform.
+     */
+    String getName();
 }

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
@@ -36,6 +36,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.alfresco.service.cmr.repository.MimetypeService;
+import org.alfresco.transform.client.model.config.CoreFunction;
 import org.alfresco.transform.client.model.config.TransformOptionGroup;
 import org.alfresco.transform.client.registry.CombinedConfig;
 import org.alfresco.transform.client.model.config.TransformOption;
@@ -472,5 +473,18 @@ public class LocalTransformServiceRegistry extends TransformServiceRegistryImpl 
             localTransform = localTransforms.get(name);
         }
         return localTransform;
+    }
+
+    /**
+     * Returns {@code true} if the {@code function} is supported by the transform. Not all transforms are
+     * able to support all functionality, as newer features may have been introduced into the core t-engine code since
+     * it was released.
+     * @param function to be checked.
+     * @param transform the local transform.
+     * @return {@code true} is supported, {@code false} otherwise.
+     */
+    boolean isSupported(CoreFunction function, LocalTransform transform)
+    {
+        return isSupported(function, transform.getName());
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformServiceRegistry.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2019 - 2021 Alfresco Software Limited
+ * Copyright (C) 2019 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/main/java/org/alfresco/repo/rendition2/SwitchingTransformServiceRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/SwitchingTransformServiceRegistry.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.rendition2;
 
+import org.alfresco.transform.client.model.config.CoreFunction;
 import org.alfresco.transform.client.registry.TransformServiceRegistry;
 
 import java.util.Map;
@@ -77,5 +78,11 @@ public class SwitchingTransformServiceRegistry implements TransformServiceRegist
             name = secondary.findTransformerName(sourceMimetype, sourceSizeInBytes, targetMimetype, actualOptions, renditionName);
         }
         return name;
+    }
+
+    @Override
+    public boolean isSupported(CoreFunction function, String transformerName)
+    {
+        return primary.isSupported(function, transformerName) && secondary.isSupported(function, transformerName);
     }
 }

--- a/repository/src/main/java/org/alfresco/transform/client/registry/CombinedConfig.java
+++ b/repository/src/main/java/org/alfresco/transform/client/registry/CombinedConfig.java
@@ -47,6 +47,8 @@ import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
 
+import static org.alfresco.transform.client.util.RequestParamMap.INCLUDE_CORE_VERSION;
+
 /**
  * This class reads multiple T-Engine config and local files and registers as if they were all
  * in one file. Transform options are shared between all sources.<p>
@@ -104,7 +106,7 @@ public class CombinedConfig extends CombinedTransformConfig
 
     private boolean addRemoteConfig(String baseUrl, String remoteType)
     {
-        String url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "transform/config";
+        String url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "transform/config?" + INCLUDE_CORE_VERSION;
         HttpGet httpGet = new HttpGet(url);
         boolean successReadingConfig = true;
         try

--- a/repository/src/main/java/org/alfresco/transform/client/registry/CombinedConfig.java
+++ b/repository/src/main/java/org/alfresco/transform/client/registry/CombinedConfig.java
@@ -106,7 +106,7 @@ public class CombinedConfig extends CombinedTransformConfig
 
     private boolean addRemoteConfig(String baseUrl, String remoteType)
     {
-        String url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "transform/config?" + INCLUDE_CORE_VERSION;
+        String url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "transform/config?" + INCLUDE_CORE_VERSION + "=" + true;
         HttpGet httpGet = new HttpGet(url);
         boolean successReadingConfig = true;
         try

--- a/repository/src/test/java/org/alfresco/repo/rendition2/TestTransformServiceRegistry.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/TestTransformServiceRegistry.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2019 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.rendition2;
 
+import org.alfresco.transform.client.model.config.CoreFunction;
 import org.alfresco.transform.client.registry.TransformServiceRegistry;
 
 import java.util.Map;
@@ -68,5 +69,11 @@ public class TestTransformServiceRegistry implements TransformServiceRegistry
                                       String targetMimetype, Map<String, String> actualOptions, String renditionName)
     {
         throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public boolean isSupported(CoreFunction function, String transformerName)
+    {
+        return true;
     }
 }


### PR DESCRIPTION
Added isSupported(CoreFunction function, String transformerName) and isSupported(CoreFunction function, LocalTransform transform) ready for work on the ACS-2493 & ACS-2494. 
