### PR TITLE
ACS-3594 Add mechanism to deprecate modules within the Repo

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/module/DeprecatedModulesValidator.java
+++ b/repository/src/main/java/org/alfresco/repo/module/DeprecatedModulesValidator.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.alfresco.service.cmr.module.ModuleDetails;
 import org.alfresco.service.cmr.module.ModuleService;
+import org.springframework.extensions.surf.util.I18NUtil;
 
 /**
  * Halts the bootstrap process if a deprecated module is present.
@@ -42,7 +43,7 @@ import org.alfresco.service.cmr.module.ModuleService;
  */
 public class DeprecatedModulesValidator
 {
-    private static final String ERROR_MSG = "The following deprecated modules are installed: %s. Please remove these AMPs in order to continue.";
+    private static final String ERROR_MSG = "module.err.deprecated_modules";
     private final ModuleService moduleService;
     private final List<String> deprecatedModules;
 
@@ -70,6 +71,6 @@ public class DeprecatedModulesValidator
 
     private static void throwException(String foundDeprecatedModules)
     {
-        throw new IllegalStateException(String.format(ERROR_MSG, foundDeprecatedModules));
+        throw new IllegalStateException(I18NUtil.getMessage(ERROR_MSG, foundDeprecatedModules));
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/module/DeprecatedModulesValidator.java
+++ b/repository/src/main/java/org/alfresco/repo/module/DeprecatedModulesValidator.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.module;
+
+import static java.util.Optional.ofNullable;
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.joining;
+
+import java.util.List;
+
+import org.alfresco.service.cmr.module.ModuleDetails;
+import org.alfresco.service.cmr.module.ModuleService;
+
+/**
+ * Halts the bootstrap process if a deprecated module is present.
+ *
+ * @author Domenico Sibilio
+ * @since 7.3.0
+ */
+public class DeprecatedModulesValidator
+{
+    private static final String ERROR_MSG = "The following deprecated modules are installed: %s. Please remove these AMPs in order to continue.";
+    private final ModuleService moduleService;
+    private final List<String> deprecatedModules;
+
+    public DeprecatedModulesValidator(final ModuleService moduleService, final List<String> deprecatedModules)
+    {
+        this.moduleService = moduleService;
+        this.deprecatedModules = deprecatedModules;
+    }
+
+    public void onInit()
+    {
+        ofNullable(moduleService.getAllModules())
+            .map(this::getDeprecatedModules)
+            .filter(not(String::isBlank))
+            .ifPresent(DeprecatedModulesValidator::throwException);
+    }
+
+    private String getDeprecatedModules(List<ModuleDetails> modules)
+    {
+        return modules.stream()
+            .filter(module -> deprecatedModules.contains(module.getId()))
+            .map(module -> module.getTitle() + " " + module.getModuleVersionNumber())
+            .collect(joining(", "));
+    }
+
+    private static void throwException(String foundDeprecatedModules)
+    {
+        throw new IllegalStateException(String.format(ERROR_MSG, foundDeprecatedModules));
+    }
+}

--- a/repository/src/main/resources/alfresco/messages/module-messages.properties
+++ b/repository/src/main/resources/alfresco/messages/module-messages.properties
@@ -18,3 +18,4 @@ module.err.component_already_registered=A component named ''{0}'' has already be
 module.err.unable_to_open_module_properties=The module properties file ''{0}'' could not be read.
 module.err.component_in_missing_module=The component ''{0}'' belongs to a non-existent module ''{1}''.
 module.err.orphaned_components={0} module components were not considered for execution.
+module.err.deprecated_modules=The following deprecated modules are installed: {0}. Please remove these AMPs in order to continue.

--- a/repository/src/main/resources/alfresco/module-context.xml
+++ b/repository/src/main/resources/alfresco/module-context.xml
@@ -24,8 +24,17 @@
       <property name="tenantAdminService" ref="tenantAdminService" />
    </bean>
 
+   <bean id="deprecatedModulesValidator" class="org.alfresco.repo.module.DeprecatedModulesValidator" init-method="onInit">
+      <constructor-arg name="moduleService" ref="moduleService" />
+      <constructor-arg name="deprecatedModules">
+         <list>
+            <value>alfresco-saml-repo</value>
+         </list>
+      </constructor-arg>
+   </bean>
+
    <!-- Import of installed modules -->
-   
+
    <!--  bootstrap context first - for any resources shared between modules like the data list model -->
    <import resource="classpath*:alfresco/module/*/module-bootstrap-context.xml"/>
    <!--  the main context for each module -->

--- a/repository/src/test/java/org/alfresco/AllUnitTestsSuite.java
+++ b/repository/src/test/java/org/alfresco/AllUnitTestsSuite.java
@@ -67,6 +67,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.management.subsystems.CryptodocSwitchableApplicationContextFactoryTest.class,
     org.alfresco.repo.module.ModuleDetailsImplTest.class,
     org.alfresco.repo.module.ModuleVersionNumberTest.class,
+    org.alfresco.repo.module.DeprecatedModulesValidatorTest.class,
     org.alfresco.repo.node.integrity.IntegrityEventTest.class,
     org.alfresco.repo.policy.MTPolicyComponentTest.class,
     org.alfresco.repo.policy.PolicyComponentTest.class,

--- a/repository/src/test/java/org/alfresco/repo/module/DeprecatedModulesValidatorTest.java
+++ b/repository/src/test/java/org/alfresco/repo/module/DeprecatedModulesValidatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.module;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.alfresco.service.cmr.module.ModuleDetails;
+import org.alfresco.service.cmr.module.ModuleService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Test suite for the {@link DeprecatedModulesValidator} class.
+ *
+ * @author Domenico Sibilio
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DeprecatedModulesValidatorTest
+{
+
+    private static final String DEPRECATED_MODULE_1 = "deprecated-module-1";
+    private static final String DEPRECATED_MODULE_2 = "deprecated-module-2";
+    private static final String VALID_MODULE = "valid-module";
+    private static final List<String> DEPRECATED_MODULES = List.of(DEPRECATED_MODULE_1, DEPRECATED_MODULE_2);
+    @Mock
+    private ModuleService moduleService;
+    @Mock
+    private ModuleDetails moduleDetails;
+    private DeprecatedModulesValidator deprecatedModulesValidator;
+
+    @Before
+    public void setUp()
+    {
+        deprecatedModulesValidator = new DeprecatedModulesValidator(moduleService, DEPRECATED_MODULES);
+    }
+
+    @Test
+    public void shouldDoNothingWhenNoModulesAreFound()
+    {
+        when(moduleService.getAllModules()).thenReturn(null);
+
+        deprecatedModulesValidator.onInit();
+
+        verify(moduleService).getAllModules();
+    }
+
+    @Test
+    public void shouldDoNothingWhenNoDeprecatedModulesAreFound()
+    {
+        when(moduleService.getAllModules()).thenReturn(List.of(moduleDetails));
+        when(moduleDetails.getId()).thenReturn(VALID_MODULE);
+
+        deprecatedModulesValidator.onInit();
+
+        verify(moduleService).getAllModules();
+        verify(moduleDetails).getId();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionWhenADeprecatedModuleIsFound()
+    {
+        when(moduleService.getAllModules()).thenReturn(List.of(moduleDetails));
+        when(moduleDetails.getId()).thenReturn(DEPRECATED_MODULE_1);
+
+        deprecatedModulesValidator.onInit();
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenMultipleDeprecatedModulesAreFound()
+    {
+        when(moduleService.getAllModules()).thenReturn(List.of(moduleDetails, moduleDetails));
+        when(moduleDetails.getId()).thenReturn(DEPRECATED_MODULE_1)
+            .thenReturn(DEPRECATED_MODULE_2);
+
+        assertThrows("IllegalStateException should be thrown.",
+            IllegalStateException.class,
+            () -> deprecatedModulesValidator.onInit());
+
+        verify(moduleService).getAllModules();
+        verify(moduleDetails, times(2)).getId();
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenBothValidAndDeprecatedModulesAreFound()
+    {
+        when(moduleService.getAllModules()).thenReturn(List.of(moduleDetails, moduleDetails));
+        when(moduleDetails.getId()).thenReturn(VALID_MODULE)
+            .thenReturn(DEPRECATED_MODULE_2);
+
+        assertThrows("IllegalStateException should be thrown.",
+            IllegalStateException.class,
+            () -> deprecatedModulesValidator.onInit());
+
+        verify(moduleService).getAllModules();
+        verify(moduleDetails, times(2)).getId();
+    }
+
+}


### PR DESCRIPTION
Has been tested manually:
- without SAML ✔️
- with SAML (correctly halts the bootstrap while presenting an exception such as `java.lang.IllegalStateException: The following deprecated modules are installed: Alfresco SAML Repository AMP Module 1.2.2. Please remove these AMPs in order to continue.`) ✔️ 

It's supposed to be extensible and will work with future module deprecations as well, featuring composite error messages such as e.g.: `The following deprecated modules are installed: Alfresco SAML Repository AMP Module 1.2.2, Alfresco Office Services Module 1.4.2. Please remove these AMPs in order to continue.`  _(just an example, AOS is not deprecated)_. 