### PR TITLE
ACS-2348: Removing `@Experimental` annotation on Storage Properties

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/content/ContentRestoreParams.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentRestoreParams.java
@@ -26,7 +26,6 @@
 
 package org.alfresco.repo.content;
 
-import org.alfresco.service.Experimental;
 
 /**
  * Enumeration with values for archive-restore parameter keys.
@@ -35,7 +34,6 @@ import org.alfresco.service.Experimental;
  *
  * @author mpichura
  */
-@Experimental
 public enum ContentRestoreParams
 {
     /**

--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -26,7 +26,6 @@
 package org.alfresco.repo.content;
 
 import org.alfresco.api.AlfrescoPublicApi;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ContentAccessor;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
@@ -340,7 +339,6 @@ public interface ContentStore
      * @param contentUrl the URL of the content for which the storage properties are to be retrieved.
      * @return Returns a key-value (String-String) collection of storage headers/properties with their respective values.
      */
-    @Experimental
     default Map<String, String> getStorageProperties(String contentUrl)
     {
         return Collections.emptyMap();
@@ -350,14 +348,12 @@ public interface ContentStore
      * Submit a request to send content to archive (offline) state.
      * If no connector is present or connector is not supporting sending to archive, then {@link UnsupportedOperationException} will be returned.
      * Specific connector will decide which storage class/tier will be set for content.
-     * This method is experimental and subject to changes.
      *
      * @param contentUrl the URL of the content which is to be archived.
      * @param archiveParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
      * @return true when request successful, false when unsuccessful.
      * @throws UnsupportedOperationException when store is unable to handle request.
      */
-    @Experimental
     default boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
         throw new UnsupportedOperationException("Request to archive content is not supported by this content store.");
@@ -370,14 +366,12 @@ public interface ContentStore
      * Keys of this map should be restricted to {@code ContentRestoreParams} enumeration.
      * For AWS S3 map can indicating expiry days, Glacier restore tier.
      * For Azure Blob map can indicate rehydrate priority.
-     * This method is experimental and subject to changes.
      *
      * @param contentUrl    the URL of the content which is to be archived.
      * @param restoreParams a map of String-Serializable parameters defining Storage Provider specific request parameters (can be empty).
      * @return true when request successful, false when unsuccessful.
      * @throws UnsupportedOperationException when store is unable to handle request.
      */
-    @Experimental
     default boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
     {
         throw new UnsupportedOperationException("Request to restore content from archive is not supported by this content store.");

--- a/data-model/src/main/java/org/alfresco/repo/content/ObjectStorageProps.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ObjectStorageProps.java
@@ -26,8 +26,6 @@
 
 package org.alfresco.repo.content;
 
-import org.alfresco.service.Experimental;
-
 /**
  * Enumeration with "header" values for Alfresco derived Storage Properties
  * Values of this enum should be used when adding Alfresco derived key-value pairs in Storage Properties map.
@@ -35,7 +33,6 @@ import org.alfresco.service.Experimental;
  *
  * @author mpichura
  */
-@Experimental
 public enum ObjectStorageProps {
     /**
      * Object's content is archived and not immediately accessible.

--- a/data-model/src/main/java/org/alfresco/service/cmr/repository/ArchivedIOException.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/repository/ArchivedIOException.java
@@ -26,7 +26,6 @@
 package org.alfresco.service.cmr.repository;
 
 import org.alfresco.api.AlfrescoPublicApi;
-import org.alfresco.service.Experimental;
 
 /**
  * Unable to access as content is in an Archived state.
@@ -34,7 +33,6 @@ import org.alfresco.service.Experimental;
  * 
  * @author David Edwards
  */
-@Experimental
 @AlfrescoPublicApi
 public class ArchivedIOException extends ContentIOException
 {

--- a/data-model/src/main/java/org/alfresco/service/cmr/repository/RestoreInProgressException.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/repository/RestoreInProgressException.java
@@ -27,7 +27,6 @@ package org.alfresco.service.cmr.repository;
 
 import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.error.AlfrescoRuntimeException;
-import org.alfresco.service.Experimental;
 
 /**
  * Content Restoration in progress
@@ -35,7 +34,6 @@ import org.alfresco.service.Experimental;
  * @author David Edwards
  */
 @AlfrescoPublicApi
-@Experimental
 public class RestoreInProgressException extends AlfrescoRuntimeException
 {
     private static final long serialVersionUID = 5483215922384016269L;

--- a/remote-api/src/main/java/org/alfresco/rest/api/ContentStorageInformation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/ContentStorageInformation.java
@@ -30,49 +30,37 @@ import org.alfresco.rest.api.model.ArchiveContentRequest;
 import org.alfresco.rest.api.model.ContentStorageInfo;
 import org.alfresco.rest.api.model.RestoreArchivedContentRequest;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
  * Storage information for content API.
- * Note: Currently marked as experimental and subject to change.
  *
  * @author mpichura
  */
-@Experimental
 public interface ContentStorageInformation
 {
     /**
-     * Note: Currently marked as experimental and subject to change.
-     *
      * @param nodeRef         Node reference
      * @param contentPropName Qualified name of content property (e.g. 'cm_content')
      * @param parameters      {@link Parameters} object to get the parameters passed into the request
      * @return {@link ContentStorageInfo} object consisting of qualified name of content property and a map of storage properties
      */
-    @Experimental
     ContentStorageInfo getStorageInfo(NodeRef nodeRef, String contentPropName, Parameters parameters);
 
     /**
-     * Note: Currently marked as experimental and subject to change.
-     *
      * @param nodeRef               Node reference
      * @param contentPropName       Qualified name of content property (e.g. 'cm_content')
      * @param archiveContentRequest {@link ArchiveContentRequest} object holding parameters for archive content request
      * @return true when request successful, false when unsuccessful
      */
-    @Experimental
     boolean requestArchiveContent(NodeRef nodeRef, String contentPropName, ArchiveContentRequest archiveContentRequest);
 
     /**
-     * Note: Currently marked as experimental and subject to change.
-     *
      * @param nodeRef                       Node reference
      * @param contentPropName               Qualified name of content property (e.g. 'cm_content')
      * @param restoreArchivedContentRequest {@link RestoreArchivedContentRequest} object holding parameters for restore from archive request
      * @return true when request successful, false when unsuccessful
      */
-    @Experimental
     boolean requestRestoreContentFromArchive(NodeRef nodeRef, String contentPropName,
                                              RestoreArchivedContentRequest restoreArchivedContentRequest);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/ContentStorageInformationImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/ContentStorageInformationImpl.java
@@ -33,7 +33,6 @@ import org.alfresco.rest.api.model.ContentStorageInfo;
 import org.alfresco.rest.api.model.RestoreArchivedContentRequest;
 import org.alfresco.rest.framework.core.exceptions.RestoreInProgressException;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.NamespaceService;
@@ -45,11 +44,9 @@ import java.util.Map;
 
 /**
  * Default implementation for {@link ContentStorageInformation}
- * Note: Currently marked as experimental and subject to change.
  *
  * @author mpichura
  */
-@Experimental
 public class ContentStorageInformationImpl implements ContentStorageInformation
 {
 
@@ -68,7 +65,6 @@ public class ContentStorageInformationImpl implements ContentStorageInformation
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public ContentStorageInfo getStorageInfo(NodeRef nodeRef, String contentPropName, Parameters parameters)
     {
         final QName propQName = getQName(contentPropName);

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/DownloadsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/DownloadsImpl.java
@@ -38,7 +38,6 @@ import org.alfresco.rest.api.Nodes;
 import org.alfresco.rest.api.model.Download;
 import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
 import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.download.DownloadService;
 import org.alfresco.service.cmr.download.DownloadStatus;
 import org.alfresco.service.cmr.module.ModuleService;
@@ -214,8 +213,7 @@ public class DownloadsImpl implements Downloads
      * @param checkLimit The maximum number of nodes to check, set to -1 for no limit
      * @see #checkArchiveStatus(NodeRef[], int, Set)
      */
-    @Experimental
-    protected void checkArchiveStatus(NodeRef[] nodeRefs, int checkLimit) 
+    protected void checkArchiveStatus(NodeRef[] nodeRefs, int checkLimit)
     {
         if (canCheckArchived()) 
         {
@@ -234,7 +232,6 @@ public class DownloadsImpl implements Downloads
      * @param checkLimit The maximum number of nodes to check, set to -1 for no limit
      * @param cache Tracks nodes that we have already checked, if null an empty cache will be created
      */
-    @Experimental
     private void checkArchiveStatus(NodeRef[] nodeRefs, int checkLimit, Set<NodeRef> cache)
     {
         // Create the cache for recursive calls.
@@ -291,8 +288,7 @@ public class DownloadsImpl implements Downloads
         }
     }
 
-    @Experimental
-    protected boolean canCheckArchived() 
+    protected boolean canCheckArchived()
     {
         return Arrays.stream(CLOUD_CONNECTOR_MODULES).anyMatch(m-> moduleService.getModule(m) != null);
     }

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/ArchiveContentRequest.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/ArchiveContentRequest.java
@@ -26,19 +26,15 @@
 
 package org.alfresco.rest.api.model;
 
-import org.alfresco.service.Experimental;
-
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Request for content archive.
- * Marked as experimental and subject to change.
  *
  * @author mpichura
  */
-@Experimental
 public class ArchiveContentRequest
 {
     /**

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/RestoreArchivedContentRequest.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/RestoreArchivedContentRequest.java
@@ -26,15 +26,11 @@
 
 package org.alfresco.rest.api.model;
 
-import org.alfresco.service.Experimental;
-
 /**
  * Request for restore content from archive.
- * Marked as experimental and subject to change.
  *
  * @author mpichura
  */
-@Experimental
 public class RestoreArchivedContentRequest
 {
     /**

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeStorageInfoRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeStorageInfoRelation.java
@@ -39,7 +39,6 @@ import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 import org.alfresco.rest.framework.webscripts.WithResponse;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.util.PropertyCheck;
@@ -49,11 +48,9 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Node storage information.
- * Note: Currently marked as experimental and subject to change.
  *
  * @author mpichura
  */
-@Experimental
 @RelationshipResource(name = "storage-info", entityResource = NodesEntityResource.class, title = "Node's content storage information")
 public class NodeStorageInfoRelation implements RelationshipResourceAction.ReadById<ContentStorageInfo>, InitializingBean
 {
@@ -82,7 +79,6 @@ public class NodeStorageInfoRelation implements RelationshipResourceAction.ReadB
         return storageInformation.getStorageInfo(nodeRef, contentPropName, parameters);
     }
 
-    @Experimental
     @Operation("archive")
     @WebApiParam(name = "archiveContentRequest", title = "Request for archive content",
             description = "Optional parameters for archive content", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
@@ -103,7 +99,6 @@ public class NodeStorageInfoRelation implements RelationshipResourceAction.ReadB
         }
     }
 
-    @Experimental
     @Operation("archive-restore")
     @WebApiParam(name = "restoreArchivedContentRequest", title = "Request for restore content from archive",
             description = "Optional parameters for restore content from archive", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeVersionsStorageInfoRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeVersionsStorageInfoRelation.java
@@ -40,7 +40,6 @@ import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 import org.alfresco.rest.framework.webscripts.WithResponse;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.version.Version;
 import org.alfresco.util.PropertyCheck;
@@ -52,12 +51,9 @@ import javax.servlet.http.HttpServletResponse;
  * Node Versions storage information.
  *
  *  - GET  /nodes/{nodeId}/versions/{versionId}/storage-info/{contentPropQNameId}
- * 
- * Note: Currently marked as experimental and subject to change.
  *
  * @author janv
  */
-@Experimental
 @RelationshipResource(name = "storage-info", entityResource = NodeVersionsRelation.class, title = "Node Version's content storage information")
 public class NodeVersionsStorageInfoRelation implements RelationshipResourceAction.ReadById<ContentStorageInfo>, InitializingBean
 {
@@ -91,7 +87,6 @@ public class NodeVersionsStorageInfoRelation implements RelationshipResourceActi
         return storageInformation.getStorageInfo(versionNodeRef, contentPropQNameId, parameters);
     }
 
-    @Experimental
     @Operation("archive")
     @WebApiParam(name = "archiveContentRequest", title = "Request for archive version content",
             description = "Optional parameters for archive version content", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)
@@ -116,7 +111,6 @@ public class NodeVersionsStorageInfoRelation implements RelationshipResourceActi
         }
     }
 
-    @Experimental
     @Operation("archive-restore")
     @WebApiParam(name = "restoreArchivedContentRequest", title = "Request for restore version content from archive",
             description = "Optional parameters for restore version content from archive", kind = ResourceParameter.KIND.HTTP_BODY_OBJECT)

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/ArchivedContentException.java
@@ -25,15 +25,12 @@
  */
 package org.alfresco.rest.framework.core.exceptions;
 
-import org.alfresco.service.Experimental;
-
 /**
  * Thrown when the content is archived and not readily accessible.
  * Status is <i>Precondition Failed</i> client error = 412.
  *
  * @author David Edwards
  */
-@Experimental
 public class ArchivedContentException  extends  ApiException
 {
 

--- a/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/RestoreInProgressException.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/core/exceptions/RestoreInProgressException.java
@@ -25,9 +25,6 @@
  */
 package org.alfresco.rest.framework.core.exceptions;
 
-import org.alfresco.service.Experimental;
-
-@Experimental
 public class RestoreInProgressException extends  ApiException
 {
     public static String DEFAULT_MESSAGE_ID = "framework.exception.RestoreInProgress";

--- a/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/AbstractRoutingContentStore.java
@@ -35,7 +35,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.cache.SimpleCache;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentWriter;
@@ -425,7 +424,6 @@ public abstract class AbstractRoutingContentStore implements ContentStore
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public Map<String, String> getStorageProperties(String contentUrl)
     {
         ContentStore contentStore = selectReadStore(contentUrl);
@@ -445,7 +443,6 @@ public abstract class AbstractRoutingContentStore implements ContentStore
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
         final ContentStore contentStore = selectReadStore(contentUrl);
@@ -463,7 +460,6 @@ public abstract class AbstractRoutingContentStore implements ContentStore
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
     {
         final ContentStore contentStore = selectReadStore(contentUrl);

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -46,7 +46,6 @@ import org.alfresco.repo.policy.ClassPolicyDelegate;
 import org.alfresco.repo.policy.JavaBehaviour;
 import org.alfresco.repo.policy.PolicyComponent;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.InvalidTypeException;
@@ -668,7 +667,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public Map<String, String> getStorageProperties(NodeRef nodeRef, QName propertyQName)
     {
         final ContentData contentData = getContentDataOrThrowError(nodeRef, propertyQName);

--- a/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
@@ -37,7 +37,6 @@ import org.alfresco.repo.content.caching.quota.QuotaManagerStrategy;
 import org.alfresco.repo.content.caching.quota.UnlimitedQuotaStrategy;
 import org.alfresco.repo.content.filestore.FileContentStore;
 import org.alfresco.repo.content.filestore.SpoofedTextContentReader;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentStreamListener;
@@ -387,7 +386,6 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public Map<String, String> getStorageProperties(final String contentUrl)
     {
         return backingStore.getStorageProperties(contentUrl);
@@ -397,7 +395,6 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
         return backingStore.requestSendContentToArchive(contentUrl, archiveParams);
@@ -407,7 +404,6 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
     {
         return backingStore.requestRestoreContentFromArchive(contentUrl, restoreParams);

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -40,7 +40,6 @@ import org.alfresco.repo.content.ContentContext;
 import org.alfresco.repo.content.ContentStore;
 import org.alfresco.repo.content.UnsupportedContentUrlException;
 import org.alfresco.repo.content.caching.CachingContentStore;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentWriter;
@@ -403,7 +402,6 @@ public class AggregatingContentStore extends AbstractContentStore
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public Map<String, String> getStorageProperties(String contentUrl)
     {
         checkPrimaryStore();
@@ -457,7 +455,6 @@ public class AggregatingContentStore extends AbstractContentStore
     /**
      * {@inheritDoc}
      */
-    @Experimental
     @Override
     public boolean requestSendContentToArchive(final String contentUrl, Map<String, Serializable> archiveParams)
     {
@@ -467,7 +464,6 @@ public class AggregatingContentStore extends AbstractContentStore
     /**
      * {@inheritDoc}
      */
-    @Experimental
     @Override
     public boolean requestRestoreContentFromArchive(final String contentUrl, final Map<String, Serializable> restoreParams)
     {

--- a/repository/src/main/java/org/alfresco/repo/tenant/AbstractTenantRoutingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/tenant/AbstractTenantRoutingContentStore.java
@@ -43,7 +43,6 @@ import org.alfresco.repo.domain.tenant.TenantEntity;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.tenant.TenantUtil.TenantRunAsWork;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.transaction.TransactionService;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -276,7 +275,6 @@ public abstract class AbstractTenantRoutingContentStore extends AbstractRoutingC
     /**
      * {@inheritDoc}
      */
-    @Experimental
     @Override
     public Map<String, String> getStorageProperties(String contentUrl)
     {
@@ -287,7 +285,6 @@ public abstract class AbstractTenantRoutingContentStore extends AbstractRoutingC
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public boolean requestSendContentToArchive(String contentUrl, Map<String, Serializable> archiveParams)
     {
         return getTenantContentStore().requestSendContentToArchive(contentUrl, archiveParams);
@@ -297,7 +294,6 @@ public abstract class AbstractTenantRoutingContentStore extends AbstractRoutingC
      * {@inheritDoc}
      */
     @Override
-    @Experimental
     public boolean requestRestoreContentFromArchive(String contentUrl, Map<String, Serializable> restoreParams)
     {
         return getTenantContentStore().requestRestoreContentFromArchive(contentUrl, restoreParams);

--- a/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/repository/ContentService.java
@@ -29,7 +29,6 @@ package org.alfresco.service.cmr.repository;
 import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.model.ContentModel;
 import org.alfresco.service.Auditable;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.dictionary.InvalidTypeException;
 import org.alfresco.service.namespace.QName;
 
@@ -260,7 +259,6 @@ public interface ContentService
      * @return Returns a key-value (String-String) collection of storage headers/properties with their respective values for a given {@link NodeRef}.
      */
     @Auditable(parameters = {"nodeRef", "propertyQName"})
-    @Experimental
     default Map<String, String> getStorageProperties(NodeRef nodeRef, QName propertyQName)
     {
         return Collections.emptyMap();
@@ -270,7 +268,6 @@ public interface ContentService
      * Submit a request to send content to archive (offline) state.
      * If no connector is present or connector is not supporting sending to archive, then {@link UnsupportedOperationException} will be returned.
      * Specific connector will decide which storage class/tier will be set for content.
-     * This method is experimental and subject to changes.
      *
      * @param nodeRef a reference to a node having a content property
      * @param propertyQName the name of the property, which must be of type <b>content</b>
@@ -279,7 +276,6 @@ public interface ContentService
      * @throws UnsupportedOperationException when method not implemented
      */
     @Auditable(parameters = {"nodeRef", "propertyQName", "archiveParams"})
-    @Experimental
     default boolean requestSendContentToArchive(NodeRef nodeRef, QName propertyQName,
                                                 Map<String, Serializable> archiveParams)
     {
@@ -293,7 +289,6 @@ public interface ContentService
      * Keys of this map should be restricted to {@code ContentRestoreParams} enumeration.
      * For AWS S3 map can indicating expiry days, Glacier restore tier.
      * For Azure Blob map can indicate rehydrate priority.
-     * This method is experimental and subject to changes.
      *
      * @param nodeRef a reference to a node having a content property
      * @param propertyQName the name of the property, which must be of type <b>content</b>
@@ -302,7 +297,6 @@ public interface ContentService
      * @throws UnsupportedOperationException when method not implemented
      */
     @Auditable(parameters = {"nodeRef", "propertyQName", "restoreParams"})
-    @Experimental
     default boolean requestRestoreContentFromArchive(NodeRef nodeRef, QName propertyQName, Map<String, Serializable> restoreParams)
     {
         throw new UnsupportedOperationException("Request to restore content from archive is not supported by content service.");


### PR DESCRIPTION
As agreed, we are ready to remove `@Experimental` annotation from objects and methods related to Storage Object Properties (list properties, archive content, restore content from archive etc.).