### PR TITLE
ACS-3429, ACS-3336: Rule action mappings (create), validations (update) - part 2

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -397,7 +397,6 @@ public class CreateRulesTests extends RestTest
 
         restClient.assertStatusCodeIs(CREATED);
         rule.assertThat().isEqualTo(expectedRuleModel, IGNORE_ID, IGNORE_IS_SHARED)
-                .assertThat().field("name").is(RULE_NAME_DEFAULT)
                 .assertThat().field("isShared").isNull();
     }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -374,13 +374,13 @@ public class CreateRulesTests extends RestTest
     public void createRuleWithActions()
     {
         final Map<String, Serializable> copyParams =
-                Map.of("destination-folder", "workspace://SpacesStore/dummy-folder-node", "deep-copy", true);
+                Map.of("destination-folder", "dummy-folder-node", "deep-copy", true);
         final RestActionBodyExecTemplateModel copyAction = createCustomActionModel("copy", copyParams);
         final Map<String, Serializable> checkOutParams =
-                Map.of("destination-folder", "workspace://SpacesStore/dummy-folder-node", "assoc-name", "cm:checkout", "assoc-type",
+                Map.of("destination-folder", "dummy-folder-node", "assoc-name", "cm:checkout", "assoc-type",
                         "cm:contains");
         final RestActionBodyExecTemplateModel checkOutAction = createCustomActionModel("check-out", checkOutParams);
-        final Map<String, Serializable> scriptParams = Map.of("script-ref", "workspace://SpacesStore/dummy-script-node-id");
+        final Map<String, Serializable> scriptParams = Map.of("script-ref", "dummy-script-node-id");
         final RestActionBodyExecTemplateModel scriptAction = createCustomActionModel("script", scriptParams);
         final RestRuleModel ruleModel = createRuleModelWithDefaultName();
         ruleModel.setActions(Arrays.asList(copyAction, checkOutAction, scriptAction));

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -28,6 +28,8 @@ package org.alfresco.rest.rules;
 import static java.util.stream.Collectors.toList;
 
 import static org.alfresco.rest.rules.RulesTestsUtils.RULE_NAME_DEFAULT;
+import static org.alfresco.rest.rules.RulesTestsUtils.addActionContextParams;
+import static org.alfresco.rest.rules.RulesTestsUtils.createCustomActionModel;
 import static org.alfresco.rest.rules.RulesTestsUtils.createDefaultActionModel;
 import static org.alfresco.rest.rules.RulesTestsUtils.createEmptyConditionModel;
 import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModel;
@@ -46,10 +48,14 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import org.alfresco.rest.RestTest;
+import org.alfresco.rest.model.RestActionBodyExecTemplateModel;
 import org.alfresco.rest.model.RestRuleModel;
 import org.alfresco.rest.model.RestRuleModelsCollection;
 import org.alfresco.utility.constants.UserRole;
@@ -95,14 +101,12 @@ public class CreateRulesTests extends RestTest
                                        .createSingleRule(ruleModel);
 
         RestRuleModel expectedRuleModel = createRuleModelWithDefaultValues();
+        expectedRuleModel.setActions(addActionContextParams(expectedRuleModel.getActions()));
         expectedRuleModel.setConditions(createEmptyConditionModel());
         restClient.assertStatusCodeIs(CREATED);
-        // TODO fix actions mapping and remove it from ignored fields, actual issue - difference:
-        // actual:   actions=[RestActionBodyExecTemplateModel{actionDefinitionId='add-features', params={actionContext=rule, aspect-name={http://www.alfresco.org/model/audio/1.0}audio}}]
-        // expected: actions=[RestActionBodyExecTemplateModel{actionDefinitionId='set-property-value', params={aspect-name={http://www.alfresco.org/model/audio/1.0}audio, actionContext=rule}}]
-        rule.assertThat().isEqualTo(expectedRuleModel, IGNORE_ID, IGNORE_IS_SHARED, "actions")
-            .assertThat().field("id").isNotNull()
-            .assertThat().field("isShared").isNull();
+        rule.assertThat().isEqualTo(expectedRuleModel, IGNORE_ID, IGNORE_IS_SHARED)
+                .assertThat().field("id").isNotNull()
+                .assertThat().field("isShared").isNull();
     }
 
     /** Check creating a rule in a non-existent folder returns an error. */
@@ -361,5 +365,39 @@ public class CreateRulesTests extends RestTest
         RestRuleModel ruleModel = createRuleModel("testRule", List.of(createDefaultActionModel()));
 
         return restClient.authenticateUser(userWithRole).withCoreAPI().usingNode(privateFolder).usingDefaultRuleSet().createSingleRule(ruleModel);
+    }
+
+    /**
+     * Check we can create a rule with several actions.
+     */
+    @Test(groups = {TestGroup.REST_API, TestGroup.RULES})
+    public void createRuleWithActions()
+    {
+        final Map<String, Serializable> copyParams =
+                Map.of("destination-folder", "workspace://SpacesStore/dummy-folder-node", "deep-copy", true);
+        final RestActionBodyExecTemplateModel copyAction = createCustomActionModel("copy", copyParams);
+        final Map<String, Serializable> checkOutParams =
+                Map.of("destination-folder", "workspace://SpacesStore/dummy-folder-node", "assoc-name", "cm:checkout", "assoc-type",
+                        "cm:contains");
+        final RestActionBodyExecTemplateModel checkOutAction = createCustomActionModel("check-out", checkOutParams);
+        final Map<String, Serializable> scriptParams = Map.of("script-ref", "workspace://SpacesStore/dummy-script-node-id");
+        final RestActionBodyExecTemplateModel scriptAction = createCustomActionModel("script", scriptParams);
+        final RestRuleModel ruleModel = createRuleModelWithDefaultName();
+        ruleModel.setActions(Arrays.asList(copyAction, checkOutAction, scriptAction));
+
+        final UserModel admin = dataUser.getAdminUser();
+
+        final RestRuleModel rule = restClient.authenticateUser(admin).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                .createSingleRule(ruleModel);
+
+        final RestRuleModel expectedRuleModel = createRuleModelWithDefaultName();
+        expectedRuleModel.setActions(addActionContextParams(Arrays.asList(copyAction, checkOutAction, scriptAction)));
+        expectedRuleModel.setConditions(createEmptyConditionModel());
+        expectedRuleModel.setTriggers(List.of("inbound"));
+
+        restClient.assertStatusCodeIs(CREATED);
+        rule.assertThat().isEqualTo(expectedRuleModel, IGNORE_ID, IGNORE_IS_SHARED)
+                .assertThat().field("name").is(RULE_NAME_DEFAULT)
+                .assertThat().field("isShared").isNull();
     }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
