### PR TITLE
ACS-2925: Elasticsearch - refactor DB switching to not use Solr-specific properties / debug log

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalPipelineTransform.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalPipelineTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2020 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalPipelineTransform.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalPipelineTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2019-2022 Alfresco Software Limited
+ * Copyright (C) 2005 - 2020 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/main/java/org/alfresco/repo/search/impl/DbCmisQueryLanguage.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DbCmisQueryLanguage.java
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.solr;
+package org.alfresco.repo.search.impl;
 
 import org.alfresco.opencmis.dictionary.CMISDictionaryService;
 import org.alfresco.opencmis.search.CMISQueryOptions;

--- a/repository/src/main/java/org/alfresco/repo/search/impl/DbCmisQueryLanguage.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DbCmisQueryLanguage.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/search/impl/DbOrIndexSwitchingQueryLanguage.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DbOrIndexSwitchingQueryLanguage.java
@@ -69,7 +69,7 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
     private SearchDAO searchDao;
     
     private Boolean hybridEnabled;
-    private Boolean solrHybridEnabled = null; // Deprecated
+    private Boolean solrHybridEnabled; // Deprecated
 
     private String subsystemName;
     
@@ -194,7 +194,7 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
                 throw new QueryModelException("No query language available");
             }
         case HYBRID:
-            if (((solrHybridEnabled != null) && (!solrHybridEnabled)) || (!hybridEnabled))
+            if (((solrHybridEnabled != null) && (!solrHybridEnabled)) || (hybridEnabled == null) || (!hybridEnabled))
             {
                 throw new DisabledFeatureException("Hybrid query is disabled.");
             }

--- a/repository/src/main/java/org/alfresco/repo/search/impl/DbOrIndexSwitchingQueryLanguage.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DbOrIndexSwitchingQueryLanguage.java
@@ -62,12 +62,14 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
     LuceneQueryLanguageSPI indexQueryLanguage;
     
     QueryConsistency queryConsistency = QueryConsistency.DEFAULT;
+    QueryConsistency solrQueryConsistency = null; // Deprecated
     
     private NodeService nodeService;
     
     private SearchDAO searchDao;
     
-    private boolean hybridEnabled;
+    private Boolean hybridEnabled;
+    private Boolean solrHybridEnabled = null; // Deprecated
 
     private String subsystemName;
     
@@ -95,6 +97,12 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
         this.queryConsistency = queryConsistency;
     }
 
+    // Deprecated
+    public void setSolrQueryConsistency(QueryConsistency solrQueryConsistency)
+    {
+        this.solrQueryConsistency = solrQueryConsistency;
+    }
+
     /**
      * @param nodeService the nodeService to set
      */
@@ -108,9 +116,15 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
         this.searchDao = searchDao;
     }
 
-    public void setHybridEnabled(boolean hybridEnabled)
+    public void setHybridEnabled(Boolean hybridEnabled)
     {
         this.hybridEnabled = hybridEnabled;
+    }
+
+    // Deprecated
+    public void setSolrHybridEnabled(Boolean solrHybridEnabled)
+    {
+        this.solrHybridEnabled = solrHybridEnabled;
     }
 
     public void setSubsystemName(String subsystemName)
@@ -123,7 +137,14 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
         QueryConsistency consistency = searchParameters.getQueryConsistency();
         if(consistency == QueryConsistency.DEFAULT)
         {
-            consistency = queryConsistency;
+            if(solrQueryConsistency != null)
+            {
+                consistency = solrQueryConsistency;
+            }
+            else 
+            {
+                consistency = queryConsistency;
+            }
         }
  
         switch(consistency)
@@ -173,7 +194,7 @@ public class DbOrIndexSwitchingQueryLanguage extends AbstractLuceneQueryLanguage
                 throw new QueryModelException("No query language available");
             }
         case HYBRID:
