### PR TITLE
ACS-2925: Elasticsearch - add support for OpenCMIS and DB Switching

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/search/impl/DbCmisQueryLanguage.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DbCmisQueryLanguage.java
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.solr;
+package org.alfresco.repo.search.impl;
 
 import org.alfresco.opencmis.dictionary.CMISDictionaryService;
 import org.alfresco.opencmis.search.CMISQueryOptions;

--- a/repository/src/main/java/org/alfresco/repo/search/impl/DisabledFeatureException.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DisabledFeatureException.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.solr;
+package org.alfresco.repo.search.impl;
 
 /**
  * Identifies an attempt to use a disabled feature.

--- a/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.solr;
+package org.alfresco.repo.search.impl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,9 +52,9 @@ import org.apache.chemistry.opencmis.commons.enums.CapabilityQuery;
 /**
  * @author Andy
  */
-public class SolrOpenCMISQueryServiceImpl implements CMISQueryService
+public class OpenCMISQueryServiceImpl implements CMISQueryService
 {
-    private LuceneQueryLanguageSPI solrQueryLanguage;
+    private LuceneQueryLanguageSPI queryLanguage;
     
     private NodeService nodeService;
 
@@ -62,9 +62,9 @@ public class SolrOpenCMISQueryServiceImpl implements CMISQueryService
 
     private CMISDictionaryService cmisDictionaryService;
     
-    public void setSolrQueryLanguage(LuceneQueryLanguageSPI solrQueryLanguage)
+    public void setQueryLanguage(LuceneQueryLanguageSPI queryLanguage)
     {
-        this.solrQueryLanguage = solrQueryLanguage;
+        this.queryLanguage = queryLanguage;
     }
 
     public void setNodeService(NodeService nodeService)
@@ -87,7 +87,7 @@ public class SolrOpenCMISQueryServiceImpl implements CMISQueryService
     {
     	SearchParameters searchParameters = options.getAsSearchParmeters();
     	searchParameters.addExtraParameter("cmisVersion", options.getCmisVersion().toString());
-        ResultSet rs = solrQueryLanguage.executeQuery(searchParameters);
+        ResultSet rs = queryLanguage.executeQuery(searchParameters);
         
         CapabilityJoin joinSupport = getJoinSupport();
         if(options.getQueryMode() == CMISQueryOptions.CMISQueryMode.CMS_WITH_ALFRESCO_EXTENSIONS)

--- a/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
@@ -61,7 +61,7 @@ public class OpenCMISQueryServiceImpl implements CMISQueryService
     private DictionaryService alfrescoDictionaryService;
 
     private CMISDictionaryService cmisDictionaryService;
-    
+
     public void setQueryLanguage(LuceneQueryLanguageSPI queryLanguage)
     {
         this.queryLanguage = queryLanguage;

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -4,7 +4,7 @@
 <!-- Core and miscellaneous bean definitions -->
 <beans>
 
-    <bean id="search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="base.search.cmis.alfresco.switching" abstract="true">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -19,15 +19,11 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.cmis.queryConsistency}</value>
-        </property>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="base.search.cmis.alfresco.switching1.1" abstract="true" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -42,12 +38,9 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.cmis.queryConsistency}</value>
-        </property>
     </bean>
 
-    <bean id="search.cmis.strict.switching" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="base.search.cmis.strict.switching" abstract="true" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -62,15 +55,11 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.cmis.queryConsistency}</value>
-        </property>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.db" class="org.alfresco.repo.search.impl.solr.DbCmisQueryLanguage" >
+    <bean id="search.cmis.alfresco.db" class="org.alfresco.repo.search.impl.DbCmisQueryLanguage" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -90,7 +79,7 @@
         </property>
     </bean>
 
-    <bean id="search.cmis.alfresco.db1.1" class="org.alfresco.repo.search.impl.solr.DbCmisQueryLanguage" >
+    <bean id="search.cmis.alfresco.db1.1" class="org.alfresco.repo.search.impl.DbCmisQueryLanguage" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -4,7 +4,7 @@
 <!-- Core and miscellaneous bean definitions -->
 <beans>
 
-    <bean id="base.search.cmis.alfresco.switching" abstract="true">
+    <bean id="base.search.cmis.alfresco.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -23,7 +23,7 @@
         <property name="searchDao" ref="searchDAO"/>
     </bean>
 
-    <bean id="base.search.cmis.alfresco.switching1.1" abstract="true" >
+    <bean id="base.search.cmis.alfresco.switching1.1" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -40,7 +40,7 @@
         </property>
     </bean>
 
-    <bean id="base.search.cmis.strict.switching" abstract="true" >
+    <bean id="base.search.cmis.strict.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -64,8 +64,8 @@
         </property>
         <!-- Query collections should be loaded on demand using this component - once loaded thay are available for use -->
     </bean>
-    
-    <bean id="search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+
+    <bean id="base.search.fts.alfresco.switching" abstract="true" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -80,12 +80,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.fts.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.fts.queryConsistency}</value>
-        </property>
         <property name="searchDao" ref="searchDAO"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
