### PR TITLE
ACS-3181 Skip MySQL 5 tests on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,7 +181,7 @@ jobs:
       script: travis_wait 20 mvn -B test -pl repository -am -Dtest=AllDBTestsTestSuite -DfailIfNoTests=false -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
 
     - name: "Repository - MySQL 5.7.23 tests"
-      if: (branch =~ /(release\/.*$|master)/ AND commit_message !~ /\[skip db\]/ AND type != pull_request) OR commit_message =~ /\[db\]/
+      if: (branch =~ /release\/.*/ AND commit_message !~ /\[skip db\]/ AND type != pull_request) OR commit_message =~ /\[db\]/
       install: skip
       before_script:
         - docker run -d -p 3307:3306 -e MYSQL_ROOT_PASSWORD=alfresco -e MYSQL_USER=alfresco -e MYSQL_DATABASE=alfresco -e MYSQL_PASSWORD=alfresco  mysql:5.7.23 --transaction-isolation='READ-COMMITTED' --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,14 +180,6 @@ jobs:
         - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.16.1
       script: travis_wait 20 mvn -B test -pl repository -am -Dtest=AllDBTestsTestSuite -DfailIfNoTests=false -Ddb.name=alfresco -Ddb.url=jdbc:mariadb://localhost:3307/alfresco?useUnicode=yes\&characterEncoding=UTF-8 -Ddb.username=alfresco -Ddb.password=alfresco -Ddb.driver=org.mariadb.jdbc.Driver
 
-    - name: "Repository - MySQL 5.7.23 tests"
-      if: (branch =~ /release\/.*/ AND commit_message !~ /\[skip db\]/ AND type != pull_request) OR commit_message =~ /\[db\]/
-      install: skip
-      before_script:
-        - docker run -d -p 3307:3306 -e MYSQL_ROOT_PASSWORD=alfresco -e MYSQL_USER=alfresco -e MYSQL_DATABASE=alfresco -e MYSQL_PASSWORD=alfresco  mysql:5.7.23 --transaction-isolation='READ-COMMITTED' --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
-        - docker run -d -p 61616:61616 -p 5672:5672 alfresco/alfresco-activemq:5.16.1
-      script: travis_wait 20 mvn -B test -pl repository -am -Dtest=AllDBTestsTestSuite -DfailIfNoTests=false -Ddb.driver=com.mysql.jdbc.Driver -Ddb.name=alfresco -Ddb.url=jdbc:mysql://localhost:3307/alfresco -Ddb.username=alfresco -Ddb.password=alfresco
-
     - name: "Repository - MySQL 8 tests"
       # We run tests on the latest version of MySQL on pull requests plus the normal master and release branches - ignored on feature branches
       if: (branch =~ /(release\/.*$|master)/ AND commit_message !~ /\[skip db\]/                         ) OR commit_message =~ /\[db\]/ OR commit_message =~ /\[latest db\]/


### PR DESCRIPTION
Skip execution of MySQL 5 tests on the master branch since ACS 7.3.X does not list MySQL 5 as a supported platform in https://alfresco.atlassian.net/wiki/spaces/CTO/pages/800587/Supported+Platforms+Roadmap.

This will enable further `mysql-connector-java` upgrades, as explained [here](https://alfresco.atlassian.net/browse/ACS-3181) in detail.