### PR TITLE
MNT-23276 - The null facet name should be considered

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/search/impl/solr/SolrJSONResultSet.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/solr/SolrJSONResultSet.java
@@ -267,13 +267,14 @@ public class SolrJSONResultSet implements SearchEngineResultSet {
                         ArrayList<Pair<String, Integer>> facetValues = new ArrayList<Pair<String, Integer>>(facetArraySize/2);
                         for(int i = 0; i < facetArraySize; i+=2)
                         {
+                            String facetEntryName = "Null";
                             if(!facets.isNull(i))
                             {
-                                String facetEntryName = facets.getString(i);
-                                Integer facetEntryCount = Integer.valueOf(facets.getInt(i + 1));
-                                Pair<String, Integer> pair = new Pair<String, Integer>(facetEntryName, facetEntryCount);
-                                facetValues.add(pair);
+                                facetEntryName = facets.getString(i);
                             }
+                            Integer facetEntryCount = Integer.valueOf(facets.getInt(i + 1));
+                            Pair<String, Integer> pair = new Pair<String, Integer>(facetEntryName, facetEntryCount);
+                            facetValues.add(pair);
                         }
                         fieldFacets.put(fieldName, facetValues);
                     }


### PR DESCRIPTION
This is the same issue of the previous PR https://github.com/Alfresco/alfresco-community-repo/pull/1534. I was disregarding the null value, but it turns out that the null value needs to be considered after all. The facet name should be the string "Null" in case of being null instead of being ignored.