### PR TITLE
ACS-3652 Node access validation for Rule Action Parameters

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,6 +2,43 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-community-repo-packaging</artifactId>
     <name>Alfresco Community Repo Packaging</name>
+<!--    <dependencies>-->
+<!--        <dependency>-->
+<!--            <groupId>org.springframework</groupId>-->
+<!--            <artifactId>spring-beans</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.slf4j</groupId>-->
+<!--            <artifactId>slf4j-api</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.springframework</groupId>-->
+<!--            <artifactId>spring-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.alfresco.tas</groupId>-->
+<!--            <artifactId>restapi</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>io.rest-assured</groupId>-->
+<!--            <artifactId>rest-assured</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.glassfish</groupId>-->
+<!--            <artifactId>jakarta.json</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.springframework</groupId>-->
+<!--            <artifactId>spring-test</artifactId>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+<!--    </dependencies>-->
     <packaging>pom</packaging>
 
     <parent>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,43 +2,6 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-community-repo-packaging</artifactId>
     <name>Alfresco Community Repo Packaging</name>
-<!--    <dependencies>-->
-<!--        <dependency>-->
-<!--            <groupId>org.springframework</groupId>-->
-<!--            <artifactId>spring-beans</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.slf4j</groupId>-->
-<!--            <artifactId>slf4j-api</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.springframework</groupId>-->
-<!--            <artifactId>spring-test</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.alfresco.tas</groupId>-->
-<!--            <artifactId>restapi</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>io.rest-assured</groupId>-->
-<!--            <artifactId>rest-assured</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.glassfish</groupId>-->
-<!--            <artifactId>jakarta.json</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.springframework</groupId>-->
-<!--            <artifactId>spring-test</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
-<!--    </dependencies>-->
     <packaging>pom</packaging>
 
     <parent>

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -26,15 +26,14 @@
 package org.alfresco.rest.rules;
 
 import static java.util.stream.Collectors.toList;
-
 import static org.alfresco.rest.actions.access.AccessRestrictionUtil.ERROR_MESSAGE_ACCESS_RESTRICTED;
 import static org.alfresco.rest.actions.access.AccessRestrictionUtil.MAIL_ACTION;
+import static org.alfresco.rest.rules.RulesTestsUtils.CHECKIN_ACTION;
 import static org.alfresco.rest.rules.RulesTestsUtils.ID;
 import static org.alfresco.rest.rules.RulesTestsUtils.INVERTED;
 import static org.alfresco.rest.rules.RulesTestsUtils.IS_SHARED;
 import static org.alfresco.rest.rules.RulesTestsUtils.RULE_NAME_DEFAULT;
-import static org.alfresco.rest.rules.RulesTestsUtils.RULE_SCRIPT_ID;
-import static org.alfresco.rest.rules.RulesTestsUtils.RULE_SCRIPT_PARAM_ID;
+import static org.alfresco.rest.rules.RulesTestsUtils.TEMPLATE_PARAM;
 import static org.alfresco.utility.constants.UserRole.SiteCollaborator;
 import static org.alfresco.utility.constants.UserRole.SiteConsumer;
 import static org.alfresco.utility.constants.UserRole.SiteContributor;
@@ -58,6 +57,7 @@ import java.util.stream.IntStream;
 
 import org.alfresco.rest.RestTest;
 import org.alfresco.rest.model.RestActionBodyExecTemplateModel;
+import org.alfresco.rest.model.RestActionConstraintModel;
 import org.alfresco.rest.model.RestActionDefinitionModel;
 import org.alfresco.rest.model.RestCompositeConditionDefinitionModel;
 import org.alfresco.rest.model.RestParameterDefinitionModel;
@@ -388,6 +388,23 @@ public class CreateRulesTests extends RestTest
                 .assertThat().field(IS_SHARED).isNull();
     }
 
+    /**
+     * Check we can create a rule with check in action with empty description parameter.
+     */
+    @Test(groups = {TestGroup.REST_API, TestGroup.RULES})
+    public void createRuleWithCheckInActionAndEmptyCheckInDescription()
+    {
+        final RestRuleModel ruleModel = rulesUtils.createRuleModelWithDefaultValues();
+        final RestActionBodyExecTemplateModel checkinAction = new RestActionBodyExecTemplateModel();
+        checkinAction.setActionDefinitionId(CHECKIN_ACTION);
+        checkinAction.setParams(Map.of("description", ""));
+        ruleModel.setActions(Arrays.asList(checkinAction));
+
+        restClient.authenticateUser(user).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet().createSingleRule(ruleModel);
+
+        restClient.assertStatusCodeIs(CREATED);
+    }
+
     /** Check that a normal user cannot create rules that use private actions. */
     @Test
     public void createRuleWithActions_userCannotUsePrivateAction()
@@ -409,7 +426,9 @@ public class CreateRulesTests extends RestTest
         restClient.assertStatusCodeIs(CREATED);
     }
 
