### PR TITLE
Upgraded Keycloak-Client to match the Identity-Service version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.2.2</dependency.poi.version>
         <dependency.ooxml-schemas.version>1.4</dependency.ooxml-schemas.version>
-        <dependency.keycloak.version>15.0.2</dependency.keycloak.version>
+        <dependency.keycloak.version>18.0.0</dependency.keycloak.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
         <dependency.camel.version>3.15.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies (can cause dependency conflicts)-->
         <dependency.activemq.version>5.17.1</dependency.activemq.version>


### PR DESCRIPTION
Upgraded Keycloak-Client to 18.0.0. This is the same Keycloak server version that Identity Service (IDS) is shipping. 
We should always be in sync with the server. IDS was released back in June, but somehow we missed to upgrade the clients.