-            if (!hybridEnabled)
+            if (((solrHybridEnabled != null) && (!solrHybridEnabled)) || (!hybridEnabled))
             {
                 throw new DisabledFeatureException("Hybrid query is disabled.");
             }

--- a/repository/src/main/java/org/alfresco/repo/search/impl/DisabledFeatureException.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/DisabledFeatureException.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.solr;
+package org.alfresco.repo.search.impl;
 
 /**
  * Identifies an attempt to use a disabled feature.

--- a/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -23,7 +23,7 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-package org.alfresco.repo.search.impl.solr;
+package org.alfresco.repo.search.impl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,9 +52,9 @@ import org.apache.chemistry.opencmis.commons.enums.CapabilityQuery;
 /**
  * @author Andy
  */
-public class SolrOpenCMISQueryServiceImpl implements CMISQueryService
+public class OpenCMISQueryServiceImpl implements CMISQueryService
 {
-    private LuceneQueryLanguageSPI solrQueryLanguage;
+    private LuceneQueryLanguageSPI queryLanguage;
     
     private NodeService nodeService;
 
@@ -62,9 +62,9 @@ public class SolrOpenCMISQueryServiceImpl implements CMISQueryService
 
     private CMISDictionaryService cmisDictionaryService;
     
-    public void setSolrQueryLanguage(LuceneQueryLanguageSPI solrQueryLanguage)
+    public void setQueryLanguage(LuceneQueryLanguageSPI queryLanguage)
     {
-        this.solrQueryLanguage = solrQueryLanguage;
+        this.queryLanguage = queryLanguage;
     }
 
     public void setNodeService(NodeService nodeService)
@@ -87,7 +87,7 @@ public class SolrOpenCMISQueryServiceImpl implements CMISQueryService
     {
     	SearchParameters searchParameters = options.getAsSearchParmeters();
     	searchParameters.addExtraParameter("cmisVersion", options.getCmisVersion().toString());
-        ResultSet rs = solrQueryLanguage.executeQuery(searchParameters);
+        ResultSet rs = queryLanguage.executeQuery(searchParameters);
         
         CapabilityJoin joinSupport = getJoinSupport();
         if(options.getQueryMode() == CMISQueryOptions.CMISQueryMode.CMS_WITH_ALFRESCO_EXTENSIONS)

--- a/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/OpenCMISQueryServiceImpl.java
@@ -61,7 +61,7 @@ public class OpenCMISQueryServiceImpl implements CMISQueryService
     private DictionaryService alfrescoDictionaryService;
 
     private CMISDictionaryService cmisDictionaryService;
-    
+
     public void setQueryLanguage(LuceneQueryLanguageSPI queryLanguage)
     {
         this.queryLanguage = queryLanguage;

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -19,6 +19,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency}}"/>
+        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled}}"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>
@@ -38,6 +40,7 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency}}"/>
     </bean>
 
     <bean id="base.search.cmis.strict.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
@@ -55,6 +58,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency}}"/>
+        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled}}"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -4,7 +4,7 @@
 <!-- Core and miscellaneous bean definitions -->
 <beans>
 
-    <bean id="search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="base.search.cmis.alfresco.switching" abstract="true">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -19,15 +19,11 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.cmis.queryConsistency}</value>
-        </property>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="base.search.cmis.alfresco.switching1.1" abstract="true" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -42,12 +38,9 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.cmis.queryConsistency}</value>
-        </property>
     </bean>
 
-    <bean id="search.cmis.strict.switching" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="base.search.cmis.strict.switching" abstract="true" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -62,15 +55,11 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.cmis.queryConsistency}</value>
-        </property>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.db" class="org.alfresco.repo.search.impl.solr.DbCmisQueryLanguage" >
+    <bean id="search.cmis.alfresco.db" class="org.alfresco.repo.search.impl.DbCmisQueryLanguage" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -90,7 +79,7 @@
         </property>
     </bean>
 