-    </bean> 
+    </bean>
 
     <bean id="search.fts.alfresco.db" class="org.alfresco.repo.search.impl.solr.DbAftsQueryLanguage" >
         <property name="dictionaryService" ref="dictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
@@ -99,7 +99,13 @@
             <ref bean="search.indexerAndSearcherFactory" />
         </property>
     </bean>
-    
+
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
     <bean id="search.fts.alfresco.index" class="org.alfresco.repo.search.impl.solr.NoIndexQueryLanguage" >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -5,18 +5,18 @@
 
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -5,6 +5,23 @@
 
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -5,7 +5,7 @@
 
    <import resource="../common-opencmis-context.xml" />
 
-  <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+  <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -15,12 +15,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -30,7 +30,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -4,7 +4,7 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -14,12 +14,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -29,7 +29,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -4,6 +4,23 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
    <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -4,18 +4,18 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
@@ -168,7 +168,13 @@
         </property>
         
     </bean>
-    
+
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
     <bean id="search.index.alfresco" class="org.alfresco.repo.search.impl.solr.SolrQueryLanguage"  >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -4,7 +4,7 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -14,12 +14,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -29,7 +29,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -4,18 +4,18 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr4"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -4,6 +4,23 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr4"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="solr4"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr4"/>
+    </bean>
+
    <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
@@ -218,6 +218,12 @@
         </property>
     </bean>
 
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="sol4"/>
+    </bean>
+
     <bean id="search.fts.alfresco.index" class="org.alfresco.repo.search.impl.solr.SolrQueryLanguage"  >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -4,7 +4,7 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -14,12 +14,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -29,7 +29,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -4,6 +4,23 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
    <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -4,18 +4,18 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
@@ -238,6 +238,12 @@
         </property>
     </bean>
 
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
     <bean id="search.fts.alfresco.index" class="org.alfresco.repo.search.impl.solr.SolrQueryLanguage"  >
         <property name="factories">
             <list>

--- a/repository/src/test/java/org/alfresco/repo/search/SearchServiceTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/SearchServiceTest.java
@@ -28,7 +28,7 @@ package org.alfresco.repo.search;
 import javax.transaction.UserTransaction;
 
 import org.alfresco.model.ContentModel;
-import org.alfresco.repo.search.impl.solr.DisabledFeatureException;
+import org.alfresco.repo.search.impl.DisabledFeatureException;
 import org.alfresco.repo.security.authentication.AuthenticationComponent;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.authentication.MutableAuthenticationDao;

--- a/repository/src/test/java/org/alfresco/repo/search/impl/solr/DbOrIndexSwitchingQueryLanguageTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/solr/DbOrIndexSwitchingQueryLanguageTest.java
@@ -38,6 +38,8 @@ import java.util.List;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.domain.node.Node;
 import org.alfresco.repo.domain.solr.SearchDAO;
+import org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage;
+import org.alfresco.repo.search.impl.DisabledFeatureException;
 import org.alfresco.repo.search.impl.lucene.LuceneQueryLanguageSPI;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.solr.NodeParameters;
@@ -159,7 +161,7 @@ public class DbOrIndexSwitchingQueryLanguageTest
         queryLang.executeQuery(searchParameters);
     }
 
-    @Test(expected=DisabledFeatureException.class)
+    @Test(expected= DisabledFeatureException.class)
     public void canDisableHybridSearch()
     {
         queryLang.setHybridEnabled(false);


### PR DESCRIPTION
- enable OpenCMIS & DB Switching for Elasticsearch connector
- see also PR for alfresco-enterprise-repo
- note: ACS-2860 & ACS-2920