-    /** Check that an administrator can create rules that use private actions. */
+    /**
+     * Check that an administrator can create rules with email (private) action with reference to an email template.
+     */
     @Test
     public void createRuleWithActions_adminCanUseMailActionWithTemplate()
     {
@@ -422,16 +441,20 @@ public class CreateRulesTests extends RestTest
         params.put("from", sender.getEmailAddress());
         params.put("to", recipient.getEmailAddress());
         params.put("subject", "Test");
-        final RestActionDefinitionModel actionDef = restClient.authenticateUser(user).withCoreAPI().usingActions().getActionDefinitionById(RULE_SCRIPT_ID);
-        final RestParameterDefinitionModel
-                paramDef = actionDef.getParameterDefinitions().stream().filter(param -> param.getName().equals(RULE_SCRIPT_PARAM_ID)).findFirst().get();
-        final String templateScriptRef = paramDef.getParameterConstraintName();
-        params.put("template", templateScriptRef);
+        final RestActionDefinitionModel actionDef =
+                restClient.authenticateUser(user).withCoreAPI().usingActions().getActionDefinitionById(MAIL_ACTION);
+        final RestParameterDefinitionModel paramDef =
+                actionDef.getParameterDefinitions().stream().filter(param -> param.getName().equals(TEMPLATE_PARAM)).findFirst().get();
+        final String constraintName = paramDef.getParameterConstraintName();
+        final RestActionConstraintModel constraint =
+                restClient.authenticateUser(user).withCoreAPI().usingActions().getActionConstraintByName(constraintName);
+        String templateScriptRef = constraint.getConstraintValues().stream().findFirst().get().getValue();
+        params.put(TEMPLATE_PARAM, templateScriptRef);
         mailAction.setParams(params);
         ruleModel.setActions(Arrays.asList(mailAction));
 
         restClient.authenticateUser(dataUser.getAdminUser()).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet()
-                .createSingleRule(rulesUtils.createRuleWithPrivateAction());
+                .createSingleRule(ruleModel);
 
         restClient.assertStatusCodeIs(CREATED);
     }
@@ -666,7 +689,7 @@ public class CreateRulesTests extends RestTest
         params.put("to", recipient.getEmailAddress());
         params.put("subject", "Test");
         final String mailTemplate = "non-existing-node-id";
-        params.put("template", mailTemplate);
+        params.put(TEMPLATE_PARAM, mailTemplate);
         mailAction.setParams(params);
         ruleModel.setActions(Arrays.asList(mailAction));
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -368,10 +368,10 @@ public class CreateRulesTests extends RestTest
         final UserModel admin = dataUser.getAdminUser();
 
         final RestRuleModel rule = restClient.authenticateUser(admin).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet()
-                .createSingleRule(rulesUtils.createVariousActions());
+                .createSingleRule(rulesUtils.createRuleWithVariousActions());
 
         RestRuleModel expectedRuleModel = rulesUtils.createRuleModelWithDefaultValues();
-        expectedRuleModel.setActions(rulesUtils.createVariousActions().getActions());
+        expectedRuleModel.setActions(rulesUtils.createRuleWithVariousActions().getActions());
         expectedRuleModel.setTriggers(List.of("inbound"));
 
         restClient.assertStatusCodeIs(CREATED);

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/CreateRulesTests.java
@@ -585,8 +585,8 @@ public class CreateRulesTests extends RestTest
         restClient.authenticateUser(user).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet()
                   .createSingleRule(ruleModel);
 
-        restClient.assertStatusCodeIs(NOT_FOUND);
-        restClient.assertLastError().containsSummary("The entity with id: " + privateFolder.getNodeRef() + " was not found");
+        restClient.assertStatusCodeIs(FORBIDDEN);
+        restClient.assertLastError().containsSummary("No proper permissions for node: " + privateFolder.getNodeRef());
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetRulesTests.java
@@ -314,9 +314,11 @@ public class GetRulesTests extends RestTest
     public void getRuleActions()
     {
         STEP("Create a rule with a few actions");
-        FolderModel folder = dataContent.usingUser(user).usingSite(site).createFolder();
-        final RestRuleModel rule = restClient.authenticateUser(user).withPrivateAPI().usingNode(folder).usingDefaultRuleSet()
-                .createSingleRule(rulesUtils.createVariousActions());
+        final FolderModel folder = dataContent.usingUser(user).usingSite(site).createFolder();
+        final RestRuleModel ruleWithVariousActions = rulesUtils.createRuleWithVariousActions();
+        final UserModel admin = dataUser.getAdminUser();
+        final RestRuleModel rule = restClient.authenticateUser(admin).withPrivateAPI().usingNode(folder).usingDefaultRuleSet()
+                .createSingleRule(ruleWithVariousActions);
 
         STEP("Retrieve the created rule via the GET endpoint");
         final RestRuleModel getRuleBody = restClient.authenticateUser(user).withPrivateAPI().usingNode(folder).usingDefaultRuleSet().getSingleRule(rule.getId());

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
@@ -67,6 +67,7 @@ public class RulesTestsUtils implements InitializingBean
     static final String RULE_SCRIPT_ID = "script";
     static final String RULE_SCRIPT_PARAM_ID = "script-ref";
     static final String RULE_ERROR_SCRIPT_LABEL = "Start Pooled Review and Approve Workflow";
+    public static final String CHECKIN_ACTION = "check-in";
     static final String INBOUND = "inbound";
     static final String UPDATE = "update";
     static final String OUTBOUND = "outbound";
@@ -77,6 +78,7 @@ public class RulesTestsUtils implements InitializingBean
     static final String IS_SHARED = "isShared";
     static final String AUDIO_ASPECT = "audio:audio";
     static final String LOCKABLE_ASPECT = "cm:lockable";
+    public static final String TEMPLATE_PARAM = "template";
 
     @Autowired
     private RestWrapper restClient;

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
@@ -236,7 +236,7 @@ public class RulesTestsUtils implements InitializingBean
         ));
     }
 
