### PR TITLE
ACS-3630 E2E tests for creating and updating rules with private actions.

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/actions/access/V1AdminAccessRestrictionTest.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/actions/access/V1AdminAccessRestrictionTest.java
@@ -1,20 +1,19 @@
 package org.alfresco.rest.actions.access;
 
-import org.alfresco.rest.RestTest;
-import org.alfresco.utility.model.FolderModel;
-import org.alfresco.utility.model.UserModel;
-import org.springframework.http.HttpStatus;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import org.alfresco.rest.core.RestWrapper;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import static org.alfresco.rest.actions.access.AccessRestrictionUtil.ERROR_MESSAGE_ACCESS_RESTRICTED;
 import static org.alfresco.rest.actions.access.AccessRestrictionUtil.MAIL_ACTION;
 import static org.alfresco.rest.actions.access.AccessRestrictionUtil.createMailParameters;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+
+import org.alfresco.rest.RestTest;
+import org.alfresco.rest.core.RestWrapper;
+import org.alfresco.utility.model.FolderModel;
+import org.alfresco.utility.model.UserModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class V1AdminAccessRestrictionTest extends RestTest {
 
@@ -45,7 +44,7 @@ public class V1AdminAccessRestrictionTest extends RestTest {
                           .executeAction(MAIL_ACTION, testFolder, createMailParameters(adminUser, testUser));
 
         restClient.onResponse()
-                .assertThat().statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .assertThat().statusCode(HttpStatus.FORBIDDEN.value())
                 .assertThat().body("entry.id", nullValue());
         restClient.assertLastError().containsSummary(ERROR_MESSAGE_ACCESS_RESTRICTED);
     }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -27,7 +27,20 @@ package org.alfresco.rest.rules;
 
 import static java.util.stream.Collectors.toList;
 
-import static org.alfresco.rest.rules.RulesTestsUtils.*;
+import static org.alfresco.rest.actions.access.AccessRestrictionUtil.ERROR_MESSAGE_ACCESS_RESTRICTED;
+import static org.alfresco.rest.rules.RulesTestsUtils.ID;
+import static org.alfresco.rest.rules.RulesTestsUtils.INVERTED;
+import static org.alfresco.rest.rules.RulesTestsUtils.IS_SHARED;
+import static org.alfresco.rest.rules.RulesTestsUtils.RULE_NAME_DEFAULT;
+import static org.alfresco.rest.rules.RulesTestsUtils.createCompositeCondition;
+import static org.alfresco.rest.rules.RulesTestsUtils.createDefaultActionModel;
+import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModel;
+import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModelWithDefaultValues;
+import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModelWithModifiedValues;
+import static org.alfresco.rest.rules.RulesTestsUtils.createRuleWithPrivateAction;
+import static org.alfresco.rest.rules.RulesTestsUtils.createSimpleCondition;
+import static org.alfresco.rest.rules.RulesTestsUtils.createVariousActions;
+import static org.alfresco.rest.rules.RulesTestsUtils.createVariousConditions;
 import static org.alfresco.utility.constants.UserRole.SiteCollaborator;
 import static org.alfresco.utility.constants.UserRole.SiteConsumer;
 import static org.alfresco.utility.constants.UserRole.SiteContributor;
@@ -41,8 +54,6 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
-import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -375,6 +386,27 @@ public class CreateRulesTests extends RestTest
         restClient.assertStatusCodeIs(CREATED);
         rule.assertThat().isEqualTo(expectedRuleModel, ID, IS_SHARED)
                 .assertThat().field(IS_SHARED).isNull();
+    }
+
+    /** Check that a normal user cannot create rules that use private actions. */
+    @Test
+    public void createRuleWithActions_userCannotUsePrivateAction()
+    {
+        restClient.authenticateUser(user).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                  .createSingleRule(createRuleWithPrivateAction());
+
+        restClient.assertStatusCodeIs(FORBIDDEN)
+                  .assertLastError().containsSummary(ERROR_MESSAGE_ACCESS_RESTRICTED);
+    }
+
+    /** Check that an administrator can create rules that use private actions. */
+    @Test
+    public void createRuleWithActions_adminCanUsePrivateAction()
+    {
+        restClient.authenticateUser(dataUser.getAdminUser()).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                  .createSingleRule(createRuleWithPrivateAction());
+
+        restClient.assertStatusCodeIs(CREATED);
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
@@ -162,6 +162,16 @@ public class RulesTestsUtils
         return ruleModel;
     }
 
