### PR TITLE
[ACS-2747] Prevent private action execution from the V1 HTTP API

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/ActionsImpl.java
@@ -26,11 +26,14 @@
 package org.alfresco.rest.api.impl;
 
 import org.alfresco.error.AlfrescoRuntimeException;
+import org.alfresco.repo.action.ActionExecutionContext;
+import org.alfresco.repo.action.RuntimeActionService;
 import org.alfresco.rest.api.Actions;
 import org.alfresco.rest.api.model.Action;
 import org.alfresco.rest.api.model.ActionDefinition;
 import org.alfresco.rest.framework.core.exceptions.EntityNotFoundException;
 import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
+import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 import org.alfresco.rest.framework.resource.parameters.SortColumn;
@@ -72,6 +75,9 @@ public class ActionsImpl implements Actions
     private NamespaceService namespaceService;
     private NodeService nodeService;
     private NamespacePrefixResolver prefixResolver;
+    private RuntimeActionService runtimeActionService;
+
+    private final String HTTP_V1_EXECUTION_SOURCE = "http-v1";
 
     public void setActionService(ActionService actionService)
     {
@@ -96,6 +102,11 @@ public class ActionsImpl implements Actions
     public void setPrefixResolver(NamespacePrefixResolver prefixResolver)
     {
         this.prefixResolver = prefixResolver;
+    }
+
+    public void setRuntimeActionService(RuntimeActionService runtimeActionService)
+    {
+        this.runtimeActionService = runtimeActionService;
     }
 
     @Override
@@ -261,6 +272,16 @@ public class ActionsImpl implements Actions
         if (actionDef == null)
         {
             throw new EntityNotFoundException(action.getActionDefinitionId());
+        }
+
+        final ActionExecutionContext actionExecutionContext = ActionExecutionContext
+                .builder(actionDef.getName())
+                .withExecutionSource(HTTP_V1_EXECUTION_SOURCE)
+                .build();
+
+        if (!runtimeActionService.isExposed(actionExecutionContext))
+        {
+            throw new PermissionDeniedException("Action '" + actionDef.getName() + "' is not exposed within '" + HTTP_V1_EXECUTION_SOURCE + "' execution source.");
         }
 
         // targetId is optional, however, currently targetId must be a valid node ID.

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -566,6 +566,7 @@
         <property name="namespaceService" ref="NamespaceService"/>
         <property name="nodeService" ref="NodeService"/>
         <property name="prefixResolver" ref="namespaceService"/>
+        <property name="runtimeActionService" ref="actionService"/>
     </bean>
     <bean id="Actions" class="org.springframework.aop.framework.ProxyFactoryBean">
         <property name="proxyInterfaces" value="org.alfresco.rest.api.Actions"/>


### PR DESCRIPTION
Implemented preventing private action execution from the V1 HTTP API. Added end-to-end test method.