-    public RestRuleModel createVariousActions()
+    public RestRuleModel createRuleWithVariousActions()
     {
         final Map<String, Serializable> copyParams =
                 Map.of("destination-folder", copyDestinationFolder.getNodeRef(), "deep-copy", true);

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/UpdateRulesTests.java
@@ -459,12 +459,10 @@ public class UpdateRulesTests extends RestTest
         final RestRuleModel rule = createAndSaveRule(rulesUtils.createRuleModelWithModifiedValues());
 
         STEP("Try to update the rule by adding several actions");
-        final Map<String, Serializable> copyParams =
-                Map.of("destination-folder", rulesUtils.getCopyDestinationFolder().getNodeRef(), "deep-copy", true);
-        final RestActionBodyExecTemplateModel copyAction = rulesUtils.createCustomActionModel("copy", copyParams);
+        final RestActionBodyExecTemplateModel counterAction = rulesUtils.createCustomActionModel("counter", null);
         final Map<String, Serializable> addAspectParams = Map.of("aspect-name", "cm:taggable");
         final RestActionBodyExecTemplateModel addAspectAction = rulesUtils.createCustomActionModel("add-features", addAspectParams);
-        rule.setActions(Arrays.asList(copyAction, addAspectAction));
+        rule.setActions(Arrays.asList(counterAction, addAspectAction));
 
         final RestRuleModel updatedRule = restClient.authenticateUser(user).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet()
                 .updateRule(rule.getId(), rule);
@@ -489,7 +487,8 @@ public class UpdateRulesTests extends RestTest
         final RestActionBodyExecTemplateModel checkOutAction = rulesUtils.createCustomActionModel("check-out", checkOutParams);
         rule.setActions(List.of(checkOutAction));
 
-        restClient.authenticateUser(user).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet()
+        final UserModel admin = dataUser.getAdminUser();
+        restClient.authenticateUser(admin).withPrivateAPI().usingNode(ruleFolder).usingDefaultRuleSet()
                 .updateRule(rule.getId(), rule);
 
         restClient.assertStatusCodeIs(BAD_REQUEST);

--- a/remote-api/src/main/java/org/alfresco/rest/api/actions/ActionValidator.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/actions/ActionValidator.java
@@ -26,13 +26,39 @@
 
 package org.alfresco.rest.api.actions;
 
+import java.util.List;
+
 import org.alfresco.rest.api.model.rules.Action;
 import org.alfresco.service.Experimental;
 
 @Experimental
 public interface ActionValidator
 {
+
+    String ALL_ACTIONS = "all";
+
+    /**
+     * Provides validation logic for given action.
+     */
     void validate(Action action);
 
+    /**
+     * Indicates whether validation is enabled. Could be based on property value in a specific implementation.
+     */
     boolean isEnabled();
+
+    /**
+     * Returns priority of validator (applied to bulk validation in @see {@link org.alfresco.rest.api.impl.mapper.rules.RestRuleActionModelMapper})
+     * @return priority expressed as int
+     */
+    int getPriority();
+
+    /**
+     * By default validator is applied to all actions
+     *
+     * @return indicator for all defined action definition ids
+     */
+    default List<String> getActionDefinitionIds() {
+        return List.of(ALL_ACTIONS);
+    }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/mapper/rules/RestRuleActionModelMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/mapper/rules/RestRuleActionModelMapper.java
@@ -29,9 +29,11 @@ package org.alfresco.rest.api.impl.mapper.rules;
 import static java.util.Collections.emptyMap;
 
 import static org.alfresco.repo.action.access.ActionAccessRestriction.ACTION_CONTEXT_PARAM_NAME;
+import static org.alfresco.rest.api.actions.ActionValidator.ALL_ACTIONS;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,6 +119,9 @@ public class RestRuleActionModelMapper implements RestModelMapper<Action, org.al
     private void validateAction(Action action) {
         actionValidators.stream()
                 .filter(ActionValidator::isEnabled)
-                .forEach(v -> v.validate(action));
+                .filter(v -> (v.getActionDefinitionIds().contains(action.getActionDefinitionId()) ||
+                        v.getActionDefinitionIds().equals(List.of(ALL_ACTIONS))))
+                .sorted(Comparator.comparing(ActionValidator::getPriority))
+                .forEachOrdered(v -> v.validate(action));
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/validator/actions/ActionNodeParameterValidator.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/validator/actions/ActionNodeParameterValidator.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.impl.validator.actions;
+
+import static org.alfresco.service.cmr.dictionary.DataTypeDefinition.NODE_REF;
+import static org.alfresco.service.cmr.security.AccessStatus.ALLOWED;
+import static org.alfresco.service.cmr.security.PermissionService.WRITE;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.alfresco.repo.action.executer.CheckOutActionExecuter;
+import org.alfresco.repo.action.executer.CopyActionExecuter;
+import org.alfresco.repo.action.executer.ImageTransformActionExecuter;
+import org.alfresco.repo.action.executer.ImporterActionExecuter;
+import org.alfresco.repo.action.executer.LinkCategoryActionExecuter;
+import org.alfresco.repo.action.executer.MailActionExecuter;
+import org.alfresco.repo.action.executer.MoveActionExecuter;
+import org.alfresco.repo.action.executer.ScriptActionExecuter;
+import org.alfresco.repo.action.executer.SimpleWorkflowActionExecuter;
+import org.alfresco.repo.action.executer.TransformActionExecuter;
+import org.alfresco.rest.api.Actions;
+import org.alfresco.rest.api.Nodes;
+import org.alfresco.rest.api.actions.ActionValidator;
+import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.rest.api.model.rules.Action;
+import org.alfresco.rest.framework.core.exceptions.EntityNotFoundException;
+import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.security.PermissionService;
+import org.alfresco.service.namespace.NamespaceService;
+import org.apache.commons.collections.MapUtils;
+
+/**
+ * This class provides logic for validation of permissions for action parameters which reference node.
+ */
+public class ActionNodeParameterValidator implements ActionValidator
+{
+    private static final boolean IS_ENABLED = true;
+    /**
+     * This list holds action parameter names which require only READ permission on a referenced node
+     * That means, all other parameters that reference nodes will require WRITE permission
+     */
+    static final List<String> REQUIRE_READ_PERMISSION_PARAMS =
+            List.of(MailActionExecuter.PARAM_TEMPLATE, LinkCategoryActionExecuter.PARAM_CATEGORY_VALUE, ScriptActionExecuter.PARAM_SCRIPTREF);
+
+    static final String NO_PROPER_PERMISSIONS_FOR_NODE = "No proper permissions for node: ";
+
+    private final Actions actions;
+    private final NamespaceService namespaceService;
+    private final Nodes nodes;
+    private final PermissionService permissionService;
+
+    public ActionNodeParameterValidator(Actions actions, NamespaceService namespaceService, Nodes nodes,
+                                        PermissionService permissionService)
+    {
+        this.actions = actions;
+        this.namespaceService = namespaceService;
+        this.nodes = nodes;
+        this.permissionService = permissionService;
+    }
+
+    /**
+     * Validates action parameters that reference nodes against access permissions for executing user.
+     * @param action Action to be validated
+     */
+    @Override
+    public void validate(Action action)
+    {
+        final ActionDefinition actionDefinition = actions.getActionDefinitionById(action.getActionDefinitionId());
+        final List<ActionDefinition.ParameterDefinition> nodeRefParams = actionDefinition.getParameterDefinitions().stream()
+                .filter(pd -> NODE_REF.toPrefixString(namespaceService).equals(pd.getType())).collect(
+                        Collectors.toList());
+        validateNodePermissions(nodeRefParams, action);
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return IS_ENABLED;
+    }
+
+    @Override
+    public List<String> getActionDefinitionIds()
+    {
+        return List.of(CopyActionExecuter.NAME, MoveActionExecuter.NAME, CheckOutActionExecuter.NAME, ImporterActionExecuter.NAME,
+                LinkCategoryActionExecuter.NAME, MailActionExecuter.NAME, ScriptActionExecuter.NAME, SimpleWorkflowActionExecuter.NAME,
+                TransformActionExecuter.NAME, ImageTransformActionExecuter.NAME);
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return Integer.MIN_VALUE + 1;
+    }
+
+    private void validateNodePermissions(final List<ActionDefinition.ParameterDefinition> nodeRefParamDefinitions,
+                                         final Action action)
+    {
+        if (MapUtils.isNotEmpty(action.getParams()))
+        {
+            nodeRefParamDefinitions.stream()
+                    .filter(pd -> action.getParams().containsKey(pd.getName()))
+                    .forEach(p -> validatePermission(p.getName(), action.getParams().get(p.getName()).toString()));
+        }
+    }
+
+    private void validatePermission(final String paramName, final String nodeId)
+    {
+        final NodeRef nodeRef = nodes.validateNode(nodeId);
+        if (permissionService.hasReadPermission(nodeRef) != ALLOWED)
+        {
+            throw new EntityNotFoundException(nodeId);
+        }
+        if (!REQUIRE_READ_PERMISSION_PARAMS.contains(paramName))
+        {
+            if (permissionService.hasPermission(nodeRef, WRITE) != ALLOWED)
+            {
+                throw new PermissionDeniedException(NO_PROPER_PERMISSIONS_FOR_NODE + nodeId);
+            }
+        }
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/validator/actions/ActionParameterDefinitionValidator.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/validator/actions/ActionParameterDefinitionValidator.java
@@ -27,6 +27,8 @@
 package org.alfresco.rest.api.impl.validator.actions;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.alfresco.rest.api.Actions;
@@ -47,6 +49,9 @@ import org.apache.commons.collections.MapUtils;
 public class ActionParameterDefinitionValidator implements ActionValidator
 {
     private static final boolean IS_ENABLED = true;
+    private static final String BASE_PACKAGE = "org/alfresco/repo/action/executer";
+    private static final String NAME = "NAME";
+
     static final String INVALID_PARAMETER_VALUE =
             "Action parameter: %s has invalid value (%s). Look up possible values for constraint name %s";
     static final String MISSING_PARAMETER = "Missing action's mandatory parameter: %s";
@@ -55,6 +60,7 @@ public class ActionParameterDefinitionValidator implements ActionValidator
             "Action parameters should not be null or empty for this action. See Action Definition for action of: %s";
     static final String INVALID_ACTION_DEFINITION = "Invalid action definition requested %s";
 
+    private final List<String> actionDefinitionIds = new ArrayList<>();
     private final Actions actions;
 
     public ActionParameterDefinitionValidator(Actions actions)
@@ -74,7 +80,8 @@ public class ActionParameterDefinitionValidator implements ActionValidator
         try
         {
             actionDefinition = actions.getActionDefinitionById(action.getActionDefinitionId());
-        } catch (NotFoundException e) {
+        } catch (NotFoundException e)
+        {
             throw new InvalidArgumentException(String.format(INVALID_ACTION_DEFINITION, action.getActionDefinitionId()));
         }
         validateParametersSize(action.getParams(), actionDefinition);
@@ -90,6 +97,27 @@ public class ActionParameterDefinitionValidator implements ActionValidator
     public boolean isEnabled()
     {
         return IS_ENABLED;
+    }
+
+    /**
+     * This validator should be applied to all actions
+     *
+     * @return list of all defined action definition ids
+     */
+    @Override
+    public List<String> getActionDefinitionIds()
+    {
+        return List.of(ALL_ACTIONS);
+    }
+
+    /**
+     * This validator should have highest priority and be executed first of all.
+     * @return minimal integer value
+     */
+    @Override
+    public int getPriority()
+    {
+        return Integer.MIN_VALUE;
     }
 
     private void validateParametersSize(final Map<String, Serializable> params, final ActionDefinition actionDefinition)
@@ -128,6 +156,4 @@ public class ActionParameterDefinitionValidator implements ActionValidator
             throw new IllegalArgumentException(String.format(MUST_NOT_CONTAIN_PARAMETER, actionDefinition.getName(), parameterName));
         }
     }
-
-
 }

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -593,6 +593,12 @@
     <bean id="actionParameterConstraintsValidator" class="org.alfresco.rest.api.impl.validator.actions.ActionParameterDefinitionValidator">
         <constructor-arg name="actions" ref="Actions"/>
     </bean>
+    <bean id="actionNodeParameterValidator" class="org.alfresco.rest.api.impl.validator.actions.ActionNodeParameterValidator">
+        <constructor-arg name="actions" ref="Actions"/>
+        <constructor-arg name="namespaceService" ref="NamespaceService"/>
+        <constructor-arg name="nodes" ref="Nodes"/>
+        <constructor-arg name="permissionService" ref="PermissionService"/>
+    </bean>
 
     <!--    action parameter validators end here-->
 
@@ -977,6 +983,7 @@
         <constructor-arg name="actionValidators">
             <list>
                 <ref bean="actionParameterConstraintsValidator"/>
+                <ref bean="actionNodeParameterValidator"/>
             </list>
         </constructor-arg>
     </bean>

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/validator/actions/ActionNodeParameterValidatorTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/validator/actions/ActionNodeParameterValidatorTest.java
@@ -1,0 +1,287 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.impl.validator.actions;
+
+import static org.alfresco.rest.api.impl.validator.actions.ActionNodeParameterValidator.NO_PROPER_PERMISSIONS_FOR_NODE;
+import static org.alfresco.rest.api.impl.validator.actions.ActionNodeParameterValidator.REQUIRE_READ_PERMISSION_PARAMS;
+import static org.alfresco.service.cmr.dictionary.DataTypeDefinition.NODE_REF;
+import static org.alfresco.service.cmr.dictionary.DataTypeDefinition.TEXT;
+import static org.alfresco.service.cmr.repository.StoreRef.STORE_REF_WORKSPACE_SPACESSTORE;
+import static org.alfresco.service.namespace.NamespaceService.DEFAULT_PREFIX;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+import java.util.Map;
+
+import org.alfresco.repo.action.executer.CheckOutActionExecuter;
+import org.alfresco.repo.action.executer.CopyActionExecuter;
+import org.alfresco.repo.action.executer.ImageTransformActionExecuter;
+import org.alfresco.repo.action.executer.ImporterActionExecuter;
+import org.alfresco.repo.action.executer.LinkCategoryActionExecuter;
+import org.alfresco.repo.action.executer.MailActionExecuter;
+import org.alfresco.repo.action.executer.MoveActionExecuter;
+import org.alfresco.repo.action.executer.ScriptActionExecuter;
+import org.alfresco.repo.action.executer.SimpleWorkflowActionExecuter;
+import org.alfresco.repo.action.executer.TransformActionExecuter;
+import org.alfresco.rest.api.Actions;
+import org.alfresco.rest.api.Nodes;
+import org.alfresco.rest.api.model.ActionDefinition;
+import org.alfresco.rest.api.model.rules.Action;
+import org.alfresco.rest.framework.core.exceptions.EntityNotFoundException;
+import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.security.AccessStatus;
+import org.alfresco.service.cmr.security.PermissionService;
+import org.alfresco.service.namespace.NamespaceService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActionNodeParameterValidatorTest
+{
+    private static final String NODE_REF_PARAM = REQUIRE_READ_PERMISSION_PARAMS.get(0);
+    private static final String WRITE_REQUIRED_NODE_REF_PARAM = "dummyNodeParam";
+    private static final String NODE_ID = "node-id";
+    private static final String DUMMY_ACTION = "dummy-action";
+
+    @Mock
+    private Actions actionsMock;
+    @Mock
+    private NamespaceService namespaceServiceMock;
+    @Mock
+    private Nodes nodesMock;
+    @Mock
+    private PermissionService permissionServiceMock;
+
+    @InjectMocks
+    private ActionNodeParameterValidator objectUnderTest;
+
+    @Test
+    public void testProperPermissionsForReadRights()
+    {
+        final Action action = new Action();
+        action.setActionDefinitionId(DUMMY_ACTION);
+        action.setParams(Map.of(NODE_REF_PARAM, NODE_ID));
+        ActionDefinition.ParameterDefinition parameterDef =
+                new ActionDefinition.ParameterDefinition(NODE_REF_PARAM, NODE_REF.toPrefixString(), false, true, null, null);
+        final ActionDefinition actionDefinition =
+                new ActionDefinition(DUMMY_ACTION, DUMMY_ACTION, null, null, null, false, false,
+                        List.of(parameterDef));
+        given(actionsMock.getActionDefinitionById(DUMMY_ACTION)).willReturn(actionDefinition);
+        given(namespaceServiceMock.getPrefixes(NODE_REF.getNamespaceURI())).willReturn(List.of(DEFAULT_PREFIX));
+        final NodeRef nodeRef = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, NODE_ID);
+        given(nodesMock.validateNode(NODE_ID)).willReturn(nodeRef);
+        given(permissionServiceMock.hasReadPermission(nodeRef)).willReturn(AccessStatus.ALLOWED);
+
+        //when
+        objectUnderTest.validate(action);
+
+        then(actionsMock).should().getActionDefinitionById(DUMMY_ACTION);
+        then(actionsMock).shouldHaveNoMoreInteractions();
+        then(namespaceServiceMock).should().getPrefixes(NODE_REF.getNamespaceURI());
+        then(namespaceServiceMock).shouldHaveNoMoreInteractions();
+        then(nodesMock).should().validateNode(NODE_ID);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).should().hasReadPermission(nodeRef);
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testNotEnoughPermissionsForReadRights()
+    {
+        final Action action = new Action();
+        action.setActionDefinitionId(DUMMY_ACTION);
+        action.setParams(Map.of(NODE_REF_PARAM, NODE_ID));
+        ActionDefinition.ParameterDefinition parameterDef =
+                new ActionDefinition.ParameterDefinition(NODE_REF_PARAM, NODE_REF.toPrefixString(), false, true, null, null);
+        final ActionDefinition actionDefinition =
+                new ActionDefinition(DUMMY_ACTION, DUMMY_ACTION, null, null, null, false, false,
+                        List.of(parameterDef));
+        given(actionsMock.getActionDefinitionById(DUMMY_ACTION)).willReturn(actionDefinition);
+        given(namespaceServiceMock.getPrefixes(NODE_REF.getNamespaceURI())).willReturn(List.of(DEFAULT_PREFIX));
+        final NodeRef nodeRef = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, NODE_ID);
+        given(nodesMock.validateNode(NODE_ID)).willReturn(nodeRef);
+        given(permissionServiceMock.hasReadPermission(nodeRef)).willReturn(AccessStatus.DENIED);
+
+        //when
+        assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(() -> objectUnderTest.validate(action));
+
+        then(actionsMock).should().getActionDefinitionById(DUMMY_ACTION);
+        then(actionsMock).shouldHaveNoMoreInteractions();
+        then(namespaceServiceMock).should().getPrefixes(NODE_REF.getNamespaceURI());
+        then(namespaceServiceMock).shouldHaveNoMoreInteractions();
+        then(nodesMock).should().validateNode(NODE_ID);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).should().hasReadPermission(nodeRef);
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testValidateForNodeNotFound()
+    {
+        final Action action = new Action();
+        action.setActionDefinitionId(DUMMY_ACTION);
+        action.setParams(Map.of(NODE_REF_PARAM, NODE_ID));
+        ActionDefinition.ParameterDefinition parameterDef =
+                new ActionDefinition.ParameterDefinition(NODE_REF_PARAM, NODE_REF.toPrefixString(), false, true, null, null);
+        final ActionDefinition actionDefinition =
+                new ActionDefinition(DUMMY_ACTION, DUMMY_ACTION, null, null, null, false, false,
+                        List.of(parameterDef));
+        given(actionsMock.getActionDefinitionById(DUMMY_ACTION)).willReturn(actionDefinition);
+        given(namespaceServiceMock.getPrefixes(NODE_REF.getNamespaceURI())).willReturn(List.of(DEFAULT_PREFIX));
+        given(nodesMock.validateNode(NODE_ID)).willThrow(EntityNotFoundException.class);
+
+        //when
+        assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(() -> objectUnderTest.validate(action));
+
+        then(actionsMock).should().getActionDefinitionById(DUMMY_ACTION);
+        then(actionsMock).shouldHaveNoMoreInteractions();
+        then(namespaceServiceMock).should().getPrefixes(NODE_REF.getNamespaceURI());
+        then(namespaceServiceMock).shouldHaveNoMoreInteractions();
+        then(nodesMock).should().validateNode(NODE_ID);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    public void testProperPermissionsForWriteRights()
+    {
+        final Action action = new Action();
+        action.setActionDefinitionId(DUMMY_ACTION);
+        action.setParams(Map.of(WRITE_REQUIRED_NODE_REF_PARAM, NODE_ID));
+        ActionDefinition.ParameterDefinition parameterDef =
+                new ActionDefinition.ParameterDefinition(WRITE_REQUIRED_NODE_REF_PARAM, NODE_REF.toPrefixString(), false, true, null, null);
+        final ActionDefinition actionDefinition =
+                new ActionDefinition(DUMMY_ACTION, DUMMY_ACTION, null, null, null, false, false,
+                        List.of(parameterDef));
+        given(actionsMock.getActionDefinitionById(DUMMY_ACTION)).willReturn(actionDefinition);
+        given(namespaceServiceMock.getPrefixes(NODE_REF.getNamespaceURI())).willReturn(List.of(DEFAULT_PREFIX));
+        final NodeRef nodeRef = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, NODE_ID);
+        given(nodesMock.validateNode(NODE_ID)).willReturn(nodeRef);
+        given(permissionServiceMock.hasReadPermission(nodeRef)).willReturn(AccessStatus.ALLOWED);
+        given(permissionServiceMock.hasPermission(nodeRef, PermissionService.WRITE)).willReturn(AccessStatus.ALLOWED);
+
+        //when
+        objectUnderTest.validate(action);
+
+        then(actionsMock).should().getActionDefinitionById(DUMMY_ACTION);
+        then(actionsMock).shouldHaveNoMoreInteractions();
+        then(namespaceServiceMock).should().getPrefixes(NODE_REF.getNamespaceURI());
+        then(namespaceServiceMock).shouldHaveNoMoreInteractions();
+        then(nodesMock).should().validateNode(NODE_ID);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).should().hasReadPermission(nodeRef);
+        then(permissionServiceMock).should().hasPermission(nodeRef, PermissionService.WRITE);
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testNotEnoughPermissionsForWriteRights()
+    {
+        final Action action = new Action();
+        action.setActionDefinitionId(DUMMY_ACTION);
+        action.setParams(Map.of(WRITE_REQUIRED_NODE_REF_PARAM, NODE_ID));
+        ActionDefinition.ParameterDefinition parameterDef =
+                new ActionDefinition.ParameterDefinition(WRITE_REQUIRED_NODE_REF_PARAM, NODE_REF.toPrefixString(), false, true, null, null);
+        final ActionDefinition actionDefinition =
+                new ActionDefinition(DUMMY_ACTION, DUMMY_ACTION, null, null, null, false, false,
+                        List.of(parameterDef));
+        given(actionsMock.getActionDefinitionById(DUMMY_ACTION)).willReturn(actionDefinition);
+        given(namespaceServiceMock.getPrefixes(NODE_REF.getNamespaceURI())).willReturn(List.of(DEFAULT_PREFIX));
+        final NodeRef nodeRef = new NodeRef(STORE_REF_WORKSPACE_SPACESSTORE, NODE_ID);
+        given(nodesMock.validateNode(NODE_ID)).willReturn(nodeRef);
+        given(permissionServiceMock.hasReadPermission(nodeRef)).willReturn(AccessStatus.ALLOWED);
+        given(permissionServiceMock.hasPermission(nodeRef, PermissionService.WRITE)).willReturn(AccessStatus.DENIED);
+
+        //when
+        assertThatExceptionOfType(PermissionDeniedException.class).isThrownBy(() -> objectUnderTest.validate(action))
+                .withMessageContaining(NO_PROPER_PERMISSIONS_FOR_NODE + NODE_ID);
+
+        then(actionsMock).should().getActionDefinitionById(DUMMY_ACTION);
+        then(actionsMock).shouldHaveNoMoreInteractions();
+        then(namespaceServiceMock).should().getPrefixes(NODE_REF.getNamespaceURI());
+        then(namespaceServiceMock).shouldHaveNoMoreInteractions();
+        then(nodesMock).should().validateNode(NODE_ID);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+        then(permissionServiceMock).should().hasReadPermission(nodeRef);
+        then(permissionServiceMock).should().hasPermission(nodeRef, PermissionService.WRITE);
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testNoValidationExecutedForNonNodeRefParam()
+    {
+        final Action action = new Action();
+        action.setActionDefinitionId(DUMMY_ACTION);
+        final String dummyParam = "dummyParam";
+        action.setParams(Map.of(dummyParam, "dummyValue"));
+        ActionDefinition.ParameterDefinition parameterDef =
+                new ActionDefinition.ParameterDefinition(dummyParam, TEXT.toPrefixString(), false, true, null, null);
+        final ActionDefinition actionDefinition =
+                new ActionDefinition(DUMMY_ACTION, DUMMY_ACTION, null, null, null, false, false,
+                        List.of(parameterDef));
+        given(actionsMock.getActionDefinitionById(DUMMY_ACTION)).willReturn(actionDefinition);
+        given(namespaceServiceMock.getPrefixes(NODE_REF.getNamespaceURI())).willReturn(List.of(DEFAULT_PREFIX));
+
+        //when
+        objectUnderTest.validate(action);
+
+        then(actionsMock).should().getActionDefinitionById(DUMMY_ACTION);
+        then(actionsMock).shouldHaveNoMoreInteractions();
+        then(namespaceServiceMock).should().getPrefixes(NODE_REF.getNamespaceURI());
+        then(namespaceServiceMock).shouldHaveNoMoreInteractions();
+        then(nodesMock).shouldHaveNoInteractions();
+        then(permissionServiceMock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    public void testGetDefinitionIds()
+    {
+        final List<String> expectedIds =
+                List.of(CopyActionExecuter.NAME, MoveActionExecuter.NAME, CheckOutActionExecuter.NAME, ImporterActionExecuter.NAME,
+                        LinkCategoryActionExecuter.NAME, MailActionExecuter.NAME, ScriptActionExecuter.NAME,
+                        SimpleWorkflowActionExecuter.NAME, TransformActionExecuter.NAME, ImageTransformActionExecuter.NAME);
+        final List<String> actualIds = objectUnderTest.getActionDefinitionIds();
+
+        assertEquals(expectedIds, actualIds);
+    }
+
+    @Test
+    public void testHasProperPriority()
+    {
+        final int expectedPriority = Integer.MIN_VALUE + 1;
+        final int actualPriority = objectUnderTest.getPriority();
+
+        assertEquals(expectedPriority, actualPriority);
+    }
+}

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/validator/actions/ActionParameterDefinitionValidatorTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/validator/actions/ActionParameterDefinitionValidatorTest.java
@@ -32,6 +32,7 @@ import static org.alfresco.rest.api.impl.validator.actions.ActionParameterDefini
 import static org.alfresco.service.cmr.dictionary.DataTypeDefinition.BOOLEAN;
 import static org.alfresco.service.cmr.dictionary.DataTypeDefinition.TEXT;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.then;
 
 import java.util.Collections;
@@ -199,6 +200,15 @@ public class ActionParameterDefinitionValidatorTest
 
         then(actionsMock).should().getActionDefinitionById(actionDefinitionId);
         then(actionsMock).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testHasProperPriority()
+    {
+        final int expectedPriority = Integer.MIN_VALUE;
+        final int actualPriority = objectUnderTest.getPriority();
+
+        assertEquals(expectedPriority, actualPriority);
     }
 
     private ActionDefinition createActionDefinition(final String actionDefinitionId,


### PR DESCRIPTION
This PR introduces access right validations for rule action parameters referencing nodes.
It considers following actions to be validated:
- copy (WRITE access required)
- move (WRITE access required)
- check-out (WRITE access required)
- import (WRITE access required)
- link-category (READ access required)
- mail (restricted to ADMIN only, READ access required)
- script (READ access required)
- simple-workflow (WRITE access required)
- transform/transform-image (WRITE access required)
