### PR TITLE
ACS-3620: E2Es - API for manual triggering rules on a folder

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/ExecuteRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/ExecuteRulesTests.java
@@ -80,7 +80,7 @@ public class ExecuteRulesTests extends RestTest
         site = dataSite.usingUser(user).createPublicRandomSite();
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void setUp()
     {
         STEP("Create parent folder, rule folder and file in it");


### PR DESCRIPTION
- adding "alwaysRun = true" to @BeforeMethod due to failing acs-packaging "REST API TAS tests with AIMS"