### PR TITLE
ACS-2850: fix for intermittent failure on expiryLock test

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/webdav/LockInfoImpl.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/LockInfoImpl.java
@@ -390,8 +390,14 @@ public class LockInfoImpl implements Serializable, LockInfo
         else
         {
             Date now = dateNow();
-            long timeout = ((expires.getTime() - now.getTime()) / 1000);
-            return timeout;
+
+            double remainingTimeoutInMs = expires.getTime() - now.getTime();
+            double remainingTimeoutInS = remainingTimeoutInMs / 1000;
+
+            long timeoutRoundedUp = (long) Math.ceil(remainingTimeoutInS);
+            long minTimeout = 0L;
+
+            return Math.max(minTimeout, timeoutRoundedUp);
         }
     }
 


### PR DESCRIPTION
First issue was int rounding of '(expirationDate - new Date())/1000', which for really close values of timeout set and passed through lockInfo could be rounded down to 0. I've added math.ceil to round it to full second value.
Second issue was treating timeout == 0 as timeout.infinite. Infinite timeout has it's own marker "-1", in case of 0, lock was automatically turned into infinite time lock, while it should be an exception instead as creating a lock for 0s timeout is a programming error - the lock would immediatelly be expired upon creation (perhaps even with a date in the past, seeing as the expiryDate is filled).