### PR TITLE
Mnt 22905/case sensitive query fix (#1107)

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/person/people.get.js
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/person/people.get.js
@@ -3,6 +3,7 @@ function main()
 
 // Get the args
 var filter = args["filter"];
+if (filter!==null && !filter.includes(":")) {filter += " [hint:useCQ]";}
 var maxResults = args["maxResults"];
 var skipCountStr = args["skipCount"];
 var skipCount = skipCountStr != null ? parseInt(skipCountStr) : -1;

--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/membership/potentialmembers.get.js
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/site/membership/potentialmembers.get.js
@@ -3,7 +3,7 @@ function main()
    // Get the args
    var siteShortName = url.templateArgs.shortname,
       site = siteService.getSite(siteShortName),
-      filter = (args.filter != null) ? args.filter : (args.shortNameFilter != null) ? args.shortNameFilter : "",
+      filter = ((args.filter != null) ? args.filter : (args.shortNameFilter != null) ? args.shortNameFilter : "" )+ " [hint:useCQ]",
       maxResults = (args.maxResults == null) ? 10 : parseInt(args.maxResults, 10),
       authorityType = args.authorityType,
       zone = args.zone,

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/person/PersonServiceTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/person/PersonServiceTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Remote API
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -52,7 +52,6 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.service.transaction.TransactionService;
 import org.alfresco.util.GUID;
 import org.alfresco.util.PropertyMap;
-import org.alfresco.util.testing.category.LuceneTests;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -86,7 +85,6 @@ import static org.mockito.Mockito.when;
  * 
  * @author Glen Johnson
  */
-@Category(LuceneTests.class)
 public class PersonServiceTest extends BaseWebScriptTest
 {    
     private MutableAuthenticationService authenticationService;
@@ -340,7 +338,7 @@ public class PersonServiceTest extends BaseWebScriptTest
 
         // Ensure that the REST call with no filter will always be routed to a DB canned query rather than a FTS
         // (see ALF-18876 for details)
-        String filter = "*%20[hint:useCQ]";
+        String filter = "*";
 
         Response response = sendRequest(new GetRequest(URL_PEOPLE + "?filter=" + filter), 200);
         JSONObject res = new JSONObject(response.getContentAsString());
@@ -386,7 +384,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&startIndex=" + 0 +
                         "&pageSize=" + 6
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         JSONObject res = new JSONObject(response.getContentAsString());
         JSONArray peopleAsc = res.getJSONArray("people");
         assertEquals("The number of returned results is not correct.", 6, peopleAsc.length());
@@ -398,7 +395,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&startIndex=" + 0 +
                         "&pageSize=" + 2
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         res = new JSONObject(response.getContentAsString());
         peopleAsc = res.getJSONArray("people");
         assertEquals("The number of returned results is not correct.", 2, peopleAsc.length());
@@ -416,7 +412,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&startIndex=" + 2 +
                         "&pageSize=" + 2
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         res = new JSONObject(response.getContentAsString());
         peopleAsc = res.getJSONArray("people");
         assertEquals("The number of returned results is not correct.", 2, peopleAsc.length());
@@ -434,7 +429,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&startIndex=" + 4 +
                         "&pageSize=" + 2
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         res = new JSONObject(response.getContentAsString());
         peopleAsc = res.getJSONArray("people");
         assertEquals("The number of returned results is not correct.", 2, peopleAsc.length());
@@ -452,7 +446,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&startIndex=" + 3 +
                         "&pageSize=" + 5
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         res = new JSONObject(response.getContentAsString());
         peopleAsc = res.getJSONArray("people");
         assertEquals("The number of returned results is not correct.", 3, peopleAsc.length());
@@ -476,6 +469,7 @@ public class PersonServiceTest extends BaseWebScriptTest
     public void testGetPeopleSorting() throws Exception
     {
         String filter = GUID.generate();
+        String filterByJob = "jobtitle:job";
         String usernameA = filter + "-aaa-";
         String usernameB = filter + "-BBB-";
         String usernameC = filter + "-ccc-";
@@ -496,12 +490,17 @@ public class PersonServiceTest extends BaseWebScriptTest
         addUserUsageContent(usernameD, 50);
         userUsageTrackingComponent.execute();
 
+        //check sorting for CQ
         checkSorting(filter, SORT_BY_USERNAME, usernameA, usernameB, usernameC, usernameD);
         checkSorting(filter, SORT_BY_FULLNAME, usernameA, usernameB, usernameC, usernameD);
-        checkSorting(filter, SORT_BY_JOBTITLE, usernameA, usernameB, usernameC, usernameD);
-        checkSorting(filter, SORT_BY_EMAIL, usernameA, usernameB, usernameC, usernameD);
-        checkSorting(filter, SORT_BY_QUOTA, usernameA, usernameB, usernameC, usernameD);
-        checkSorting(filter, SORT_BY_USAGE, usernameA, usernameB, usernameC, usernameD);
+
+        //since CQ search only sorts by fullname and username test the other sorts by filtering for a job which bypasses CQ (MNT 22905)
+        checkSorting(filterByJob, SORT_BY_USERNAME, usernameA, usernameB, usernameC, usernameD);
+        checkSorting(filterByJob, SORT_BY_FULLNAME, usernameA, usernameB, usernameC, usernameD);
+        checkSorting(filterByJob, SORT_BY_JOBTITLE, usernameA, usernameB, usernameC, usernameD);
+        checkSorting(filterByJob, SORT_BY_EMAIL, usernameA, usernameB, usernameC, usernameD);
+        checkSorting(filterByJob, SORT_BY_QUOTA, usernameA, usernameB, usernameC, usernameD);
+        checkSorting(filterByJob, SORT_BY_USAGE, usernameA, usernameB, usernameC, usernameD);
     }
 
     private void checkSorting(String filter, String sortBy, String... usernames) throws Exception
@@ -519,7 +518,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&filter=" + filter +
                         "&dir=" + ASC_DIR
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         JSONObject res = new JSONObject(response.getContentAsString());
         JSONArray peopleAsc = res.getJSONArray("people");
         assertEquals(usernames.length, peopleAsc.length());
@@ -530,7 +528,6 @@ public class PersonServiceTest extends BaseWebScriptTest
                         "&filter=" + filter +
                         "&dir=" + DESC_DIR
                 ), Status.STATUS_OK);
