### PR TITLE
ACS-2674 - fix/ACS-2674_delete_existing_rendition

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
@@ -38,7 +38,7 @@ public abstract class RenditionIntegrationTests extends RestTest
         FileModel file = new FileModel();
         file.setNodeRef(nodeId);
 
-        // 1. Preventive delete an existing rendition of the file using RESTAPI
+        // 1. Preemptively delete an existing rendition of the file using RESTAPI
         restClient.withCoreAPI().usingNode(file).deleteNodeRendition(renditionId);
 
         // 2. Create a rendition of the file using RESTAPI

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
@@ -7,9 +7,7 @@ import org.alfresco.utility.Utility;
 import org.alfresco.utility.model.FileModel;
 import org.alfresco.utility.model.FolderModel;
 import org.alfresco.utility.model.SiteModel;
-
 import org.alfresco.utility.model.UserModel;
-
 import org.springframework.http.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -40,17 +38,20 @@ public abstract class RenditionIntegrationTests extends RestTest
         FileModel file = new FileModel();
         file.setNodeRef(nodeId);
 
-        // 1. Create a rendition of the file using RESTAPI
+        // 1. Preventive delete an existing rendition of the file using RESTAPI
+        restClient.withCoreAPI().usingNode(file).deleteNodeRendition(renditionId);
+
+        // 2. Create a rendition of the file using RESTAPI
         restClient.withCoreAPI().usingNode(file).createNodeRendition(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.ACCEPTED.value(),
                 "Failed to submit a request for rendition. [" + fileName+ ", " + renditionId+"] [source file, rendition ID]. ");
 
-        // 2. Verify that a rendition of the file is created and has content using RESTAPI
+        // 3. Verify that a rendition of the file is created and has content using RESTAPI
         RestResponse restResponse = restClient.withCoreAPI().usingNode(file).getNodeRenditionContentUntilIsCreated(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.OK.value(),
                 "Failed to produce rendition. [" + fileName+ ", " + renditionId+"] [source file, rendition ID] ");
 
-        // 3. Check the returned content type
+        // 4. Check the returned content type
         Assert.assertEquals(restClient.getResponseHeaders().getValue("Content-Type"), expectedMimeType+";charset=UTF-8",
                 "Rendition was created but it has the wrong Content-Type. [" + fileName+ ", " + renditionId + "] [source file, rendition ID]");
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency.mariadb.version>2.7.4</dependency.mariadb.version>
         <dependency.tas-utility.version>3.0.47</dependency.tas-utility.version>
         <dependency.rest-assured.version>3.3.0</dependency.rest-assured.version>
-        <dependency.tas-restapi.version>1.79</dependency.tas-restapi.version>
+        <dependency.tas-restapi.version>1.80</dependency.tas-restapi.version>
         <dependency.tas-cmis.version>1.31</dependency.tas-cmis.version>
         <dependency.tas-email.version>1.8</dependency.tas-email.version>
         <dependency.tas-webdav.version>1.6</dependency.tas-webdav.version>


### PR DESCRIPTION
This change prevents the creation of an existing rendition. There have been cases where a test has tried to re-create an existing rendition, sometimes causing an error in the test.