### PR TITLE
ACS-2476: Update to Camel 3.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -766,7 +766,12 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
-                <artifactId>camel-spring</artifactId>
+                <artifactId>camel-core</artifactId>
+                <version>${dependency.camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-spring-xml</artifactId>
                 <version>${dependency.camel.version}</version>
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
         <dependency.xercesImpl.version>2.12.2</dependency.xercesImpl.version>
         <dependency.slf4j.version>1.7.35</dependency.slf4j.version>
-        <dependency.gytheio.version>0.14</dependency.gytheio.version>
+        <dependency.gytheio.version>0.15</dependency.gytheio.version>
         <dependency.groovy.version>3.0.9</dependency.groovy.version>
         <dependency.tika.version>2.2.1</dependency.tika.version> 
         <dependency.spring-security.version>5.6.1</dependency.spring-security.version>
@@ -82,7 +82,7 @@
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.keycloak.version>15.0.2</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.4.3.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>3.11.5</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
+        <dependency.camel.version>3.14.1</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
         <dependency.apache-compress.version>1.21</dependency.apache-compress.version>
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
         <dependency.xercesImpl.version>2.12.2</dependency.xercesImpl.version>
         <dependency.slf4j.version>1.7.35</dependency.slf4j.version>
-        <dependency.gytheio.version>0.15</dependency.gytheio.version>
+        <dependency.gytheio.version>0.16</dependency.gytheio.version>
         <dependency.groovy.version>3.0.9</dependency.groovy.version>
         <dependency.tika.version>2.2.1</dependency.tika.version> 
         <dependency.spring-security.version>5.6.1</dependency.spring-security.version>
@@ -82,7 +82,7 @@
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.keycloak.version>15.0.2</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.4.3.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>3.14.1</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
+        <dependency.camel.version>3.15.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
         <dependency.apache-compress.version>1.21</dependency.apache-compress.version>
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>
@@ -803,7 +803,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.72.Final</version>
+                <version>4.1.73.Final</version>
             </dependency>
             <dependency>
                 <!--  If you are going to bump dependency.camel.version, please check if the netty-codec-http has higher version that the one above.-->

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
         <dependency.xercesImpl.version>2.12.2</dependency.xercesImpl.version>
         <dependency.slf4j.version>1.7.35</dependency.slf4j.version>
-        <dependency.gytheio.version>0.13</dependency.gytheio.version>
+        <dependency.gytheio.version>0.14</dependency.gytheio.version>
         <dependency.groovy.version>3.0.9</dependency.groovy.version>
         <dependency.tika.version>2.2.1</dependency.tika.version> 
         <dependency.spring-security.version>5.6.1</dependency.spring-security.version>
@@ -82,7 +82,7 @@
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
         <dependency.keycloak.version>15.0.2</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.4.3.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>3.7.7</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
+        <dependency.camel.version>3.11.5</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
         <dependency.activemq.version>5.16.1</dependency.activemq.version>
         <dependency.apache-compress.version>1.21</dependency.apache-compress.version>
         <dependency.apache.taglibs.version>1.2.5</dependency.apache.taglibs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -801,11 +801,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>4.1.73.Final</version>
-            </dependency>
-            <dependency>
                 <!--  If you are going to bump dependency.camel.version, please check if the netty-codec-http has higher version that the one above.-->
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-amqp</artifactId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -656,7 +656,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-spring</artifactId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring-xml</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
Follow-on to https://github.com/Alfresco/alfresco-community-repo/pull/977 (to update from Gytheio 0.13 to 0.16)

Hence, we will have:

- Gytheio 0.16
- Camel 3.15.0 (including Netty 4.1.73.Final)