### PR TITLE
[MNT-21377] Prevent LDAP checks from running multiple times

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/security/authentication/ldap/LDAPInitialDirContextFactoryImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/ldap/LDAPInitialDirContextFactoryImpl.java
@@ -85,11 +85,7 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
     private String trustStoreType;
     private String trustStorePassPhrase;
 
-    private JobLockService jobLockService;
-    private final QName LOCK_QNAME = QName.createQName(NamespaceService.SYSTEM_MODEL_1_0_URI, "LDAPInitialDirContextFactoryImpl");
-    private final long LOCK_TTL = 1000 * 60 * 5;
-    private final long LOCK_RETRY_WAIT = 0;
-    private final int LOCK_RETRY_COUNT = 0;
+    private boolean initialChecksEnabled = true;
 
     private final String ANONYMOUS_CHECK = "anonymous_check";
     private final String SIMPLE_DN_CHECK = "simple_dn_check";
@@ -494,34 +490,21 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
     {
         logger.debug("after Properties Set");
 
-        String lockToken = null;
-
-        try
+        if (initialChecksEnabled)
         {
-            lockToken = this.jobLockService.getLock(LOCK_QNAME, LOCK_TTL, LOCK_RETRY_WAIT, LOCK_RETRY_COUNT);
-
             checkAnonymousBind();
             checkSimpleDnAndPassword();
             checkDnAndPassword();
             checkPrincipal();
         }
-        catch (LockAcquisitionException e)
+        else
         {
-            // Don't proceed with the LDAP checks if it is already running on another node
-            logger.warn("LDAP initial dir context checks are already running on another thread. Tests aborted.");
-        }
-        finally
-        {
-            if (lockToken != null)
-            {
-                jobLockService.releaseLock(lockToken, LOCK_QNAME);
-            }
-
+            logger.info("LDAP checks are disabled");
         }
     }
 
     /**
-     * 1) Check Anonymous bind
+     * Check Anonymous bind
      */
     private void checkAnonymousBind()
     {
@@ -539,6 +522,8 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
 
         if (!isCached(ANONYMOUS_CHECK, env))
         {
+            logger.debug("Starting check: Anonymous bind");
+
             try
             {
                 new InitialDirContext(env);
@@ -559,7 +544,7 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
     }
 
     /**
-     * 2) Simple DN and password
+     * Check simple DN and password
      */
     private void checkSimpleDnAndPassword()
     {
@@ -577,6 +562,8 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
 
         if (!isCached(SIMPLE_DN_CHECK, env))
         {
+            logger.debug("Starting check: Simple DN and Password");
+
             try
             {
                 new InitialDirContext(env);
@@ -600,7 +587,7 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
     }
 
     /**
-     * 3) DN and Password
+     * Check DN and Password
      */
     private void checkDnAndPassword()
     {
@@ -618,6 +605,8 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
 
         if (!isCached(DN_CHECK, env))
         {
+            logger.debug("Starting check: DN and Password");
+
             try
             {
                 new InitialDirContext(env);
@@ -640,7 +629,7 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
     }
 
     /**
-     * 4) Check more if we have a real principal we expect to work
+     * Check more if we have a real principal we expect to work
      */
     private void checkPrincipal()
     {
@@ -664,6 +653,8 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
 
             if (!isCached(PRINCIPAL_CHECK, env))
             {
+                logger.debug("Starting check: Principal");
+
                 try
                 {
                     new InitialDirContext(env);
@@ -769,16 +760,6 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
         return ks;
     }
 
-    public void setJobLockService(JobLockService jobLockService)
-    {
-        this.jobLockService = jobLockService;
-    }
-
-    public void setLdapInitialDirContextCache(SimpleCache<String, Set<Map<String, String>>> cache)
-    {
-        this.ldapInitialDirContextCache = cache;
-    }
-
     private void addToCache(String key, Map<String, String> value)
     {
         Set<Map<String, String>> envs = ldapInitialDirContextCache.get(key);
@@ -787,8 +768,8 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
         {
             envs = Collections.synchronizedSet(new HashSet<Map<String, String>>(11));
         }
-
-        if (envs != null && !envs.contains(value))
+        
+        if (!envs.contains(value))
         {
             envs.add(value);
         }
@@ -827,7 +808,19 @@ public class LDAPInitialDirContextFactoryImpl implements LDAPInitialDirContextFa
                 isCached = true;
             }
         }
+        
+        logger.debug("LDAP check: " + key + " / isCached: " + (isCached ? "yes" : "no"));
 
         return isCached;
+    }
+
+    public void setLdapInitialDirContextCache(SimpleCache<String, Set<Map<String, String>>> cache)
+    {
+        this.ldapInitialDirContextCache = cache;
+    }
+
+    public void setInitialChecksEnabled(boolean initialChecksEnabled)
+    {
+        this.initialChecksEnabled = initialChecksEnabled;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/security/authentication/ldap/LDAPInitialDirContextFactoryImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/ldap/LDAPInitialDirContextFactoryImpl.java
@@ -58,13 +58,9 @@ import javax.naming.ldap.PagedResultsResponseControl;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.cache.SimpleCache;
-import org.alfresco.repo.lock.JobLockService;
-import org.alfresco.repo.lock.LockAcquisitionException;
 import org.alfresco.repo.security.authentication.AlfrescoSSLSocketFactory;
 import org.alfresco.repo.security.authentication.AuthenticationDiagnostic;
 import org.alfresco.repo.security.authentication.AuthenticationException;
-import org.alfresco.service.namespace.NamespaceService;
-import org.alfresco.service.namespace.QName;
 import org.alfresco.util.ApplicationContextHelper;
 import org.alfresco.util.PropertyCheck;
 import org.apache.commons.logging.Log;

--- a/repository/src/main/resources/alfresco/cache-context.xml
+++ b/repository/src/main/resources/alfresco/cache-context.xml
@@ -506,4 +506,12 @@
     <bean name="queryAcceleratorCache" factory-bean="cacheFactory" factory-method="createCache">
         <constructor-arg value="cache.queryAcceleratorCache"/>
     </bean>
+
+   <!-- ===================================== -->
+   <!-- LDAP Initial Dir Context cache		  -->
+   <!-- ===================================== -->
+
+    <bean name="ldapInitialDirContextCache" factory-bean="cacheFactory" factory-method="createCache">
+        <constructor-arg value="cache.ldapInitialDirContextCache"/>
+    </bean>
 </beans>

--- a/repository/src/main/resources/alfresco/caches.properties
+++ b/repository/src/main/resources/alfresco/caches.properties
@@ -699,3 +699,15 @@ cache.queryAcceleratorCache.backup-count=1
 cache.queryAcceleratorCache.eviction-policy=NONE
 cache.queryAcceleratorCache.merge-policy=com.hazelcast.map.merge.LatestUpdateMapMergePolicy
 cache.queryAcceleratorCache.readBackupData=false
+
+#
+# LDAP initial dir context checks cluster cache
+#
+cache.ldapInitialDirContextCache.maxItems=100
+cache.ldapInitialDirContextCache.timeToLiveSeconds=0
+cache.ldapInitialDirContextCache.maxIdleSeconds=0
+cache.ldapInitialDirContextCache.cluster.type=fully-distributed
+cache.ldapInitialDirContextCache.backup-count=1
+cache.ldapInitialDirContextCache.eviction-policy=NONE
+cache.ldapInitialDirContextCache.merge-policy=com.hazelcast.map.merge.LatestUpdateMapMergePolicy
+cache.ldapInitialDirContextCache.readBackupData=false

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
@@ -119,7 +119,9 @@
    -->
 
    <bean id="ldapInitialDirContextFactory" class="org.alfresco.repo.security.authentication.ldap.LDAPInitialDirContextFactoryImpl">
-
+      <property name="ldapInitialDirContextCache">
+         <ref bean="ldapInitialDirContextCache" />
+      </property>
       <property name="trustStorePath">
          <value>${ldap.authentication.truststore.path}</value>
       </property>

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
@@ -122,6 +122,9 @@
       <property name="ldapInitialDirContextCache">
          <ref bean="ldapInitialDirContextCache" />
       </property>
+      <property name="initialChecksEnabled">
+         <value>${ldap.initial.checks.enabled}</value>
+      </property>
       <property name="trustStorePath">
          <value>${ldap.authentication.truststore.path}</value>
       </property>

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/common-ldap-context.xml
@@ -123,7 +123,7 @@
          <ref bean="ldapInitialDirContextCache" />
       </property>
       <property name="initialChecksEnabled">
-         <value>${ldap.initial.checks.enabled}</value>
+         <value>${ldap.authentication.initial.checks.enabled}</value>
       </property>
       <property name="trustStorePath">
          <value>${ldap.authentication.truststore.path}</value>

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/ldap-ad/ldap-ad-authentication.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/ldap-ad/ldap-ad-authentication.properties
@@ -177,4 +177,4 @@ ldap.synchronization.userAccountStatusProperty=userAccountControl
 ldap.synchronization.userAccountStatusInterpreter=ldapadUserAccountStatusInterpreter
 
 # Allows to enable or disable LDAP-AD initial checks (anonymous bind, simple dn, dn and principal)
-ldap.initial.checks.enabled=true
+ldap.authentication.initial.checks.enabled=true

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/ldap-ad/ldap-ad-authentication.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/ldap-ad/ldap-ad-authentication.properties
@@ -175,3 +175,6 @@ ldap.synchronization.userAccountStatusProperty=userAccountControl
 
 # The Account Status Interpreter bean name
 ldap.synchronization.userAccountStatusInterpreter=ldapadUserAccountStatusInterpreter
+
+# Allows to enable or disable LDAP-AD initial checks (anonymous bind, simple dn, dn and principal)
+ldap.initial.checks.enabled=true

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/ldap/ldap-authentication.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/ldap/ldap-authentication.properties
@@ -192,3 +192,6 @@ ldap.synchronization.disabledAccountPropertyValueCanBeNull=true
 
 # The Account Status Interpreter bean name
 ldap.synchronization.userAccountStatusInterpreter=ldapUserAccountStatusInterpreter
+
+# Allows to enable or disable LDAP initial checks (anonymous bind, simple dn, dn and principal)
+ldap.initial.checks.enabled=true

--- a/repository/src/main/resources/alfresco/subsystems/Authentication/ldap/ldap-authentication.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Authentication/ldap/ldap-authentication.properties
@@ -194,4 +194,4 @@ ldap.synchronization.disabledAccountPropertyValueCanBeNull=true
 ldap.synchronization.userAccountStatusInterpreter=ldapUserAccountStatusInterpreter
 
 # Allows to enable or disable LDAP initial checks (anonymous bind, simple dn, dn and principal)
-ldap.initial.checks.enabled=true
+ldap.authentication.initial.checks.enabled=true


### PR DESCRIPTION
Added the property below to give the ability to enable/disable LDAP checks (by default is true):

> ldap.initial.checks.enabled

The goal is to allow the checks to run only in one cluster node, disabling them in the other cluster members and preventing the configured principal account from being locked due to invalid attempts.

A cluster aware cache was also added to store the checks that have been executed already, so they won’t be executed again if some configuration is changed in the admin console, however, if, for example, the host or port change, the checks will be performed again.