### PR TITLE
Downgrade mysql-connector-java from 8.0.29 to 8.0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <license-maven-plugin.version>2.0.1.alfresco-2</license-maven-plugin.version>
 
         <dependency.postgresql.version>42.4.0</dependency.postgresql.version>
-        <dependency.mysql.version>8.0.29</dependency.mysql.version>
+        <dependency.mysql.version>8.0.27</dependency.mysql.version>
         <dependency.mysql-image.version>8</dependency.mysql-image.version>
         <dependency.mariadb.version>2.7.4</dependency.mariadb.version>
         <dependency.tas-utility.version>3.0.48</dependency.tas-utility.version>


### PR DESCRIPTION
This reverts commit 6320621f0ddc6297ad22ba3d5f3f5499392895b1.
This is necessary because it causes this kind of failure on master: https://app.travis-ci.com/github/Alfresco/alfresco-community-repo/jobs/573746851

Further `mysql-connector-java` upgrades will require more analysis before being merged.

`Communications link failure The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.`