### PR TITLE
ACS-2064 DAU: Fix response content type always PDF (#754)

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
+++ b/data-model/src/main/java/org/alfresco/repo/content/ContentStore.java
@@ -269,9 +269,25 @@ public interface ContentStore
      * @return A direct access {@code URL} object for the content
      * @throws UnsupportedOperationException if the store is unable to provide the information
      */
+    @Deprecated
     default DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName)
     {
-        return requestContentDirectUrl(contentUrl, attachment, fileName, null);
+        return requestContentDirectUrl(contentUrl, attachment, fileName, null, null);
+    }
+
+    /**
+     * Gets a presigned URL to directly access the content. It is up to the actual store
+     * implementation if it can fulfil this request with an expiry time or not.
+     *
+     * @param contentUrl A content store {@code URL}
+     * @param attachment {@code true} if an attachment URL is requested, {@code false} for an embedded {@code URL}.
+     * @param fileName File name of the content
+     * @return A direct access {@code URL} object for the content
+     * @throws UnsupportedOperationException if the store is unable to provide the information
+     */
+    default DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, String mimetype)
+    {
+        return requestContentDirectUrl(contentUrl, attachment, fileName, mimetype, null);
     }
 
     /**
@@ -285,7 +301,25 @@ public interface ContentStore
      * @return A direct access {@code URL} object for the content.
      * @throws UnsupportedOperationException if the store is unable to provide the information
      */
+    @Deprecated
     default DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, Long validFor)
+    {
+        return requestContentDirectUrl(contentUrl, attachment, fileName, null, validFor);
+    }
+
+    /**
+     * Gets a presigned URL to directly access the content. It is up to the actual store
+     * implementation if it can fulfil this request with an expiry time or not.
+     *
+     * @param contentUrl A content store {@code URL}
+     * @param attachment {@code true} if an attachment URL is requested, {@code false} for an embedded {@code URL}.
+     * @param fileName File name of the content
+     * @param mimetype Mimetype of the content
+     * @param validFor The time at which the direct access {@code URL} will expire.
+     * @return A direct access {@code URL} object for the content.
+     * @throws UnsupportedOperationException if the store is unable to provide the information
+     */
+    default DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, String mimetype, Long validFor)
     {
         throw new UnsupportedOperationException(
                 "Retrieving direct access URLs is not supported by this content store.");

--- a/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/ContentServiceImpl.java
@@ -617,7 +617,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                 throw new IllegalArgumentException("The supplied nodeRef " + nodeRef + " has no content.");
             }
 
-            contentDirectUrlEnabled = (store.isContentDirectUrlEnabled(getContentUrl(nodeRef)));
+            contentDirectUrlEnabled = (store.isContentDirectUrlEnabled(contentData.getContentUrl()));
         }
 
         return contentDirectUrlEnabled;
@@ -652,7 +652,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         {
             try
             {
-                directAccessUrl = store.requestContentDirectUrl(contentUrl, attachment, fileName, validFor);
+                directAccessUrl = store.requestContentDirectUrl(contentUrl, attachment, fileName, contentMimetype, validFor);
             }
             catch (UnsupportedOperationException ex)
             {
@@ -660,19 +660,6 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             }
         }
         return directAccessUrl;
-    }
-
-    protected String getContentUrl(NodeRef nodeRef)
-    {
-        ContentData contentData = getContentData(nodeRef, ContentModel.PROP_CONTENT);
-
-        // check that the URL is available
-        if (contentData == null || contentData.getContentUrl() == null)
-        {
-            throw new IllegalArgumentException("The supplied nodeRef " + nodeRef + " has no content.");
-        }
-
-        return contentData.getContentUrl();
     }
 
     protected String getFileName(NodeRef nodeRef)

--- a/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/caching/CachingContentStore.java
@@ -509,4 +509,12 @@ public class CachingContentStore implements ContentStore, ApplicationEventPublis
     {
         return backingStore.requestContentDirectUrl(contentUrl, attachment, fileName, validFor);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, String mimeType, Long validFor)
+    {
+        return backingStore.requestContentDirectUrl(contentUrl, attachment, fileName, mimeType, validFor);
+    }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
+++ b/repository/src/main/java/org/alfresco/repo/content/replication/AggregatingContentStore.java
@@ -317,7 +317,7 @@ public class AggregatingContentStore extends AbstractContentStore
         return isContentDirectUrlEnabled;
     }
 
