### PR TITLE
MNT-23276 - Protect from null facet names

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/search/impl/solr/SolrJSONResultSet.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/solr/SolrJSONResultSet.java
@@ -267,10 +267,13 @@ public class SolrJSONResultSet implements SearchEngineResultSet {
                         ArrayList<Pair<String, Integer>> facetValues = new ArrayList<Pair<String, Integer>>(facetArraySize/2);
                         for(int i = 0; i < facetArraySize; i+=2)
                         {
-                            String facetEntryName = facets.getString(i);
-                            Integer facetEntryCount = Integer.valueOf(facets.getInt(i+1));
-                            Pair<String, Integer> pair = new Pair<String, Integer>(facetEntryName, facetEntryCount);
-                            facetValues.add(pair);
+                            if(!facets.isNull(i))
+                            {
+                                String facetEntryName = facets.getString(i);
+                                Integer facetEntryCount = Integer.valueOf(facets.getInt(i + 1));
+                                Pair<String, Integer> pair = new Pair<String, Integer>(facetEntryName, facetEntryCount);
+                                facetValues.add(pair);
+                            }
                         }
                         fieldFacets.put(fieldName, facetValues);
                     }


### PR DESCRIPTION
The problem was that when the response is being built, one of the facet fields filtered by "creator" was returning the expected fields **plus** a null JSONObject. Since the code is expecting a String, an exception was being thrown for this null JSONObject and it would continue the execution without adding any values to the map `fieldFacets` that is then added to the response. This issue is fixed simply by adding a condition that tests if the facet fields are null.