### PR TITLE
MNT-23176 - Revert "ACS-1600 : Error when running propTablesCleanupJob on an env …

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/domain/schema/script/DeleteNotExistsExecutor.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/schema/script/DeleteNotExistsExecutor.java
@@ -220,6 +220,7 @@ public class DeleteNotExistsExecutor implements StatementExecutor
                 {
                     // Process batch
                     primaryId = processPrimaryTableResultSet(primaryPrepStmt, secondaryPrepStmts, deletePrepStmt, deleteIds, primaryTableName, primaryColumnName, tableColumn);
+                    connection.commit();
 
                     if (primaryId == null)
                     {
@@ -298,7 +299,6 @@ public class DeleteNotExistsExecutor implements StatementExecutor
                     if (deleteIds.size() == deleteBatchSize)
                     {
                         deleteFromPrimaryTable(deletePrepStmt, deleteIds, primaryTableName);
-                        connection.commit();
                     }
 
                     if (!resultSet.next())

--- a/repository/src/main/java/org/alfresco/repo/domain/schema/script/MySQLDeleteNotExistsExecutor.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/schema/script/MySQLDeleteNotExistsExecutor.java
@@ -117,6 +117,7 @@ public class MySQLDeleteNotExistsExecutor extends DeleteNotExistsExecutor
                 {
                     // Process batch
                     primaryId = processPrimaryTableResultSet(primaryPrepStmt, secondaryPrepStmts, deletePrepStmt, deleteIds, primaryTableName, primaryColumnName, tableColumn);
+                    connection.commit();
 
                     if (primaryId == null)
                     {


### PR DESCRIPTION
…with 100 million records in alf_prop_value (#473)"

This reverts commit 00b0b21668d013f06d5765eb84f2dc49a766f85f.

Causes errors "ERROR: portal "C_XXX" does not exist" on PostgreSQL as the resultsets on secondary tables are still open when we commit deletes on primary tables that cascade to the secondary tables. See MNT-23176

To prevent the original problem, use smaller batchsizes. 