### PR TITLE
Origin/feature/apps 1164 alfresco logs

### DIFF
--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/DeclareAndFileDocumentAsRecordTests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/DeclareAndFileDocumentAsRecordTests.java
@@ -257,7 +257,7 @@ public class DeclareAndFileDocumentAsRecordTests extends BaseRMRestTest
      * Then I receive an error indicating that I have attempted to declare and file a document into an invalid record folder
      * And the document is not declared as a record
      */
-    @Test (dataProvider = "invalidDestinationPaths")
+    @Test (dataProvider = "invalidDestinationPaths",groups = { TestGroup.NOT_SUPPORTED_ON_SINGLE_PIPELINE })
     public void declareAndFileToInvalidLocationUsingActionsAPI(String containerPath, String expectedException) throws Exception
     {
         STEP("Declare document as record with an invalid location parameter value");

--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/DeclareAndFileDocumentAsRecordTests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/DeclareAndFileDocumentAsRecordTests.java
@@ -73,6 +73,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.alfresco.utility.model.TestGroup;
 
 /**
  * API tests for declaring document as record and filing it immediately to a record folder location within the file plan

--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/FileVersionAsRecordTests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/FileVersionAsRecordTests.java
@@ -207,7 +207,7 @@ public class FileVersionAsRecordTests extends BaseRMRestTest
      * record folder
      * And the document is not declared as a version record
      */
-    @Test (dataProvider = "invalidDestinationPaths")
+    @Test (dataProvider = "invalidDestinationPaths", groups = { TestGroup.NOT_SUPPORTED_ON_SINGLE_PIPELINE })
     public void declareVersionAndFileToInvalidLocationUsingActionsAPI(String containerPath, String expectedException) throws Exception
     {
         STEP("Declare document as record version with an invalid location parameter value");

--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/FileVersionAsRecordTests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/files/FileVersionAsRecordTests.java
@@ -62,6 +62,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.alfresco.utility.model.TestGroup;
 
 /**
  * API tests for declaring a document version as record and filing to a record folder location within the file plan


### PR DESCRIPTION
added test group NOT_SUPPORTED_ON_SINGLE_PIPELINE for the test cases trying to access the alfresco logs so these test cases will continue to run in component pipeline and we would exclude this group in single pipeline to skip these test cases to run.