-    <bean id="search.cmis.alfresco.db1.1" class="org.alfresco.repo.search.impl.solr.DbCmisQueryLanguage" >
+    <bean id="search.cmis.alfresco.db1.1" class="org.alfresco.repo.search.impl.DbCmisQueryLanguage" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -19,8 +19,9 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
-        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled:false}}"/>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency}"/>
+        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> <!-- Deprecated -->
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>
@@ -40,7 +41,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency}"/>
+        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> <!-- Deprecated -->
     </bean>
 
     <bean id="base.search.cmis.strict.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
@@ -58,8 +60,9 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
-        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled:false}}"/>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency}"/>
+        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> <!-- Deprecated -->
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -19,9 +19,14 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
+
         <property name="queryConsistency" value="${query.cmis.queryConsistency}"/>
-        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> <!-- Deprecated -->
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+
+        <!-- Deprecated -->
+        <property name="hybridEnabled" value="${query.hybrid.enabled}"/>
+        <property name="solrHybridEnabled" value="${solr.query.hybrid.enabled}"/>
+
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>
@@ -41,8 +46,12 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
+
         <property name="queryConsistency" value="${query.cmis.queryConsistency}"/>
-        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> <!-- Deprecated -->
+
+        <!-- Deprecated -->
+        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> 
+
     </bean>
 
     <bean id="base.search.cmis.strict.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
@@ -60,9 +69,14 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
+
         <property name="queryConsistency" value="${query.cmis.queryConsistency}"/>
-        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/> <!-- Deprecated -->
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="solrQueryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+
+        <!-- Deprecated -->
+        <property name="hybridEnabled" value="${query.hybrid.enabled}"/>
+        <property name="solrHybridEnabled" value="${solr.query.hybrid.enabled}"/>
+
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -4,7 +4,7 @@
 <!-- Core and miscellaneous bean definitions -->
 <beans>
 
-    <bean id="base.search.cmis.alfresco.switching" abstract="true">
+    <bean id="base.search.cmis.alfresco.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -23,7 +23,7 @@
         <property name="searchDao" ref="searchDAO"/>
     </bean>
 
-    <bean id="base.search.cmis.alfresco.switching1.1" abstract="true" >
+    <bean id="base.search.cmis.alfresco.switching1.1" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -40,7 +40,7 @@
         </property>
     </bean>
 
-    <bean id="base.search.cmis.strict.switching" abstract="true" >
+    <bean id="base.search.cmis.strict.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-opencmis-context.xml
@@ -19,8 +19,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency}}"/>
-        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled}}"/>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
+        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled:false}}"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>
@@ -40,7 +40,7 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency}}"/>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
     </bean>
 
     <bean id="base.search.cmis.strict.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
@@ -58,8 +58,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.cmis.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency}}"/>
-        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled}}"/>
+        <property name="queryConsistency" value="${query.cmis.queryConsistency:${solr.query.cmis.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
+        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled:false}}"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -64,8 +64,8 @@
         </property>
         <!-- Query collections should be loaded on demand using this component - once loaded thay are available for use -->
     </bean>
-    
-    <bean id="search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.solr.DbOrIndexSwitchingQueryLanguage" >
+
+    <bean id="base.search.fts.alfresco.switching" abstract="true" >
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />
@@ -80,12 +80,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.fts.alfresco.index" />
         </property>
-        <property name="queryConsistency">
-            <value>${solr.query.fts.queryConsistency}</value>
-        </property>
         <property name="searchDao" ref="searchDAO"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
-    </bean> 
+    </bean>
 
     <bean id="search.fts.alfresco.db" class="org.alfresco.repo.search.impl.solr.DbAftsQueryLanguage" >
         <property name="dictionaryService" ref="dictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -80,9 +80,14 @@
         <property name="indexQueryLanguage">
             <ref bean="search.fts.alfresco.index" />
         </property>
+
         <property name="queryConsistency" value="${query.fts.queryConsistency}"/>
