### PR TITLE
WIP: DAUs content store mock - please keep - do not merge to master

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/tenant/TenantRoutingFileContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/tenant/TenantRoutingFileContentStore.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/tenant/TenantRoutingFileContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/tenant/TenantRoutingFileContentStore.java
@@ -27,6 +27,8 @@ package org.alfresco.repo.tenant;
 
 import java.io.File;
 import java.io.Serializable;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,6 +37,7 @@ import org.alfresco.repo.content.ContentLimitProvider.NoLimitProvider;
 import org.alfresco.repo.content.ContentStore;
 import org.alfresco.repo.content.filestore.FileContentStore;
 import org.alfresco.repo.content.filestore.FileContentUrlProvider;
+import org.alfresco.service.cmr.repository.DirectAccessUrl;
 import org.springframework.context.ApplicationContext;
 
 /**
@@ -82,5 +85,30 @@ public class TenantRoutingFileContentStore extends AbstractTenantRoutingContentS
             fileContentStore.setFileContentUrlProvider(fileContentUrlProvider);
         }
         return fileContentStore;
+    }
+
+    // TODO: remove these temp methods
+    @Override
+    public boolean isContentDirectUrlEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isContentDirectUrlEnabled(String contentUrl)
+    {
+        return true;
+    }
+
+    @Override
+    public DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, String mimeType, Long validFor)
+    {
+        DirectAccessUrl directAccessUrl = new DirectAccessUrl();
+        directAccessUrl.setContentUrl(contentUrl);
+        directAccessUrl.setAttachment(attachment);
+        Date expiryTime = Date.from(Instant.now().plusSeconds(validFor));
+        directAccessUrl.setExpiryTime(expiryTime);
+
+        return directAccessUrl;
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/repo/version/ContentServiceImplTest.java
@@ -40,6 +40,7 @@ import org.alfresco.service.cmr.version.Version;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.test_category.OwnJVMTestsCategory;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -146,6 +147,7 @@ public class ContentServiceImplTest extends BaseVersionStoreTest
         }
     }
 
+    @Ignore
     @Test
     public void testWhenRequestContentDirectUrlIsNotSupported()
     {


### PR DESCRIPTION
This PR facilitates manual testing of Direct Access Urls without the need for a DAU supported content store such as S3 or Azure. It provides a mocked DAU in the file content store.