### PR TITLE
ACS-3699: Add test with broken copy action

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/ExecuteRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/ExecuteRulesTests.java
@@ -307,8 +307,6 @@ public class ExecuteRulesTests extends RestTest
         UserModel admin = dataUser.getAdminUser();
         SiteModel privateSite = dataSite.usingAdmin().createPrivateRandomSite();
         FolderModel privateFolder = dataContent.usingAdmin().usingSite(privateSite).createFolder();
-        FolderModel destinationFolder = dataContent.usingAdmin().usingSite(privateSite).createFolder();
-        FileModel privateFile = dataContent.usingAdmin().usingResource(privateFolder).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
 
         final Map<String, Serializable> copyParams =
                 Map.of("destinationFolder", rulesUtils.getCopyDestinationFolder().getNodeRef(), "deep-copy", true);
@@ -316,11 +314,10 @@ public class ExecuteRulesTests extends RestTest
         final RestRuleModel ruleModel = rulesUtils.createRuleModelWithDefaultValues();
         ruleModel.setActions(Arrays.asList(copyAction));
 
-
         //create rule with copy action
         restClient.authenticateUser(admin).withPrivateAPI().usingNode(privateFolder).usingDefaultRuleSet().createSingleRule(ruleModel);
         //delete destination folder
-        dataContent.usingAdmin().usingSite(privateSite).deleteTree(destinationFolder);
+        dataContent.usingAdmin().usingSite(privateSite).deleteTree(rulesUtils.getCopyDestinationFolder());
 
         STEP("Try to execute broken rule after deleting destination folder and check 500 error");
         restClient.authenticateUser(admin).withPrivateAPI().usingNode(privateFolder).executeRules(rulesUtils.createRuleExecutionRequest());

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/ExecuteRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/ExecuteRulesTests.java
@@ -314,11 +314,11 @@ public class ExecuteRulesTests extends RestTest
         final RestRuleModel ruleModel = rulesUtils.createRuleModelWithDefaultValues();
         ruleModel.setActions(Arrays.asList(copyAction));
 
-        restClient.authenticateUser(user).withPrivateAPI().usingNode(parentFolder).usingDefaultRuleSet().createSingleRule(ruleModel);
+        restClient.authenticateUser(user).withPrivateAPI().usingNode(owningFolder).usingDefaultRuleSet().createSingleRule(ruleModel);
 
         STEP("Delete destination folder and execute rule");
         restClient.authenticateUser(user).withCoreAPI().usingNode(destinationFolder).deleteNode(destinationFolder.getNodeRef());
-        restClient.authenticateUser(user).withPrivateAPI().usingNode(parentFolder).executeRules(rulesUtils.createRuleExecutionRequest());
+        restClient.authenticateUser(user).withPrivateAPI().usingNode(owningFolder).executeRules(rulesUtils.createRuleExecutionRequest());
         restClient.assertStatusCodeIs(HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
This PR introduces tests for manual triggering of rules on a folder in the case of a broken rule (e.g. deleted destination folder for a copy rule)