### PR TITLE
make SortItem public

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/search/SortItem.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/search/SortItem.java
@@ -31,7 +31,7 @@ import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.service.namespace.QName;
 
 @AlfrescoPublicApi
-/*package*/ class SortItem
+public class SortItem
 {
     public QName property = null;
     public boolean assc = true;


### PR DESCRIPTION
The RecordsManagementSearchParameters and SortItem classes are marked as a public APIs, but callers can't create a SortItem and pass it to RecordsManagementSearchParameters.setSortOrder() because SortOrder is scoped at the package level.  I've changed SortItem to public to fix this.