@@ -25,6 +25,8 @@
  */
 package org.alfresco.rest.rules;
 
+import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,6 +99,24 @@ public class RulesTestsUtils
         RestActionBodyExecTemplateModel restActionModel = new RestActionBodyExecTemplateModel();
         restActionModel.setActionDefinitionId("add-features");
         restActionModel.setParams(Map.of("aspect-name", "cm:audio"));
+        return restActionModel;
+    }
+
+    public static List<RestActionBodyExecTemplateModel> addActionContextParams(List<RestActionBodyExecTemplateModel> inputActions)
+    {
+        inputActions.forEach(inputAction -> {
+            final Map<String, Serializable> params = new HashMap<>((Map<String, Serializable>) inputAction.getParams());
+            params.put("actionContext", "rule");
+            inputAction.setParams(params);
+        });
+        return inputActions;
+    }
+
+    public static RestActionBodyExecTemplateModel createCustomActionModel(String actionDefinitionId, Map<String, Serializable> params)
+    {
+        RestActionBodyExecTemplateModel restActionModel = new RestActionBodyExecTemplateModel();
+        restActionModel.setActionDefinitionId(actionDefinitionId);
+        restActionModel.setParams(params);
         return restActionModel;
     }
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
@@ -161,8 +161,7 @@ public class UpdateRulesTests extends RestTest
         RestRuleModel rule = createAndSaveRule("Rule name");
 
         STEP("Try to update the rule to have no name.");
-        RestRuleModel updatedRuleModel = new RestRuleModel();
-        updatedRuleModel.setName("");
+        RestRuleModel updatedRuleModel = createRuleModel("");
         restClient.authenticateUser(user).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet().updateRule(rule.getId(), updatedRuleModel);
 
         restClient.assertLastError().statusCodeIs(BAD_REQUEST)

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/rules/ActionParameterConverter.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/rules/ActionParameterConverter.java
@@ -42,6 +42,7 @@ import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryException;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
@@ -98,7 +99,7 @@ public class ActionParameterConverter
             return ((QName) param).toPrefixString(namespaceService);
         }
         else if (param instanceof NodeRef) {
-            return param.toString();
+            return ((NodeRef) param).getId();
         }
         else
         {
@@ -134,12 +135,18 @@ public class ActionParameterConverter
                 list.add(convertValue(typeQName, ((JSONArray) propertyValue).get(i)));
             }
             value = (Serializable) list;
