### PR TITLE
MNT-22293 added getPaths instead of cyclic check

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
@@ -1318,7 +1318,8 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
         }
         
         // check that the child addition of the child has not created a cyclic relationship
-        nodeDAO.cycleCheck(childNodeId);
+     //   nodeDAO.cycleCheck(childNodeId);
+        getPaths(childRef, false);
 
         // Invoke policy behaviours
         for (ChildAssociationRef childAssocRef : childAssociationRefs)


### PR DESCRIPTION
As we are having OOM error- Heap Memory while uploading 41st file in the recorded version, as the removal of cyclic check is not having any impact on other repository and other functionality are also working fine as we have checked with basic testing proper QA analysis will be done post, getting the reviews. 