-        <property name="solrQueryConsistency" value="${solr.query.fts.queryConsistency}"/> <!-- Deprecated -->
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="solrQueryConsistency" value="${solr.query.fts.queryConsistency}"/>
+
+        <!-- Deprecated -->
+        <property name="hybridEnabled" value="${query.hybrid.enabled}"/>
+        <property name="solrHybridEnabled" value="${solr.query.hybrid.enabled}"/> 
+
         <property name="searchDao" ref="searchDAO"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -65,7 +65,7 @@
         <!-- Query collections should be loaded on demand using this component - once loaded thay are available for use -->
     </bean>
 
-    <bean id="base.search.fts.alfresco.switching" abstract="true" >
+    <bean id="base.search.fts.alfresco.switching" abstract="true" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage">
         <property name="factories">
             <list>
                 <ref bean="search.indexerAndSearcherFactory" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -80,6 +80,8 @@
         <property name="indexQueryLanguage">
             <ref bean="search.fts.alfresco.index" />
         </property>
+        <property name="queryConsistency" value="${query.fts.queryConsistency:${solr.query.fts.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
+        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled:false}}"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/common-search-context.xml
@@ -80,8 +80,9 @@
         <property name="indexQueryLanguage">
             <ref bean="search.fts.alfresco.index" />
         </property>
-        <property name="queryConsistency" value="${query.fts.queryConsistency:${solr.query.fts.queryConsistency:TRANSACTIONAL_IF_POSSIBLE}}"/>
-        <property name="hybridEnabled" value="${query.hybrid.enabled:${solr.query.hybrid.enabled:false}}"/>
+        <property name="queryConsistency" value="${query.fts.queryConsistency}"/>
+        <property name="solrQueryConsistency" value="${solr.query.fts.queryConsistency}"/> <!-- Deprecated -->
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="searchDao" ref="searchDAO"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/common-search.properties
@@ -2,10 +2,6 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
-solr.query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.hybrid.enabled=false
-
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/common-search.properties
@@ -2,6 +2,15 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
+# Deprecated
+solr.query.fts.queryConsistency=
+solr.query.cmis.queryConsistency=
+solr.query.hybrid.enabled=
+
+query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.hybrid.enabled=false
+
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
@@ -101,8 +101,6 @@
     </bean>
 
     <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
@@ -100,7 +100,7 @@
         </property>
     </bean>
 
-    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/noindex-search-context.xml
@@ -99,7 +99,13 @@
             <ref bean="search.indexerAndSearcherFactory" />
         </property>
     </bean>
-    
+
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
     <bean id="search.fts.alfresco.index" class="org.alfresco.repo.search.impl.solr.NoIndexQueryLanguage" >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -6,19 +6,14 @@
    <import resource="../common-opencmis-context.xml" />
 
     <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 
     <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 
     <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -5,18 +5,18 @@
 
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="noindex"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="noindex"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -5,6 +5,23 @@
 
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="noindex"/>
+    </bean>
+
   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/noindex/opencmis-context.xml
@@ -5,7 +5,7 @@
 
    <import resource="../common-opencmis-context.xml" />
 
-  <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+  <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -15,12 +15,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -30,7 +30,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/common-search.properties
@@ -2,10 +2,6 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
-solr.query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.hybrid.enabled=false
-
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/common-search.properties
@@ -2,6 +2,15 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
+# Deprecated
+solr.query.fts.queryConsistency=
+solr.query.cmis.queryConsistency=
+solr.query.hybrid.enabled=
+
+query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.hybrid.enabled=false
+
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -4,7 +4,7 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -14,12 +14,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -29,7 +29,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -4,6 +4,23 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
    <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -4,18 +4,18 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/opencmis-context.xml
@@ -5,19 +5,14 @@
    <import resource="../common-opencmis-context.xml" />
 
     <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 
     <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 
     <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
@@ -168,7 +168,13 @@
         </property>
         
     </bean>