-        } else
+        }
+        else
         {
             if (typeQName.equals(DataTypeDefinition.QNAME) && typeQName.toString().contains(":"))
             {
                 value = QName.createQName(propertyValue.toString(), namespaceService);
-            } else
+            }
+            else if (typeQName.isMatch(DataTypeDefinition.NODE_REF))
+            {
+                value = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, propertyValue.toString());
+            }
+            else
             {
                 value = (Serializable) DefaultTypeConverter.INSTANCE.convert(dictionaryService.getDataType(typeQName), propertyValue);
             }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/rules/ActionParameterConverter.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/rules/ActionParameterConverter.java
@@ -41,6 +41,7 @@ import org.alfresco.service.cmr.action.ParameterizedItemDefinition;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryException;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
+import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.datatype.DefaultTypeConverter;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
@@ -62,7 +63,8 @@ public class ActionParameterConverter
         this.namespaceService = namespaceService;
     }
 
-    Map<String, Serializable> getConvertedParams(Map<String, Serializable> params, String name) {
+    Map<String, Serializable> getConvertedParams(Map<String, Serializable> params, String name)
+    {
         final Map<String, Serializable> parameters = new HashMap<>(params.size());
         final ParameterizedItemDefinition definition = actionService.getActionDefinition(name);
         if (definition == null)
@@ -87,6 +89,21 @@ public class ActionParameterConverter
             }
         }
         return parameters;
+    }
+
+    public Serializable convertParamFromServiceModel(Serializable param)
+    {
+        if (param instanceof QName)
+        {
+            return ((QName) param).toPrefixString(namespaceService);
+        }
+        else if (param instanceof NodeRef) {
+            return param.toString();
+        }
+        else
+        {
+            return param;
+        }
     }
 
     private Serializable convertValue(QName typeQName, Object propertyValue) throws JSONException

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/ActionParameterConverterTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/ActionParameterConverterTest.java
@@ -36,6 +36,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 import org.alfresco.repo.action.executer.AddFeaturesActionExecuter;
@@ -559,5 +560,41 @@ public class ActionParameterConverterTest
         final Serializable convertedPropTypeParam = convertedParams.get(propertyTypeKey);
         assertTrue(convertedPropTypeParam instanceof String);
         assertEquals(propType, convertedPropTypeParam);
+    }
+
+    @Test
+    public void testQnameServiceModelParamConversion() {
+        given(namespaceService.getPrefixes(any())).willReturn(List.of("cm"));
+        final String qname = "{cm-dummy-prefix}audio";
+        final Serializable qnameParam = QName.createQName(qname);
+
+        //when
+        final Serializable convertedParam = objectUnderTest.convertParamFromServiceModel(qnameParam);
+
+        then(namespaceService).should().getPrefixes(any());
+        then(namespaceService).shouldHaveNoMoreInteractions();
+        assertEquals("cm:audio", convertedParam);
+    }
+
+    @Test
+    public void testNodeRefServiceModelParamConversion() {
+        final Serializable nodeRefParam = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, "dummy-id");
+
+        //when
+        final Serializable convertedParam = objectUnderTest.convertParamFromServiceModel(nodeRefParam);
+
+        then(namespaceService).shouldHaveNoInteractions();
+        assertEquals("workspace://SpacesStore/dummy-id", convertedParam);
+    }
+
+    @Test
+    public void testOtherServiceModelParamConversion() {
+        //given
+        final Serializable dummyStringParam = "dummy-param";
+        //when
+        final Serializable convertedParam = objectUnderTest.convertParamFromServiceModel(dummyStringParam);
+
+        then(namespaceService).shouldHaveNoInteractions();
+        assertEquals(dummyStringParam, convertedParam);
     }
 }

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/ActionParameterConverterTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/ActionParameterConverterTest.java
@@ -80,10 +80,7 @@ public class ActionParameterConverterTest
     private static final String IDENTIFIER_ASPECT = NamespaceService.CONTENT_MODEL_PREFIX + QName.NAMESPACE_PREFIX + IDENTIFIER;
 
     private static final String DUMMY_FOLDER_NODE_ID = "dummy-folder-node";