-    public DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, Long validFor)
+    public DirectAccessUrl requestContentDirectUrl(String contentUrl, boolean attachment, String fileName, String mimetype, Long validFor)
     {
         if (primaryStore == null)
         {
@@ -337,7 +337,7 @@ public class AggregatingContentStore extends AbstractContentStore
             // Check the primary store
             try
             {
-                directAccessUrl = primaryStore.requestContentDirectUrl(contentUrl, attachment, fileName, validFor);
+                directAccessUrl = primaryStore.requestContentDirectUrl(contentUrl, attachment, fileName, mimetype, validFor);
             }
             catch (UnsupportedOperationException e)
             {
@@ -360,7 +360,7 @@ public class AggregatingContentStore extends AbstractContentStore
             {
                 try
                 {
-                    directAccessUrl = store.requestContentDirectUrl(contentUrl, attachment, fileName, validFor);
+                    directAccessUrl = store.requestContentDirectUrl(contentUrl, attachment, fileName, mimetype, validFor);
                 }
                 catch (UnsupportedOperationException e)
                 {

--- a/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/ContentServiceImplUnitTest.java
@@ -83,6 +83,7 @@ public class ContentServiceImplUnitTest
         openMocks(this);
         when(mockNodeService.getProperty(NODE_REF, ContentModel.PROP_CONTENT)).thenReturn(mockContentData);
         when(mockContentData.getContentUrl()).thenReturn("someContentUrl");
+        when(mockContentData.getMimetype()).thenReturn("someMimetype");
         when(mockNodeService.getProperty(NODE_REF, ContentModel.PROP_NAME)).thenReturn("someFilename");
     }
 
@@ -133,7 +134,7 @@ public class ContentServiceImplUnitTest
 
         DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, true, 20L);
         assertNull(directAccessUrl);
-        verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyLong());
+        verify(mockContentStore, never()).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
     }
 
     @Test
@@ -144,7 +145,7 @@ public class ContentServiceImplUnitTest
 
         DirectAccessUrl directAccessUrl = contentService.requestContentDirectUrl(NODE_REF, true, 20L);
         assertNull(directAccessUrl);
-        verify(mockContentStore, times(1)).requestContentDirectUrl(anyString(), eq(true), anyString(), anyLong());
+        verify(mockContentStore, times(1)).requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong());
     }
 
     /* Helper method to set system-wide direct access url configuration settings */

--- a/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/caching/CachingContentStoreTest.java
@@ -505,8 +505,8 @@ public class CachingContentStoreTest
     {
         try
         {
-            when(backingStore.requestContentDirectUrl(anyString(), eq(true), anyString(), anyLong())).thenThrow(new UnsupportedOperationException());
-            cachingStore.requestContentDirectUrl("url", true,"someFile", 30L);
+            when(backingStore.requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong())).thenThrow(new UnsupportedOperationException());
+            cachingStore.requestContentDirectUrl("url", true,"someFile", "someMimetype", 30L);
             fail();
         }
         catch (UnsupportedOperationException e)
@@ -518,7 +518,7 @@ public class CachingContentStoreTest
     @Test
     public void getRequestContentDirectUrl()
     {
-        when(backingStore.requestContentDirectUrl(anyString(), eq(true), anyString(), anyLong())).thenReturn(new DirectAccessUrl());
-        cachingStore.requestContentDirectUrl("url", true,"someFile", 30L);
+        when(backingStore.requestContentDirectUrl(anyString(), eq(true), anyString(), anyString(), anyLong())).thenReturn(new DirectAccessUrl());
+        cachingStore.requestContentDirectUrl("url", true,"someFile", "someMimeType", 30L);
     }
 }

--- a/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/replication/AggregatingContentStoreTest.java
@@ -227,14 +227,14 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
         UnsupportedContentUrlException unsupportedContentUrlExc = new UnsupportedContentUrlException(aggStore, "");
 
         // By default it is unsupported
-        DirectAccessUrl directAccessUrl = aggStore.requestContentDirectUrl("url", true, "anyfilename", 30L);
+        DirectAccessUrl directAccessUrl = aggStore.requestContentDirectUrl("url", true, "anyfilename", "anyMimetype", 30L);
         assertNull(directAccessUrl);
 
         // Direct access not supported
         try
         {
-            when(primaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any())).thenThrow(unsupportedExc);
-            when(secondaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any())).thenThrow(unsupportedExc);
+            when(primaryStoreMock.requestContentDirectUrl(any(), any(), any(), any(), any())).thenThrow(unsupportedExc);
+            when(secondaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any(), any())).thenThrow(unsupportedExc);
             aggStore.requestContentDirectUrl(eq("urlDANotSupported"), true, "anyfilename", 30L);
             fail();
         }