-    
+
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr"/>
+    </bean>
+
     <bean id="search.index.alfresco" class="org.alfresco.repo.search.impl.solr.SolrQueryLanguage"  >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
@@ -170,8 +170,6 @@
     </bean>
 
     <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr/solr-search-context.xml
@@ -169,7 +169,7 @@
         
     </bean>
 
-    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/common-search.properties
@@ -2,10 +2,6 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
-solr.query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.hybrid.enabled=false
-
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/common-search.properties
@@ -2,6 +2,15 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
+# Deprecated
+solr.query.fts.queryConsistency=
+solr.query.cmis.queryConsistency=
+solr.query.hybrid.enabled=
+
+query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.hybrid.enabled=false
+
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.maxAllowedReplicaTxCountDifference=1000

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -5,19 +5,14 @@
    <import resource="../common-opencmis-context.xml" />
 
     <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 
     <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 
     <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -4,7 +4,7 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -14,12 +14,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -29,7 +29,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -4,18 +4,18 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr4"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr4"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/opencmis-context.xml
@@ -4,6 +4,23 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr4"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="solr4"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr4"/>
+    </bean>
+
    <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
@@ -219,8 +219,6 @@
     </bean>
 
     <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="sol4"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
@@ -218,7 +218,7 @@
         </property>
     </bean>
 
-    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="sol4"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr4/solr-search-context.xml
@@ -218,6 +218,12 @@
         </property>
     </bean>
 
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="sol4"/>
+    </bean>
+
     <bean id="search.fts.alfresco.index" class="org.alfresco.repo.search.impl.solr.SolrQueryLanguage"  >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/common-search.properties
@@ -2,6 +2,15 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
+# Deprecated
+solr.query.fts.queryConsistency=
+solr.query.cmis.queryConsistency=
+solr.query.hybrid.enabled=
+
+query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
+query.hybrid.enabled=false
+
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.dbidRangeRefreshTimeoutInSeconds=30

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/common-search.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/common-search.properties
@@ -2,10 +2,6 @@ search.solrTrackingSupport.enabled=true
 search.solrTrackingSupport.ignorePathsForSpecificTypes=false
 search.solrTrackingSupport.ignorePathsForSpecificAspects=false
 
-solr.query.fts.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.cmis.queryConsistency=TRANSACTIONAL_IF_POSSIBLE
-solr.query.hybrid.enabled=false
-
 search.solrShardRegistry.purgeOnInit=false
 search.solrShardRegistry.shardInstanceTimeoutInSeconds=300
 search.solrShardRegistry.dbidRangeRefreshTimeoutInSeconds=30

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -4,7 +4,7 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />
         </property>
@@ -14,12 +14,12 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching" />
         </property>
     </bean>
 
-   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.solr.SolrOpenCMISQueryServiceImpl" >
+   <bean id="search.OpenCMISQueryService1.1" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService1.1" />
         </property>
@@ -29,7 +29,7 @@
         <property name="alfrescoDictionaryService">
             <ref bean="dictionaryService" />
         </property>
-        <property name="solrQueryLanguage">
+        <property name="queryLanguage">
             <ref bean="search.cmis.alfresco.switching1.1" />
         </property>
     </bean>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -4,6 +4,23 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
    <bean id="search.OpenCMISQueryService" class="org.alfresco.repo.search.impl.OpenCMISQueryServiceImpl" >
        <property name="cmisDictionaryService">
             <ref bean="OpenCMISDictionaryService" />

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -5,19 +5,14 @@
    <import resource="../common-opencmis-context.xml" />
 
     <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 
     <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 
     <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
-        <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/opencmis-context.xml
@@ -4,18 +4,18 @@
 <beans>
    <import resource="../common-opencmis-context.xml" />
 
