### PR TITLE
ACS-3220 Folder rules delete rule v1 API

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/Rules.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Rules.java
@@ -57,4 +57,13 @@ public interface Rules
      * @return {@link Rule} definition
      */
     Rule getRuleById(String folderNodeId, String ruleSetId, String ruleId);
+
+    /**
+     * Delete rule for rule's ID and check associations with folder node and rule set node
+     *
+     * @param folderNodeId - folder node ID
+     * @param ruleSetId - rule set ID
+     * @param ruleId - rule ID     *
+     */
+    void deleteRuleById(String folderNodeId, String ruleSetId, String ruleId);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/RulesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/RulesImpl.java
@@ -82,6 +82,16 @@ public class RulesImpl implements Rules
         return Rule.from(ruleService.getRule(ruleNodeRef));
     }
 
+    @Override
+    public void deleteRuleById(String folderNodeId, String ruleSetId, String ruleId)
+    {
+        final NodeRef folderNodeRef = validateFolderNode(folderNodeId);
+        final NodeRef ruleSetNodeRef = validateRuleSetNode(ruleSetId, folderNodeRef);
+        final NodeRef ruleNodeRef = validateRuleNode(ruleId, ruleSetNodeRef);
+        final org.alfresco.service.cmr.rule.Rule rule = ruleService.getRule(ruleNodeRef);
+        ruleService.removeRule(folderNodeRef, rule);
+    }
+
     public void setNodes(Nodes nodes)
     {
         this.nodes = nodes;

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeRulesRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeRulesRelation.java
@@ -46,7 +46,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 @Experimental
 @RelationshipResource(name = "rules", entityResource = NodeRuleSetsRelation.class, title = "Folder node rules")
-public class NodeRulesRelation implements RelationshipResourceAction.Read<Rule>, RelationshipResourceAction.ReadById<Rule>, InitializingBean
+public class NodeRulesRelation implements RelationshipResourceAction.Read<Rule>, RelationshipResourceAction.ReadById<Rule>,
+        RelationshipResourceAction.Delete, InitializingBean
 {
 
     private Rules rules;
@@ -106,5 +107,27 @@ public class NodeRulesRelation implements RelationshipResourceAction.Read<Rule>,
     public void setRules(Rules rules)
     {
         this.rules = rules;
+    }
+
+    /**
+     * Delete single folder rule for given node's, rule set's and rule's IDs.
+     *
+     * - DELETE /nodes/{folderNodeId}/rule-sets/{ruleSetId}/rules/{ruleId}
+     *
+     * @param folderNodeId - entity resource context for this relationship
+     * @param ruleSetId - rule set node ID (associated with folder node)
+     * @param parameters - Should not be null. Should contain at least ruleId (relationship2Id)
+     * @throws RelationshipResourceNotFoundException in case resource was not found
+     */
+    @WebApiDescription(
+            title="Delete folder node rule",
+            description = "Deletes a single rule definition for given node's, rule set's and rule's IDs",
+            successStatus = HttpServletResponse.SC_OK
+    )
+    @Override
+    public void delete(String folderNodeId, String ruleSetId, Parameters parameters)
+    {
+        final String ruleId = parameters.getRelationship2Id();
+        rules.deleteRuleById(folderNodeId, ruleSetId, ruleId);
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeRulesRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/nodes/NodeRulesRelation.java
@@ -144,7 +144,7 @@ public class NodeRulesRelation implements RelationshipResourceAction.Read<Rule>,
     @WebApiDescription(
             title="Delete folder node rule",
             description = "Deletes a single rule definition for given node's, rule set's and rule's IDs",
-            successStatus = HttpServletResponse.SC_OK
+            successStatus = HttpServletResponse.SC_NO_CONTENT
     )
     @Override
     public void delete(String folderNodeId, String ruleSetId, Parameters parameters)

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/RulesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/RulesImplTest.java
@@ -96,7 +96,7 @@ public class RulesImplTest extends TestCase
         MockitoAnnotations.openMocks(this);
 
         given(nodesMock.validateOrLookupNode(eq(FOLDER_NODE_ID), any())).willReturn(folderNodeRef);
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(RULE_SET_ID)).willReturn(ruleSetNodeRef);
         given(nodesMock.nodeMatches(any(), any(), any())).willReturn(true);
         given(permissionServiceMock.hasReadPermission(any())).willReturn(AccessStatus.ALLOWED);
     }
@@ -110,15 +110,15 @@ public class RulesImplTest extends TestCase
         // when
         final CollectionWithPagingInfo<Rule> rulesPage = rules.getRules(FOLDER_NODE_ID, RULE_SET_ID, paging);
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
-        then(ruleServiceMock).should().getRules(eq(folderNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
+        then(ruleServiceMock).should().getRules(folderNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
         assertThat(rulesPage)
                 .isNotNull()
@@ -140,13 +140,13 @@ public class RulesImplTest extends TestCase
         // when
         final CollectionWithPagingInfo<Rule> rulesPage = rules.getRules(FOLDER_NODE_ID, DEFAULT_ID, paging);
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().getRuleSetNode(eq(folderNodeRef));
-        then(ruleServiceMock).should().getRules(eq(folderNodeRef));
+        then(ruleServiceMock).should().getRuleSetNode(folderNodeRef);
+        then(ruleServiceMock).should().getRules(folderNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
         assertThat(rulesPage)
                 .isNotNull()
@@ -194,7 +194,7 @@ public class RulesImplTest extends TestCase
         assertThatExceptionOfType(InvalidArgumentException.class).isThrownBy(
             () -> rules.getRules(FOLDER_NODE_ID, RULE_SET_ID, paging));
 
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 
@@ -213,7 +213,7 @@ public class RulesImplTest extends TestCase
     @Test
     public void testGetRuleById()
     {
-        given(nodesMock.validateNode(eq(RULE_ID))).willReturn(ruleNodeRef);
+        given(nodesMock.validateNode(RULE_ID)).willReturn(ruleNodeRef);
         given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(true);
         given(ruleServiceMock.isRuleAssociatedWithRuleSet(any(), any())).willReturn(true);
         given(ruleServiceMock.getRule(any())).willReturn(createRule(RULE_ID));
@@ -221,18 +221,18 @@ public class RulesImplTest extends TestCase
         // when
         final Rule rule = rules.getRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID);
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
-        then(nodesMock).should().validateNode(eq(RULE_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
+        then(nodesMock).should().validateNode(RULE_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
-        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(eq(ruleNodeRef), eq(ruleSetNodeRef));
-        then(ruleServiceMock).should().getRule(eq(ruleNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
+        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(ruleNodeRef, ruleSetNodeRef);
+        then(ruleServiceMock).should().getRule(ruleNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
         assertThat(rule)
                 .isNotNull()
@@ -244,7 +244,7 @@ public class RulesImplTest extends TestCase
     public void testGetRuleByIdForDefaultRuleSet()
     {
         final String defaultRuleSetId = "-default-";
-        given(nodesMock.validateNode(eq(RULE_ID))).willReturn(ruleNodeRef);
+        given(nodesMock.validateNode(RULE_ID)).willReturn(ruleNodeRef);
         given(ruleServiceMock.getRuleSetNode(any())).willReturn(ruleSetNodeRef);
         given(ruleServiceMock.isRuleAssociatedWithRuleSet(any(), any())).willReturn(true);
         given(ruleServiceMock.getRule(any())).willReturn(createRule(RULE_ID));
@@ -252,15 +252,15 @@ public class RulesImplTest extends TestCase
         // when
         final Rule rule = rules.getRuleById(FOLDER_NODE_ID, defaultRuleSetId, RULE_ID);
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().getRuleSetNode(eq(folderNodeRef));
-        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(eq(ruleNodeRef), eq(ruleSetNodeRef));
+        then(ruleServiceMock).should().getRuleSetNode(folderNodeRef);
+        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(ruleNodeRef, ruleSetNodeRef);
         then(ruleServiceMock).should().getRule(eq(ruleNodeRef));
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
         assertThat(rule)
@@ -272,8 +272,8 @@ public class RulesImplTest extends TestCase
     @Test
     public void testGetRuleByIdForNotAssociatedRuleToRuleSet()
     {
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
-        given(nodesMock.validateNode(eq(RULE_ID))).willReturn(ruleNodeRef);
+        given(nodesMock.validateNode(RULE_SET_ID)).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(RULE_ID)).willReturn(ruleNodeRef);
         given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(true);
         given(ruleServiceMock.isRuleAssociatedWithRuleSet(any(), any())).willReturn(false);
 
@@ -281,8 +281,8 @@ public class RulesImplTest extends TestCase
         assertThatExceptionOfType(InvalidArgumentException.class).isThrownBy(
             () -> rules.getRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
 
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
-        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(eq(ruleNodeRef), eq(ruleSetNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
+        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(ruleNodeRef, ruleSetNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 
@@ -397,8 +397,8 @@ public class RulesImplTest extends TestCase
 
     @Test
     public void testDeleteRuleById() {
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
-        given(nodesMock.validateNode(eq(RULE_ID))).willReturn(ruleNodeRef);
+        given(nodesMock.validateNode(RULE_SET_ID)).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(RULE_ID)).willReturn(ruleNodeRef);
         given(ruleServiceMock.isRuleAssociatedWithRuleSet(any(), any())).willReturn(true);
         given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(true);
         org.alfresco.service.cmr.rule.Rule rule = createRule(RULE_ID);
@@ -407,17 +407,17 @@ public class RulesImplTest extends TestCase
         //when
         rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID);
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
-        then(nodesMock).should().validateNode(eq(RULE_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
+        then(nodesMock).should().validateNode(RULE_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
-        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(eq(ruleNodeRef), eq(ruleSetNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
+        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(ruleNodeRef, ruleSetNodeRef);
         then(ruleServiceMock).should().getRule(ruleNodeRef);
         then(ruleServiceMock).should().removeRule(folderNodeRef, rule);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
@@ -425,30 +425,30 @@ public class RulesImplTest extends TestCase
 
     @Test
     public void testDeleteRuleById_NonExistingRuleId() {
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
-        given(nodesMock.validateNode(eq(RULE_ID))).willThrow(new EntityNotFoundException(RULE_ID));
+        given(nodesMock.validateNode(RULE_SET_ID)).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(RULE_ID)).willThrow(new EntityNotFoundException(RULE_ID));
         given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(true);
 
         //when
         assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(
                 () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
-        then(nodesMock).should().validateNode(eq(RULE_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
+        then(nodesMock).should().validateNode(RULE_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void testDeleteRuleById_RuleIdNotInRuleSet() {
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
-        given(nodesMock.validateNode(eq(RULE_ID))).willReturn(ruleNodeRef);
+        given(nodesMock.validateNode(RULE_SET_ID)).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(RULE_ID)).willReturn(ruleNodeRef);
         given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(true);
         given(ruleServiceMock.isRuleAssociatedWithRuleSet(any(), any())).willReturn(false);
 
@@ -456,66 +456,66 @@ public class RulesImplTest extends TestCase
         assertThatExceptionOfType(InvalidArgumentException.class).isThrownBy(
                 () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
-        then(nodesMock).should().validateNode(eq(RULE_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
+        then(nodesMock).should().validateNode(RULE_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
-        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(eq(ruleNodeRef), eq(ruleSetNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
+        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(ruleNodeRef, ruleSetNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void testDeleteRuleById_NonExistingRuleSetId() {
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willThrow(new EntityNotFoundException(RULE_SET_ID));
+        given(nodesMock.validateNode(RULE_SET_ID)).willThrow(new EntityNotFoundException(RULE_SET_ID));
 
         //when
         assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(
                 () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void testDeleteRuleById_RuleSetNotInFolder() {
-        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(RULE_SET_ID)).willReturn(ruleSetNodeRef);
         given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(false);
 
         //when
         assertThatExceptionOfType(InvalidArgumentException.class).isThrownBy(
                 () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
-        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
+        then(nodesMock).should().validateNode(RULE_SET_ID);
         then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
         then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
         then(nodesMock).shouldHaveNoMoreInteractions();
-        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).should().hasReadPermission(folderNodeRef);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(ruleSetNodeRef, folderNodeRef);
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void testDeleteRuleById_NonExistingFolderId() {
-        given(nodesMock.validateOrLookupNode(eq(FOLDER_NODE_ID), isNull())).willThrow(new EntityNotFoundException(RULE_ID));
+        given(nodesMock.validateOrLookupNode(FOLDER_NODE_ID, null)).willThrow(new EntityNotFoundException(RULE_ID));
 
         //when
         assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(
                 () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
 
-        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
+        then(nodesMock).should().validateOrLookupNode(FOLDER_NODE_ID, null);
         then(nodesMock).shouldHaveNoMoreInteractions();
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
         then(ruleServiceMock).shouldHaveNoMoreInteractions();

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/RulesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/RulesImplTest.java
@@ -333,6 +333,31 @@ public class RulesImplTest extends TestCase
     }
 
     @Test
+    public void testDeleteRuleById_RuleIdNotInRuleSet() {
+        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
+        given(nodesMock.validateNode(eq(RULE_ID))).willReturn(ruleNodeRef);
+        given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(true);
+        given(ruleServiceMock.isRuleAssociatedWithRuleSet(any(), any())).willReturn(false);
+
+        //when
+        assertThatExceptionOfType(InvalidArgumentException.class).isThrownBy(
+                () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
+
+        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
+        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
+        then(nodesMock).should().validateNode(eq(RULE_ID));
+        then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
+        then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
+        then(nodesMock).should().nodeMatches(eq(ruleNodeRef), any(), isNull());
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
+        then(ruleServiceMock).should().isRuleAssociatedWithRuleSet(eq(ruleNodeRef), eq(ruleSetNodeRef));
+        then(ruleServiceMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
     public void testDeleteRuleById_NonExistingRuleSetId() {
         given(nodesMock.validateNode(eq(RULE_SET_ID))).willThrow(new EntityNotFoundException(RULE_SET_ID));
 
@@ -346,6 +371,26 @@ public class RulesImplTest extends TestCase
         then(nodesMock).shouldHaveNoMoreInteractions();
         then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
+        then(ruleServiceMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testDeleteRuleById_RuleSetNotInFolder() {
+        given(nodesMock.validateNode(eq(RULE_SET_ID))).willReturn(ruleSetNodeRef);
+        given(ruleServiceMock.isRuleSetAssociatedWithFolder(any(), any())).willReturn(false);
+
+        //when
+        assertThatExceptionOfType(InvalidArgumentException.class).isThrownBy(
+                () -> rules.deleteRuleById(FOLDER_NODE_ID, RULE_SET_ID, RULE_ID));
+
+        then(nodesMock).should().validateOrLookupNode(eq(FOLDER_NODE_ID), isNull());
+        then(nodesMock).should().validateNode(eq(RULE_SET_ID));
+        then(nodesMock).should().nodeMatches(eq(folderNodeRef), any(), isNull());
+        then(nodesMock).should().nodeMatches(eq(ruleSetNodeRef), any(), isNull());
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).should().hasReadPermission(eq(folderNodeRef));
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+        then(ruleServiceMock).should().isRuleSetAssociatedWithFolder(eq(ruleSetNodeRef), eq(folderNodeRef));
         then(ruleServiceMock).shouldHaveNoMoreInteractions();
     }
 

--- a/remote-api/src/test/java/org/alfresco/rest/api/nodes/NodeRulesRelationTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/nodes/NodeRulesRelationTest.java
@@ -89,4 +89,14 @@ public class NodeRulesRelationTest extends TestCase
         then(rulesMock).should().getRuleById(eq(FOLDER_NODE_ID), eq(RULE_SET_ID), eq(RULE_ID));
         then(rulesMock).shouldHaveNoMoreInteractions();
     }
+
+    @Test
+    public void testDeleteById() {
+        final Parameters parameters = ParamsExtender.valueOf(null, FOLDER_NODE_ID, RULE_SET_ID, RULE_ID);
+        // when
+        nodeRulesRelation.delete(FOLDER_NODE_ID, RULE_SET_ID, parameters);
+
+        then(rulesMock).should().deleteRuleById(eq(FOLDER_NODE_ID), eq(RULE_SET_ID), eq(RULE_ID));
+        then(rulesMock).shouldHaveNoMoreInteractions();
+    }
 }

--- a/repository/src/main/java/org/alfresco/repo/rule/RuleServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/rule/RuleServiceImpl.java
@@ -901,10 +901,9 @@ public class RuleServiceImpl
     {
         checkForLinkedRules(nodeRef);
         
-        if (this.permissionService.hasPermission(nodeRef, PermissionService.CHANGE_PERMISSIONS) == AccessStatus.ALLOWED)
+        if (permissionService.hasPermission(nodeRef, PermissionService.CHANGE_PERMISSIONS) == AccessStatus.ALLOWED)
         {
-            if (this.nodeService.exists(nodeRef) == true &&
-                this.nodeService.hasAspect(nodeRef, RuleModel.ASPECT_RULES) == true)
+            if (nodeService.exists(nodeRef) && nodeService.hasAspect(nodeRef, RuleModel.ASPECT_RULES))
             {
                 disableRules(nodeRef);
                 try
@@ -912,7 +911,7 @@ public class RuleServiceImpl
                     NodeRef ruleNodeRef = rule.getNodeRef();
                     if (ruleNodeRef != null)
                     {
-                        this.nodeService.removeChild(getSavedRuleFolderRef(nodeRef), ruleNodeRef);
+                        nodeService.removeChild(getSavedRuleFolderRef(nodeRef), ruleNodeRef);
                     }
                 }
                 finally
@@ -935,7 +934,7 @@ public class RuleServiceImpl
                         }
                     }
                     
-                    this.nodeService.removeAspect(nodeRef, RuleModel.ASPECT_RULES);
+                    nodeService.removeAspect(nodeRef, RuleModel.ASPECT_RULES);
                 }
             }
             // Drop the rules from the cache
@@ -945,8 +944,8 @@ public class RuleServiceImpl
         {
             throw new RuleServiceException("Insufficient permissions to remove a rule.");
         }
-    }    
-    
+    }
+
     /**
      * Checks if rules are linked and throws an exception if they are.
      * 


### PR DESCRIPTION
This PR covers following features: 
- endpoint for DELETE single rule
  - DELETE /nodes/{folderNodeId}/rule-sets/{ruleSetId}/rules/{ruleId}
- business logic to remove the rule
- unit tests covering above

Not covered - bulk delete rules under rule set or folder.