### PR TITLE
ACS-3536 Omit actionContext for rules.

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -95,7 +95,6 @@ public class CreateRulesTests extends RestTest
                                        .createSingleRule(ruleModel);
 
         RestRuleModel expectedRuleModel = createRuleModelWithModifiedValues();
-        expectedRuleModel.setActions(addActionContextParams(expectedRuleModel.getActions()));
         expectedRuleModel.setConditions(createEmptyConditionModel());
         restClient.assertStatusCodeIs(CREATED);
         rule.assertThat().isEqualTo(expectedRuleModel, IGNORE_ID, IGNORE_IS_SHARED)
@@ -385,7 +384,7 @@ public class CreateRulesTests extends RestTest
                 .createSingleRule(ruleModel);
 
         final RestRuleModel expectedRuleModel = createRuleModelWithDefaultValues();
-        expectedRuleModel.setActions(addActionContextParams(Arrays.asList(copyAction, checkOutAction, scriptAction)));
+        expectedRuleModel.setActions(Arrays.asList(copyAction, checkOutAction, scriptAction));
         expectedRuleModel.setConditions(createEmptyConditionModel());
         expectedRuleModel.setTriggers(List.of("inbound"));
 
@@ -407,7 +406,6 @@ public class CreateRulesTests extends RestTest
             .createSingleRule(ruleModel);
 
         RestRuleModel expectedRuleModel = createRuleModelWithDefaultValues();
-        expectedRuleModel.setActions(addActionContextParams(expectedRuleModel.getActions()));
         expectedRuleModel.setConditions(createVariousConditions());
         expectedRuleModel.setTriggers(List.of("inbound"));
         restClient.assertStatusCodeIs(CREATED);
@@ -427,7 +425,6 @@ public class CreateRulesTests extends RestTest
             .createSingleRule(ruleModel);
 
         RestRuleModel expectedRuleModel = createRuleModelWithDefaultValues();
-        expectedRuleModel.setActions(addActionContextParams(expectedRuleModel.getActions()));
         expectedRuleModel.setConditions(createCompositeCondition(null));
         expectedRuleModel.setTriggers(List.of("inbound"));
         restClient.assertStatusCodeIs(CREATED);

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetRulesTests.java
@@ -189,7 +189,6 @@ public class GetRulesTests extends RestTest
                 .createSingleRule(ruleModel);
 
         RestRuleModel expectedRuleModel = createRuleModelWithModifiedValues();
-        expectedRuleModel.setActions(addActionContextParams(expectedRuleModel.getActions()));
         expectedRuleModel.setTriggers(List.of("update"));
         expectedRuleModel.setConditions(createEmptyConditionModel());
 
@@ -212,7 +211,6 @@ public class GetRulesTests extends RestTest
                 .createSingleRule(ruleModel);
 
         RestRuleModel expectedRuleModel = createRuleModelWithDefaultValues();
-        expectedRuleModel.setActions(addActionContextParams(expectedRuleModel.getActions()));
         expectedRuleModel.setTriggers(List.of("inbound"));
         expectedRuleModel.setConditions(createEmptyConditionModel());
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
@@ -26,7 +26,6 @@
 package org.alfresco.rest.rules;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,16 +102,6 @@ public class RulesTestsUtils
         restActionModel.setActionDefinitionId("set-property-value");
         restActionModel.setParams(Map.of("aspect-name", "cm:audio"));
         return restActionModel;
-    }
-
-    public static List<RestActionBodyExecTemplateModel> addActionContextParams(List<RestActionBodyExecTemplateModel> inputActions)
-    {
-        inputActions.forEach(inputAction -> {
-            final Map<String, Serializable> params = new HashMap<>((Map<String, Serializable>) inputAction.getParams());
-            params.put("actionContext", "rule");
-            inputAction.setParams(params);
-        });
-        return inputActions;
     }
 
     public static RestActionBodyExecTemplateModel createCustomActionModel(String actionDefinitionId, Map<String, Serializable> params)

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
@@ -218,7 +218,9 @@ public class UpdateRulesTests extends RestTest
                                               .updateRule(rule.getId(), rule);
 
         restClient.assertStatusCodeIs(OK);
-        updatedRule.assertThat().field("name").is("Updated rule name");
+        updatedRule.assertThat().field("name").is("Updated rule name")
+                   .assertThat().field("actions.actionDefinitionId").is(List.of("copy"))
+                   .assertThat().field("actions.params").is(List.of(ImmutableMap.of("destination-folder", destination.getNodeRef())));
     }
 
     private RestRuleModel createAndSaveRule(String name)

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
@@ -36,6 +36,8 @@ import static org.springframework.http.HttpStatus.OK;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.alfresco.rest.RestTest;
 import org.alfresco.rest.model.RestActionBodyExecTemplateModel;
 import org.alfresco.rest.model.RestRuleModel;
@@ -196,6 +198,27 @@ public class UpdateRulesTests extends RestTest
                                               .updateRule(rule.getId(), updatedRuleModel);
 
         updatedRule.assertThat().field("isShared").isNotNull();
+    }
+
+    /** Check we can use the POST response to create the new rule. */
+    @Test (groups = { TestGroup.REST_API, TestGroup.RULES, TestGroup.SANITY })
+    public void updateCopyRuleWithResponseFromPOST()
+    {
+        FolderModel destination = dataContent.usingUser(user).usingSite(site).createFolder();
+
+        RestActionBodyExecTemplateModel copyAction = new RestActionBodyExecTemplateModel();
+        copyAction.setActionDefinitionId("copy");
+        copyAction.setParams(ImmutableMap.of("destination-folder", destination.getNodeRef()));
+        RestRuleModel rule = createAndSaveRule("Rule name", List.of(copyAction));
+
+        STEP("Try to update the rule.");
+        rule.setName("Updated rule name");
+        RestRuleModel updatedRule = restClient.authenticateUser(user).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                                              .include("isShared")
+                                              .updateRule(rule.getId(), rule);
+
+        restClient.assertStatusCodeIs(OK);
+        updatedRule.assertThat().field("name").is("Updated rule name");
     }
 
     private RestRuleModel createAndSaveRule(String name)

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/rules/Action.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/rules/Action.java
@@ -26,6 +26,8 @@
 
 package org.alfresco.rest.api.model.rules;
 
+import static org.alfresco.repo.action.access.ActionAccessRestriction.ACTION_CONTEXT_PARAM_NAME;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +62,9 @@ public class Action
         final Action.Builder builder = builder().actionDefinitionId(actionModel.getActionDefinitionName());
         if (actionModel.getParameterValues() != null)
         {
-            builder.params(new HashMap<>(actionModel.getParameterValues()));
+            Map<String, Serializable> params = new HashMap<>(actionModel.getParameterValues());
+            params.remove(ACTION_CONTEXT_PARAM_NAME);
+            builder.params(params);
         }
 
         return builder.create();


### PR DESCRIPTION
It will always be set to 'Rule' anyway.