-    private static final String DUMMY_FOLDER_NODE_REF = STORE_REF_WORKSPACE_SPACESSTORE + "/" + DUMMY_FOLDER_NODE_ID;
     private static final String DUMMY_SCRIPT_NODE_ID = "dummy-script-ref";
-    private static final String DUMMY_SCRIPT_NODE_REF = STORE_REF_WORKSPACE_SPACESSTORE + "/" + DUMMY_SCRIPT_NODE_ID;
-
 
     @Mock
     private DictionaryService dictionaryService;
@@ -149,7 +146,7 @@ public class ActionParameterConverterTest
         final String name = CopyActionExecuter.NAME;
         final String destinationFolderKey = CopyActionExecuter.PARAM_DESTINATION_FOLDER;
         final String deepCopyKey = CopyActionExecuter.PARAM_DEEP_COPY;
-        final Map<String, Serializable> params = Map.of(destinationFolderKey, DUMMY_FOLDER_NODE_REF, deepCopyKey, true);
+        final Map<String, Serializable> params = Map.of(destinationFolderKey, DUMMY_FOLDER_NODE_ID, deepCopyKey, true);
 
         given(actionService.getActionDefinition(name)).willReturn(actionDefinition);
         given(actionDefinition.getParameterDefintion(destinationFolderKey)).willReturn(actionDefinitionParam1);
@@ -160,7 +157,6 @@ public class ActionParameterConverterTest
         given(actionDefinitionParam2.getType()).willReturn(bool);
 
         given(dictionaryService.getDataType(nodeRef)).willReturn(dataTypeDefinition1);
-        given(dataTypeDefinition1.getJavaClassName()).willReturn(NodeRef.class.getName());
         given(dictionaryService.getDataType(bool)).willReturn(dataTypeDefinition2);
         given(dataTypeDefinition2.getJavaClassName()).willReturn(Boolean.class.getName());
 
@@ -173,7 +169,7 @@ public class ActionParameterConverterTest
         then(actionDefinition).should().getParameterDefintion(deepCopyKey);
         then(actionDefinition).shouldHaveNoMoreInteractions();
         then(dictionaryService).should(times(2)).getDataType(bool);
-        then(dictionaryService).should(times(2)).getDataType(nodeRef);
+        then(dictionaryService).should().getDataType(nodeRef);
         then(dictionaryService).shouldHaveNoMoreInteractions();
         then(namespaceService).shouldHaveNoInteractions();
 
