### PR TITLE
ACS-3635 Alfresco WebDAV CSRF - allowInsecurePOSTMethod flag

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
@@ -123,7 +123,7 @@ public class WebDAVServlet extends HttpServlet
 
         if (request.getMethod().equals("POST") && !initParams.isPostMethodAllowed())
         {
-            logger.error("POST method not allowed!");
+            logger.error("POST method is not allowed!");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             return;
         }

--- a/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
@@ -121,6 +121,13 @@ public class WebDAVServlet extends HttpServlet
             startTime = System.currentTimeMillis();
         }
 
+        if (request.getMethod().equals("POST") && !initParams.isPostMethodAllowed())
+        {
+            logger.error("POST method not allowed!");
+            response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return;
+        }
+
         FileFilterMode.setClient(Client.webdav);
 
         try
@@ -407,6 +414,7 @@ public class WebDAVServlet extends HttpServlet
         private String storeName;
         private String rootPath;
         private String urlPathPrefix;
+        private boolean postMethodAllowed = false;
         
         public boolean getEnabled()
         {
@@ -481,6 +489,16 @@ public class WebDAVServlet extends HttpServlet
         public void setUrlPathPrefix(String urlPathPrefix)
         {
             this.urlPathPrefix = urlPathPrefix;
+        }
+
+        public boolean isPostMethodAllowed()
+        {
+            return postMethodAllowed;
+        }
+
+        public void setPostMethodAllowed(boolean postMethodAllowed)
+        {
+            this.postMethodAllowed = postMethodAllowed;
         }
     }
 }

--- a/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
@@ -121,7 +121,7 @@ public class WebDAVServlet extends HttpServlet
             startTime = System.currentTimeMillis();
         }
 
-        if (request.getMethod().equals("POST") && !initParams.isPostMethodAllowed())
+        if (request.getMethod().equals("POST") && !initParams.allowInsecurePOSTMethod())
         {
             logger.error("POST method is not allowed!");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
@@ -414,7 +414,7 @@ public class WebDAVServlet extends HttpServlet
         private String storeName;
         private String rootPath;
         private String urlPathPrefix;
-        private boolean postMethodAllowed = false;
+        private boolean allowInsecurePOSTMethod = false;
         
         public boolean getEnabled()
         {
@@ -491,14 +491,14 @@ public class WebDAVServlet extends HttpServlet
             this.urlPathPrefix = urlPathPrefix;
         }
 
-        public boolean isPostMethodAllowed()
+        public boolean allowInsecurePOSTMethod()
         {
-            return postMethodAllowed;
+            return allowInsecurePOSTMethod;
         }
 
-        public void setPostMethodAllowed(boolean postMethodAllowed)
+        public void setAllowInsecurePOSTMethod(boolean allowInsecurePOSTMethod)
         {
-            this.postMethodAllowed = postMethodAllowed;
+            this.allowInsecurePOSTMethod = allowInsecurePOSTMethod;
         }
     }
 }

--- a/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/webdav/WebDAVServlet.java
@@ -121,7 +121,7 @@ public class WebDAVServlet extends HttpServlet
             startTime = System.currentTimeMillis();
         }
 
-        if (request.getMethod().equals("POST") && !initParams.allowInsecurePOSTMethod())
+        if (request.getMethod().equals(WebDAV.METHOD_POST) && !initParams.allowInsecurePOSTMethod())
         {
             logger.error("POST method is not allowed!");
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);

--- a/remote-api/src/main/resources/alfresco/remote-api-context.xml
+++ b/remote-api/src/main/resources/alfresco/remote-api-context.xml
@@ -8,6 +8,7 @@
         <property name="enabled" value="${system.webdav.servlet.enabled}" />
         <property name="storeName" value="${system.webdav.storeName}" />
         <property name="rootPath" value="${system.webdav.rootPath}" />
+        <property name="postMethodAllowed" value="${system.webdav.postMethodAllowed}" />
     </bean>
     
     <bean id="webDAVLockService" class="org.alfresco.repo.webdav.WebDAVLockServiceImpl">

--- a/remote-api/src/main/resources/alfresco/remote-api-context.xml
+++ b/remote-api/src/main/resources/alfresco/remote-api-context.xml
@@ -8,7 +8,7 @@
         <property name="enabled" value="${system.webdav.servlet.enabled}" />
         <property name="storeName" value="${system.webdav.storeName}" />
         <property name="rootPath" value="${system.webdav.rootPath}" />
-        <property name="postMethodAllowed" value="${system.webdav.postMethodAllowed}" />
+        <property name="allowInsecurePOSTMethod" value="${system.webdav.allowInsecurePOSTMethod}" />
     </bean>
     
     <bean id="webDAVLockService" class="org.alfresco.repo.webdav.WebDAVLockServiceImpl">

