### PR TITLE
MNT-22710 - ContentURLs with CRC collision and same last 12 chars are…

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
@@ -352,13 +352,20 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         }
 
         /**
-         * Looks the node up based on the NodeRef of the given node
+         * Looks the entity up based on the ContentURL of the given node
          */
         @Override
         public Pair<Long, ContentUrlEntity> findByValue(ContentUrlEntity entity)
         {
             String contentUrl = entity.getContentUrl();
             ContentUrlEntity ret = getContentUrlEntity(contentUrl);
+            // Validate if this entity has exactly the value we are looking for or if it is a CRC collision
+            if (ret != null && !entity.getContentUrl().equals(ret.getContentUrl()))
+            {
+                throw new IllegalArgumentException("Collision detected for this contentURL. '" + entity.getContentUrl()
+                        + "' collides with existing contentURL '" + ret.getContentUrl() + "'. (ContentUrlShort;ContentUrlCrc) pair collision: ('"
+                        + entity.getContentUrlShort() + "';'" + entity.getContentUrlCrc() + "')");
+            }
             return (ret != null ? new Pair<Long, ContentUrlEntity>(ret.getId(), ret) : null);
         }
 


### PR DESCRIPTION
… assumed as duplicates and node is linked to the wrong contentURL (#944)

* Added a validation to assure the URL is the same and if it is not, throw an error
* Added a unit test to replicate the problem

(cherry picked from commit 85b5b2660e39f8fc4253dea0db7b50ac441150d0)