+    public static RestRuleModel createRuleWithPrivateAction()
+    {
+        RestActionBodyExecTemplateModel mailAction = new RestActionBodyExecTemplateModel();
+        mailAction.setActionDefinitionId("mail");
+        mailAction.setParams(Map.of("to", "test@example.com"));
+        RestRuleModel ruleModel = createRuleModelWithDefaultValues();
+        ruleModel.setActions(Arrays.asList(mailAction));
+        return ruleModel;
+    }
+
     public static RestSimpleConditionDefinitionModel createSimpleCondition(String field, String comparator, String parameter)
     {
         RestSimpleConditionDefinitionModel simpleCondition = new RestSimpleConditionDefinitionModel();

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.rest.rules;
 
+import static org.alfresco.rest.actions.access.AccessRestrictionUtil.ERROR_MESSAGE_ACCESS_RESTRICTED;
 import static org.alfresco.rest.rules.RulesTestsUtils.ID;
 import static org.alfresco.rest.rules.RulesTestsUtils.INBOUND;
 import static org.alfresco.rest.rules.RulesTestsUtils.INVERTED;
@@ -36,8 +37,8 @@ import static org.alfresco.rest.rules.RulesTestsUtils.createCompositeCondition;
 import static org.alfresco.rest.rules.RulesTestsUtils.createCustomActionModel;
 import static org.alfresco.rest.rules.RulesTestsUtils.createDefaultActionModel;
 import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModel;
-import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModelWithDefaultValues;
 import static org.alfresco.rest.rules.RulesTestsUtils.createRuleModelWithModifiedValues;
+import static org.alfresco.rest.rules.RulesTestsUtils.createRuleWithPrivateAction;
 import static org.alfresco.rest.rules.RulesTestsUtils.createSimpleCondition;
 import static org.alfresco.rest.rules.RulesTestsUtils.createVariousConditions;
 import static org.alfresco.utility.constants.UserRole.SiteCollaborator;
@@ -526,6 +527,40 @@ public class UpdateRulesTests extends RestTest
 
         restClient.assertStatusCodeIs(INTERNAL_SERVER_ERROR);
         restClient.assertLastError().containsSummary("Namespace prefix dummy is not mapped to a namespace URI");
+    }
+
+    /** Check that a normal user cannot create rules that use private actions. */
+    @Test
+    public void updateRuleWithActions_userCannotUsePrivateAction()
+    {
+        STEP("Using admin create a rule with a private action.");
+        RestRuleModel rule = restClient.authenticateUser(dataUser.getAdminUser()).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                                       .createSingleRule(createRuleWithPrivateAction());
+
+        STEP("Try to update the rule with a normal user.");
+        rule.setName("Updated name");
+        restClient.authenticateUser(user).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                  .updateRule(rule.getId(), rule);
+
+        restClient.assertStatusCodeIs(FORBIDDEN)
+                  .assertLastError().containsSummary(ERROR_MESSAGE_ACCESS_RESTRICTED);
+    }
+
+    /** Check that an administrator can create rules that use private actions. */
+    @Test
+    public void updateRuleWithActions_adminCanUsePrivateAction()
+    {
+        STEP("Using admin create a rule with a private action.");
+        RestRuleModel rule = restClient.authenticateUser(dataUser.getAdminUser()).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                                       .createSingleRule(createRuleWithPrivateAction());
+
+        STEP("Try to update the rule with the admin user.");
+        rule.setName("Updated name");
+        RestRuleModel updatedRule = restClient.authenticateUser(dataUser.getAdminUser()).withCoreAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+                                              .updateRule(rule.getId(), rule);
+
+        restClient.assertStatusCodeIs(OK);
+        updatedRule.assertThat().field("name").is("Updated name");
     }
 
     private RestRuleModel createAndSaveRule(String name)

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -155,6 +155,7 @@
                 <entry key="org.alfresco.rest.framework.core.exceptions.PermissionDeniedException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_FORBIDDEN}" />
                 <entry key="org.alfresco.repo.security.authority.UnknownAuthorityException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_NOT_FOUND}" />
                 <entry key="org.alfresco.repo.security.permissions.AccessDeniedException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_FORBIDDEN}" />
+                <entry key="org.alfresco.repo.action.access.ActionAccessException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_FORBIDDEN}" />
                 <entry key="org.alfresco.rest.framework.core.exceptions.UnsupportedResourceOperationException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_METHOD_NOT_ALLOWED}" />
                 <entry key="org.alfresco.rest.framework.core.exceptions.ConstraintViolatedException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_CONFLICT}" />
                 <entry key="org.alfresco.service.cmr.lock.NodeLockedException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_CONFLICT}" />


### PR DESCRIPTION
Ensure that 403 Forbidden is returned rather than 500 Internal Server Error.