### PR TITLE
ACS-3013: Uppercasing services used to allow security proxy

### DIFF
--- a/repository/src/main/resources/alfresco/action-services-context.xml
+++ b/repository/src/main/resources/alfresco/action-services-context.xml
@@ -375,10 +375,10 @@
          <value>false</value>
       </property>
       <property name="nodeService">
-         <ref bean="nodeService"/>
+         <ref bean="NodeService"/>
       </property>
       <property name="versionService">
-         <ref bean="versionService"/>
+         <ref bean="VersionService"/>
       </property>
    </bean>
 


### PR DESCRIPTION
Not much happens in class, check node, create version.
Added Beans including security interceptors, but VersionService has no restrictions and for node service all there is are a few checks, so it likely never was a security issue to begin with.