@@ -191,7 +187,7 @@ public class ActionParameterConverterTest
     {
         final String name = ScriptActionExecuter.NAME;
         final String executeScriptKey = ScriptActionExecuter.PARAM_SCRIPTREF;
-        final Map<String, Serializable> params = Map.of(executeScriptKey, DUMMY_SCRIPT_NODE_REF);
+        final Map<String, Serializable> params = Map.of(executeScriptKey, DUMMY_SCRIPT_NODE_ID);
 
         given(actionService.getActionDefinition(name)).willReturn(actionDefinition);
         given(actionDefinition.getParameterDefintion(executeScriptKey)).willReturn(actionDefinitionParam1);
@@ -199,7 +195,6 @@ public class ActionParameterConverterTest
         given(actionDefinitionParam1.getType()).willReturn(scriptNodeRef);
 
         given(dictionaryService.getDataType(scriptNodeRef)).willReturn(dataTypeDefinition1);
-        given(dataTypeDefinition1.getJavaClassName()).willReturn(NodeRef.class.getName());
 
         //when
         final Map<String, Serializable> convertedParams = objectUnderTest.getConvertedParams(params, name);
@@ -208,7 +203,7 @@ public class ActionParameterConverterTest
         then(actionService).shouldHaveNoMoreInteractions();
         then(actionDefinition).should().getParameterDefintion(executeScriptKey);
         then(actionDefinition).shouldHaveNoMoreInteractions();
-        then(dictionaryService).should(times(2)).getDataType(scriptNodeRef);
+        then(dictionaryService).should().getDataType(scriptNodeRef);
         then(dictionaryService).shouldHaveNoMoreInteractions();
         then(namespaceService).shouldHaveNoInteractions();
 
@@ -223,7 +218,7 @@ public class ActionParameterConverterTest
     {
         final String name = MoveActionExecuter.NAME;
         final String destinationFolderKey = MoveActionExecuter.PARAM_DESTINATION_FOLDER;
-        final Map<String, Serializable> params = Map.of(destinationFolderKey, DUMMY_FOLDER_NODE_REF);
+        final Map<String, Serializable> params = Map.of(destinationFolderKey, DUMMY_FOLDER_NODE_ID);
 
         given(actionService.getActionDefinition(name)).willReturn(actionDefinition);
         given(actionDefinition.getParameterDefintion(destinationFolderKey)).willReturn(actionDefinitionParam1);
@@ -231,7 +226,6 @@ public class ActionParameterConverterTest
         given(actionDefinitionParam1.getType()).willReturn(nodeRef);
 
         given(dictionaryService.getDataType(nodeRef)).willReturn(dataTypeDefinition1);
-        given(dataTypeDefinition1.getJavaClassName()).willReturn(NodeRef.class.getName());
 
         //when
         final Map<String, Serializable> convertedParams = objectUnderTest.getConvertedParams(params, name);
@@ -240,7 +234,7 @@ public class ActionParameterConverterTest
         then(actionService).shouldHaveNoMoreInteractions();
         then(actionDefinition).should().getParameterDefintion(destinationFolderKey);
         then(actionDefinition).shouldHaveNoMoreInteractions();
-        then(dictionaryService).should(times(2)).getDataType(nodeRef);
+        then(dictionaryService).should().getDataType(nodeRef);
         then(dictionaryService).shouldHaveNoMoreInteractions();
         then(namespaceService).shouldHaveNoInteractions();
 
@@ -301,7 +295,7 @@ public class ActionParameterConverterTest
         final String assocNameKey = CheckOutActionExecuter.PARAM_ASSOC_QNAME;
         final String assocTypeKey = CheckOutActionExecuter.PARAM_ASSOC_TYPE_QNAME;
         final Map<String, Serializable> params =
-                Map.of(destinationFolderKey, DUMMY_FOLDER_NODE_REF, assocNameKey, CHECKOUT_ASPECT, assocTypeKey, CONTAINS_ASPECT);
+                Map.of(destinationFolderKey, DUMMY_FOLDER_NODE_ID, assocNameKey, CHECKOUT_ASPECT, assocTypeKey, CONTAINS_ASPECT);
 
         given(actionService.getActionDefinition(name)).willReturn(actionDefinition);
         given(actionDefinition.getParameterDefintion(destinationFolderKey)).willReturn(actionDefinitionParam1);
@@ -314,7 +308,6 @@ public class ActionParameterConverterTest
         given(actionDefinitionParam3.getType()).willReturn(qname);
 
         given(dictionaryService.getDataType(nodeRef)).willReturn(dataTypeDefinition1);
-        given(dataTypeDefinition1.getJavaClassName()).willReturn(NodeRef.class.getName());
         given(dictionaryService.getDataType(qname)).willReturn(dataTypeDefinition2);
         given(namespaceService.getNamespaceURI(any())).willReturn(NamespaceService.DICTIONARY_MODEL_1_0_URI);
 
@@ -328,7 +321,7 @@ public class ActionParameterConverterTest
         then(actionDefinition).should().getParameterDefintion(assocTypeKey);
         then(actionDefinition).shouldHaveNoMoreInteractions();
         then(dictionaryService).should(times(2)).getDataType(qname);
-        then(dictionaryService).should(times(2)).getDataType(nodeRef);
+        then(dictionaryService).should().getDataType(nodeRef);
         then(dictionaryService).shouldHaveNoMoreInteractions();
         then(namespaceService).should(times(2)).getNamespaceURI(any());
         then(namespaceService).shouldHaveNoMoreInteractions();
@@ -355,7 +348,7 @@ public class ActionParameterConverterTest
         final String name = LinkCategoryActionExecuter.NAME;
         final String categoryAspectKey = LinkCategoryActionExecuter.PARAM_CATEGORY_ASPECT;
         final String categoryValueKey = LinkCategoryActionExecuter.PARAM_CATEGORY_VALUE;
-        final Map<String, Serializable> params = Map.of(categoryAspectKey, CLASSIFIABLE_ASPECT, categoryValueKey, DUMMY_FOLDER_NODE_REF);
+        final Map<String, Serializable> params = Map.of(categoryAspectKey, CLASSIFIABLE_ASPECT, categoryValueKey, DUMMY_FOLDER_NODE_ID);
 
         given(actionService.getActionDefinition(name)).willReturn(actionDefinition);
         given(actionDefinition.getParameterDefintion(categoryAspectKey)).willReturn(actionDefinitionParam1);
@@ -366,7 +359,6 @@ public class ActionParameterConverterTest
         given(actionDefinitionParam2.getType()).willReturn(nodeRef);
 
         given(dictionaryService.getDataType(nodeRef)).willReturn(dataTypeDefinition1);
-        given(dataTypeDefinition1.getJavaClassName()).willReturn(NodeRef.class.getName());
         given(dictionaryService.getDataType(qname)).willReturn(dataTypeDefinition2);
         given(namespaceService.getNamespaceURI(any())).willReturn(NamespaceService.DICTIONARY_MODEL_1_0_URI);
 
@@ -379,7 +371,7 @@ public class ActionParameterConverterTest
         then(actionDefinition).should().getParameterDefintion(categoryValueKey);
         then(actionDefinition).shouldHaveNoMoreInteractions();
         then(dictionaryService).should().getDataType(qname);
-        then(dictionaryService).should(times(2)).getDataType(nodeRef);
+        then(dictionaryService).should().getDataType(nodeRef);
         then(dictionaryService).shouldHaveNoMoreInteractions();
         then(namespaceService).should().getNamespaceURI(any());
         then(namespaceService).shouldHaveNoMoreInteractions();
@@ -441,8 +433,8 @@ public class ActionParameterConverterTest
         final String approve = "Approve";
         final String reject = "Reject";
         final Map<String, Serializable> params =
-                Map.of(approveStepKey, approve, approveFolderKey, DUMMY_FOLDER_NODE_REF, approveMoveKey, true,
-                        rejectStepKey, reject, rejectFolderKey, DUMMY_FOLDER_NODE_REF, rejectMoveKey, true);
+                Map.of(approveStepKey, approve, approveFolderKey, DUMMY_FOLDER_NODE_ID, approveMoveKey, true,
+                        rejectStepKey, reject, rejectFolderKey, DUMMY_FOLDER_NODE_ID, rejectMoveKey, true);
 
         given(actionService.getActionDefinition(name)).willReturn(actionDefinition);
         given(actionDefinition.getParameterDefintion(rejectStepKey)).willReturn(actionDefinitionParam1);
@@ -459,7 +451,6 @@ public class ActionParameterConverterTest
         given(actionDefinitionParam3.getType()).willReturn(bool, bool);
 
         given(dictionaryService.getDataType(nodeRef)).willReturn(dataTypeDefinition1);
-        given(dataTypeDefinition1.getJavaClassName()).willReturn(NodeRef.class.getName());
         given(dictionaryService.getDataType(text)).willReturn(dataTypeDefinition2);
         given(dataTypeDefinition2.getJavaClassName()).willReturn(String.class.getName());
         given(dictionaryService.getDataType(bool)).willReturn(dataTypeDefinition3);
@@ -478,7 +469,7 @@ public class ActionParameterConverterTest
         then(actionDefinition).should().getParameterDefintion(rejectMoveKey);
         then(actionDefinition).shouldHaveNoMoreInteractions();
         then(dictionaryService).should(times(4)).getDataType(text);
-        then(dictionaryService).should(times(4)).getDataType(nodeRef);
+        then(dictionaryService).should(times(2)).getDataType(nodeRef);
         then(dictionaryService).should(times(4)).getDataType(bool);
         then(dictionaryService).shouldHaveNoMoreInteractions();
         then(namespaceService).shouldHaveNoInteractions();
@@ -578,13 +569,14 @@ public class ActionParameterConverterTest
 
     @Test
     public void testNodeRefServiceModelParamConversion() {
-        final Serializable nodeRefParam = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, "dummy-id");
+        //given
+        final Serializable nodeRefParam = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, DUMMY_FOLDER_NODE_ID);
 
         //when
         final Serializable convertedParam = objectUnderTest.convertParamFromServiceModel(nodeRefParam);
 
         then(namespaceService).shouldHaveNoInteractions();
-        assertEquals("workspace://SpacesStore/dummy-id", convertedParam);
+        assertEquals(DUMMY_FOLDER_NODE_ID, convertedParam);
     }
 
     @Test


### PR DESCRIPTION
This PR is a second installment for https://github.com/Alfresco/alfresco-community-repo/pull/1305.
This PR roughly consists of:
- initial TAS tests for create rule with multiple actions
- action parameters mappings for rule retrieval + unit tests
- rule/action validations for rule update + unit tests