-        assertSearchQuery(filter, true);
         res = new JSONObject(response.getContentAsString());
         JSONArray peopleDesc = res.getJSONArray("people");
         assertEquals(usernames.length, peopleDesc.length());
@@ -541,7 +538,11 @@ public class PersonServiceTest extends BaseWebScriptTest
             assertEquals(peopleAsc.getJSONObject(i).getString("userName"),
                     peopleDesc.getJSONObject(peopleAsc.length() - i - 1).getString("userName"));
         }
+        assertCorrectSort(sortBy, peopleAsc);
+    }
 
+    private void assertCorrectSort(String sortBy, JSONArray peopleAsc)
+    {
         // Check Asc sorting for each field
         for (int i = 0; i < peopleAsc.length() - 1; i++)
         {
@@ -765,7 +766,52 @@ public class PersonServiceTest extends BaseWebScriptTest
         createPerson(userName, "myTitle", "", "myLastName", "myOrganisation",
                         "myJobTitle", "firstName.lastName@email.com", "myBio", "images/avatar.jpg", 0,
                         Status.STATUS_BAD_REQUEST);        
-    }  
+    }
+
+    public void testUserNameCaseSensitivityCQ() throws Exception
+    {
+        String upperCaseUserName = "PersonServiceTest.MixedCaseUser";
+        String lowerCaseUserName = upperCaseUserName.toLowerCase();
+        // Create a new person
+
+        String currentUser = this.authenticationComponent.getCurrentUserName();
+        try
+        {
+            /**
+             *  simulate cloud with lower case user names
+             */
+            createPerson(lowerCaseUserName, "myTitle", "myFirstName", "myLastName", "myOrganisation",
+                    "myJobTitle", "firstName.lastName@email.com", "myBio", "images/avatar.jpg", 0,
+                    Status.STATUS_OK);
+
+            String adminUser = this.authenticationComponent.getSystemUserName();
+            this.authenticationComponent.setCurrentUser(adminUser);
+            personService.setCreateMissingPeople(false);
+
+            //try with canned query
+            String filter = "PerSOnSerVIceTest.MixEDCasEUseR";
+            assertPersonIsFound(filter);
+
+            filter = "MyFiRsTnAmE";
+            assertPersonIsFound(filter);
+
+            filter = "MyLaStNaMe";
+            assertPersonIsFound(filter);
+        }
+        finally
+        {
+            this.authenticationComponent.setCurrentUser(currentUser);
+        }
+    }
+
+    private void assertPersonIsFound(String filter) throws Exception
+    {
+        Response response = sendRequest(new GetRequest(URL_PEOPLE + "?filter=" + filter), 200);
+        JSONObject res = new JSONObject(response.getContentAsString());
+        int peopleFound = res.getJSONArray("people").length();
+        assertTrue("No people found", peopleFound > 0);
+    }
+
     /**
      * 
      * @throws Exception


### PR DESCRIPTION
* useCQ = true

* useCQ back to original

* useCQ = true

* Copyright Update

* useCQ restored, Javascrpit changed

* Javascript changes to filter

* PR comments requested change

* Revert "PR comments requested change"

This reverts commit 0673b6c3ffdf90ab4dc88005f40a1dcd024e4426.

* Revert "useCQ restored, Javascrpit changed"

This reverts commit 00b79b5acaccef1eefbd5ca42ae3a74146f7885d.

* Revert "Copyright Update"

This reverts commit 76d1f1c0057d1451bc9589b7d9b14c01f49a2041.

* Revert "useCQ = true"

This reverts commit 215ad952f53aa20165e7a1a2d053a2e351479b36.

* Revert "useCQ back to original"

This reverts commit deb5e82218913fe738d9cac3da93a4d696d39be4.

* Revert "useCQ = true"

This reverts commit 115910ffc136a908f107132dbe7f0dc78e898baa.

* test change

* Initial changes

* Further changes

* Space deleted

* jobtitle search

* Restore check sorting and mock

* Avoid null [hint:useCQ]

* Wrong sign

* Fix

* Clean up

* Initial changes

* Rename Method

(cherry picked from commit 1ccb8a21644e32e39c2dc1ff61949b66fa6728e1)