### PR TITLE
REPO-5712 Fix exception logging in EventGeneratorQueue

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGeneratorQueue.java
@@ -91,7 +91,7 @@ public class EventGeneratorQueue implements InitializingBean
             }
             catch (Exception e)
             {
-                LOGGER.error("Unexpected error while enqueuing maker function for repository event" + e);
+                LOGGER.error("Unexpected error while enqueuing maker function for repository event", e);
             }
         });
     }
@@ -122,7 +122,7 @@ public class EventGeneratorQueue implements InitializingBean
                         }
                         catch (Exception e)
                         {
-                            LOGGER.error("Unexpected error while dequeuing and sending repository event" + e);
+                            LOGGER.error("Unexpected error while dequeuing and sending repository event", e);
                         }
                     }
                 }


### PR DESCRIPTION
Include the exception stacktrace so that any event framework
wrong configuration can be easily detected.