--- a/remote-api/src/test/java/org/alfresco/AppContextExtraTestSuite.java
+++ b/remote-api/src/test/java/org/alfresco/AppContextExtraTestSuite.java
@@ -99,6 +99,7 @@ import org.junit.runners.Suite;
     org.alfresco.repo.webdav.WebDAVMethodTest.class,
     org.alfresco.repo.webdav.PutMethodTest.class,
     org.alfresco.repo.webdav.WebDAVonContentUpdateTest.class,
+    org.alfresco.repo.webdav.WebDAVInsecurePostMethodTest.class,
 
     // [classpath:test-rest-context.xml]
     org.alfresco.rest.framework.tests.core.ExceptionResolverTests.class,

--- a/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
@@ -67,74 +67,59 @@ public class WebDAVInsecurePostMethodTest
         davServlet = new WebDAVServlet();
         ReflectionTestUtils.setField(davServlet, "initParams", webDAVInitParameters);
         ReflectionTestUtils.setField(davServlet, "m_davMethods", davMethods);
-        doReturn(true).when(webDAVInitParameters).getEnabled();
+        when(webDAVInitParameters.getEnabled()).thenReturn(true);
     }
 
 
     @Test
     public void shouldReturn405StatusForPostMethodWhenNotAllowed() throws ServletException, IOException
     {
-        // given
         prepareRequest("POST");
         when(webDAVInitParameters.allowInsecurePOSTMethod()).thenReturn(false);
 
-        // when
         davServlet.service(request, response);
 
-        // then
         verify(response).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     @Test
     public void shouldNotReturn405StatusForPostMethodWhenAllowed() throws ServletException, IOException
     {
-        // given
         prepareRequest("POST");
         when(webDAVInitParameters.allowInsecurePOSTMethod()).thenReturn(true);
 
-        // when
         davServlet.service(request, response);
 
-        // then
         verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     @Test
     public void shouldNotReturn405StatusForPutMethod() throws ServletException, IOException
     {
-        // given
         prepareRequest("PUT");
 
-        // when
         davServlet.service(request, response);
 
-        // then
         verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     @Test
     public void shouldNotReturn405StatusForGetMethod() throws ServletException, IOException
     {
-        // given
         prepareRequest("GET");
 
-        // when
         davServlet.service(request, response);
 
-        // then
         verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
     @Test
     public void shouldNotReturn405StatusForDeleteMethod() throws ServletException, IOException
     {
-        // given
         prepareRequest("DELETE");
 
-        // when
         davServlet.service(request, response);
 
-        // then
         verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 

--- a/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
@@ -72,7 +72,7 @@ public class WebDAVInsecurePostMethodTest
 
 
     @Test
-    public void shouldReturn405StatusForPostMethodWhenNotAllowed() throws ServletException, IOException
+    public void shouldReturn405StatusWhenPostMethodIsNotAllowed() throws ServletException, IOException
     {
         prepareRequest("POST");
         when(webDAVInitParameters.allowInsecurePOSTMethod()).thenReturn(false);
@@ -83,7 +83,7 @@ public class WebDAVInsecurePostMethodTest
     }
 
     @Test
-    public void shouldNotReturn405StatusForPostMethodWhenAllowed() throws ServletException, IOException
+    public void shouldNotReturn405StatusWhenPostMethodIsAllowed() throws ServletException, IOException
     {
         prepareRequest("POST");
         when(webDAVInitParameters.allowInsecurePOSTMethod()).thenReturn(true);

--- a/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
@@ -1,0 +1,140 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.repo.webdav;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.alfresco.repo.webdav.WebDAVServlet.WebDAVInitParameters;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Tests for the allowing insecure POST method flag.
+ *
+ * @see  WebDAVInitParameters
+ * @author Aleksandra Onych
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WebDAVInsecurePostMethodTest
+{
+    private WebDAVServlet davServlet;
+
+    private @Mock WebDAVInitParameters webDAVInitParameters;
+
+    private @Mock HttpServletRequest request;
+
+    private @Mock HttpServletResponse response;
+
+    @Before
+    public void setUp()
+    {
+        davServlet = new WebDAVServlet();
+        ReflectionTestUtils.setField(davServlet, "initParams", webDAVInitParameters);
+        doReturn(true).when(webDAVInitParameters).getEnabled();
+    }
+
+
+    @Test
+    public void shouldReturn405StatusForPostMethodWhenNotAllowed() throws ServletException, IOException
+    {
+        // given
+        when(webDAVInitParameters.isPostMethodAllowed()).thenReturn(false);
+        when(request.getMethod()).thenReturn("POST");
+
+        // when
+        davServlet.service(request, response);
+
+        // then
+        verify(response).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    public void shouldNotReturn405StatusForPostMethodWhenAllowed() throws ServletException, IOException
+    {
+        // given
+        when(webDAVInitParameters.isPostMethodAllowed()).thenReturn(true);
+        when(request.getMethod()).thenReturn("POST");
+
+        // when
+        davServlet.service(request, response);
+
+        // then
+        verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    public void shouldNotReturn405StatusForPutMethod() throws ServletException, IOException
+    {
+        // given
+        when(request.getMethod()).thenReturn("PUT");
+
+        // when
+        davServlet.service(request, response);
+
+        // then
+        verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    public void shouldNotReturn405StatusForGetMethod() throws ServletException, IOException
+    {
+        // given
+        when(request.getMethod()).thenReturn("GET");
+
+        // when
+        davServlet.service(request, response);
+
+        // then
+        verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    public void shouldNotReturn405StatusForDeleteMethod() throws ServletException, IOException
+    {
+        // given
+        when(request.getMethod()).thenReturn("DELETE");
+
+        // when
+        davServlet.service(request, response);
+
+        // then
+        verify(response, never()).sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    }
+}

--- a/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/webdav/WebDAVInsecurePostMethodTest.java
@@ -74,7 +74,7 @@ public class WebDAVInsecurePostMethodTest
     @Test
     public void shouldReturn405StatusWhenPostMethodIsNotAllowed() throws ServletException, IOException
     {
-        prepareRequest("POST");
+        prepareRequest(WebDAV.METHOD_POST);
         when(webDAVInitParameters.allowInsecurePOSTMethod()).thenReturn(false);
 
         davServlet.service(request, response);
@@ -85,7 +85,7 @@ public class WebDAVInsecurePostMethodTest
     @Test
     public void shouldNotReturn405StatusWhenPostMethodIsAllowed() throws ServletException, IOException
     {
-        prepareRequest("POST");
+        prepareRequest(WebDAV.METHOD_POST);
         when(webDAVInitParameters.allowInsecurePOSTMethod()).thenReturn(true);
 
         davServlet.service(request, response);
@@ -96,7 +96,7 @@ public class WebDAVInsecurePostMethodTest
     @Test
     public void shouldNotReturn405StatusForPutMethod() throws ServletException, IOException
     {
-        prepareRequest("PUT");
+        prepareRequest(WebDAV.METHOD_PUT);
 
         davServlet.service(request, response);
 
@@ -106,7 +106,7 @@ public class WebDAVInsecurePostMethodTest
     @Test
     public void shouldNotReturn405StatusForGetMethod() throws ServletException, IOException
     {
-        prepareRequest("GET");
+        prepareRequest(WebDAV.METHOD_GET);
 
         davServlet.service(request, response);
 
@@ -116,7 +116,7 @@ public class WebDAVInsecurePostMethodTest
     @Test
     public void shouldNotReturn405StatusForDeleteMethod() throws ServletException, IOException
     {
-        prepareRequest("DELETE");
+        prepareRequest(WebDAV.METHOD_DELETE);
 
         davServlet.service(request, response);
 

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -53,6 +53,7 @@ system.webdav.servlet.enabled=true
 system.webdav.url.path.prefix=
 system.webdav.storeName=${protocols.storeName}
 system.webdav.rootPath=${protocols.rootPath}
+system.webdav.postMethodAllowed=false
 # File name patterns that trigger rename shuffle detection
 # pattern is used by move - tested against full path after it has been lower cased.
 system.webdav.renameShufflePattern=(.*/\\..*)|(.*[a-f0-9]{8}+$)|(.*\\.tmp$)|(.*atmp[0-9]+$)|(.*\\.wbk$)|(.*\\.bak$)|(.*\\~$)|(.*backup.*\\.do[ct]{1}[x]?[m]?$)|(.*\\.sb\\-\\w{8}\\-\\w{6}$)

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -53,7 +53,7 @@ system.webdav.servlet.enabled=true
 system.webdav.url.path.prefix=
 system.webdav.storeName=${protocols.storeName}
 system.webdav.rootPath=${protocols.rootPath}
-system.webdav.postMethodAllowed=false
+system.webdav.allowInsecurePOSTMethod=false
 # File name patterns that trigger rename shuffle detection
 # pattern is used by move - tested against full path after it has been lower cased.
 system.webdav.renameShufflePattern=(.*/\\..*)|(.*[a-f0-9]{8}+$)|(.*\\.tmp$)|(.*atmp[0-9]+$)|(.*\\.wbk$)|(.*\\.bak$)|(.*\\~$)|(.*backup.*\\.do[ct]{1}[x]?[m]?$)|(.*\\.sb\\-\\w{8}\\-\\w{6}$)


### PR DESCRIPTION
Adding allowInsecurePOSTMethod flag for webDAV. When the POST method is disable, it returns 405 status code.