### PR TITLE
ACS-3402: Add actual dependency, not just dependencyManagement

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -691,6 +691,16 @@
             <artifactId>camel-mock</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Netty non-transitive dependencies declared for depending projects usage in conjunction with Camel's other transitive netty dependencies -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-classes</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>


### PR DESCRIPTION
Record of non-transitive netty dependencies to be used in AMPs