@@ -245,9 +245,9 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
 
         try
         {
-            when(primaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
-            when(secondaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any())).thenThrow(unsupportedExc);
-            aggStore.requestContentDirectUrl("urlDANotSupported", true, "anyfilename", 30L);
+            when(primaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
+            when(secondaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any(), any())).thenThrow(unsupportedExc);
+            aggStore.requestContentDirectUrl("urlDANotSupported", true, "anyfilename", "anyMimetype", 30L);
             fail();
         }
         catch (UnsupportedOperationException e)
@@ -257,9 +257,9 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
 
         try
         {
-            when(primaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any())).thenThrow(unsupportedExc);
-            when(secondaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
-            aggStore.requestContentDirectUrl("urlDANotSupported", true, "anyfilename", 30L);
+            when(primaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any(), any())).thenThrow(unsupportedExc);
+            when(secondaryStoreMock.requestContentDirectUrl(eq("urlDANotSupported"), any(), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
+            aggStore.requestContentDirectUrl("urlDANotSupported", true, "anyfilename", "anyMimetype", 30L);
             fail();
         }
         catch (UnsupportedOperationException e)
@@ -270,9 +270,9 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
         // Content url not supported
         try
         {
-            when(primaryStoreMock.requestContentDirectUrl(eq("urlNotSupported"), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
-            when(secondaryStoreMock.requestContentDirectUrl(eq("urlNotSupported"), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
-            aggStore.requestContentDirectUrl("urlNotSupported", true, "anyfilename", 30L);
+            when(primaryStoreMock.requestContentDirectUrl(eq("urlNotSupported"), any(), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
+            when(secondaryStoreMock.requestContentDirectUrl(eq("urlNotSupported"), any(), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
+            aggStore.requestContentDirectUrl("urlNotSupported", true, "anyfilename", "anyMimetype", 30L);
             fail();
         }
         catch (UnsupportedContentUrlException e)
@@ -280,31 +280,31 @@ public class AggregatingContentStoreTest extends AbstractWritableContentStoreTes
             // Expected
         }
 
-        when(primaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any())).thenReturn(new DirectAccessUrl());
-        when(secondaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any())).thenThrow(unsupportedExc);
-        directAccessUrl = aggStore.requestContentDirectUrl("urlPriSupported", true, "anyfilename", 30L);
+        when(primaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any(), any())).thenReturn(new DirectAccessUrl());
+        when(secondaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any(), any())).thenThrow(unsupportedExc);
+        directAccessUrl = aggStore.requestContentDirectUrl("urlPriSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
 
-        when(primaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any())).thenReturn(new DirectAccessUrl());
-        when(secondaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
-        directAccessUrl = aggStore.requestContentDirectUrl("urlPriSupported", true, "anyfilename", 30L);
+        when(primaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any(), any())).thenReturn(new DirectAccessUrl());
+        when(secondaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
+        directAccessUrl = aggStore.requestContentDirectUrl("urlPriSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
 
-        when(primaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any())).thenThrow(unsupportedExc);
-        when(secondaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any())).thenReturn(new DirectAccessUrl());
-        directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", 30L);
+        when(primaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any(), any())).thenThrow(unsupportedExc);
+        when(secondaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any(), any())).thenReturn(new DirectAccessUrl());
+        directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
 
-        when(primaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
-        when(secondaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any())).thenReturn(new DirectAccessUrl());
-        directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", 30L);
+        when(primaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any(), any())).thenThrow(unsupportedContentUrlExc);
+        when(secondaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any(), any())).thenReturn(new DirectAccessUrl());
+        directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
 
-        when(primaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any())).thenReturn(new DirectAccessUrl());
-        when(secondaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any())).thenReturn(new DirectAccessUrl());
-        directAccessUrl = aggStore.requestContentDirectUrl("urlPriSupported", true, "anyfilename", 30L);
+        when(primaryStoreMock.requestContentDirectUrl(eq("urlPriSupported"), any(), any(), any(), any())).thenReturn(new DirectAccessUrl());
+        when(secondaryStoreMock.requestContentDirectUrl(eq("urlSecSupported"), any(), any(), any(), any())).thenReturn(new DirectAccessUrl());
+        directAccessUrl = aggStore.requestContentDirectUrl("urlPriSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
-        directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", 30L);
+        directAccessUrl = aggStore.requestContentDirectUrl("urlSecSupported", true, "anyfilename", "anyMimetype", 30L);
         assertNotNull(directAccessUrl);
     }
 }


### PR DESCRIPTION
* ACS-2064 ContentStore.java to require mimetype

- Updates the ContentStore interface to also require a mimetype, deprecates old method signatures
- Original interface methods maintained so code should be backwards compatible
- Implementing classes updated to reflect changes