-    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching" parent="base.search.cmis.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 
-    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.alfresco.switching1.1" parent="base.search.cmis.alfresco.switching1.1" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 
-    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.cmis.strict.switching" parent="base.search.cmis.strict.switching" >
         <property name="queryConsistency" value="${solr.query.cmis.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
@@ -238,6 +238,12 @@
         </property>
     </bean>
 
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
+        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
+        <property name="subsystemName" value="solr6"/>
+    </bean>
+
     <bean id="search.fts.alfresco.index" class="org.alfresco.repo.search.impl.solr.SolrQueryLanguage"  >
         <property name="factories">
             <list>

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
@@ -239,8 +239,6 @@
     </bean>
 
     <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
-        <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
-        <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>
     </bean>
 

--- a/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/solr6/solr-search-context.xml
@@ -238,7 +238,7 @@
         </property>
     </bean>
 
-    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" class="org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage" >
+    <bean id="search.fts.alfresco.switching" parent="base.search.fts.alfresco.switching" >
         <property name="queryConsistency" value="${solr.query.fts.queryConsistency}"/>
         <property name="hybridEnabled" value="${solr.query.hybrid.enabled}"/>
         <property name="subsystemName" value="solr6"/>

--- a/repository/src/test/java/org/alfresco/repo/search/SearchServiceTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/SearchServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/test/java/org/alfresco/repo/search/SearchServiceTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/SearchServiceTest.java
@@ -28,7 +28,7 @@ package org.alfresco.repo.search;
 import javax.transaction.UserTransaction;
 
 import org.alfresco.model.ContentModel;
-import org.alfresco.repo.search.impl.solr.DisabledFeatureException;
+import org.alfresco.repo.search.impl.DisabledFeatureException;
 import org.alfresco.repo.security.authentication.AuthenticationComponent;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.authentication.MutableAuthenticationDao;

--- a/repository/src/test/java/org/alfresco/repo/search/impl/solr/DbOrIndexSwitchingQueryLanguageTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/solr/DbOrIndexSwitchingQueryLanguageTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -161,7 +161,7 @@ public class DbOrIndexSwitchingQueryLanguageTest
         queryLang.executeQuery(searchParameters);
     }
 
-    @Test(expected= DisabledFeatureException.class)
+    @Test(expected=DisabledFeatureException.class)
     public void canDisableHybridSearch()
     {
         queryLang.setHybridEnabled(false);

--- a/repository/src/test/java/org/alfresco/repo/search/impl/solr/DbOrIndexSwitchingQueryLanguageTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/solr/DbOrIndexSwitchingQueryLanguageTest.java
@@ -38,6 +38,8 @@ import java.util.List;
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.domain.node.Node;
 import org.alfresco.repo.domain.solr.SearchDAO;
+import org.alfresco.repo.search.impl.DbOrIndexSwitchingQueryLanguage;
+import org.alfresco.repo.search.impl.DisabledFeatureException;
 import org.alfresco.repo.search.impl.lucene.LuceneQueryLanguageSPI;
 import org.alfresco.repo.search.impl.querymodel.QueryModelException;
 import org.alfresco.repo.solr.NodeParameters;
@@ -159,7 +161,7 @@ public class DbOrIndexSwitchingQueryLanguageTest
         queryLang.executeQuery(searchParameters);
     }
 
-    @Test(expected=DisabledFeatureException.class)
+    @Test(expected= DisabledFeatureException.class)
     public void canDisableHybridSearch()
     {
         queryLang.setHybridEnabled(false);


### PR DESCRIPTION
- branch was renamed hence new PR ( previously https://github.com/Alfresco/alfresco-community-repo/pull/1085 )
- see also PR for alfresco-enterprise-repo

- new generic query.* props

  - query.cmis.queryConsistency
  - query.fts.queryConsistency
  - query.hybrid.enabled

- deprecate current solr.query.* props (eg. upgrade) - default back if not present

  - solr.query.cmis.queryConsistency
  - solr.query.fts.queryConsistency
  - solr.query.hybrid.enabled