### PR TITLE
ACS-3964: fix for non-inheritable rules still appearing in inherited rule sets

### DIFF
--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetInheritedRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetInheritedRulesTests.java
@@ -100,7 +100,7 @@ public class GetInheritedRulesTests extends RestTest
      * Check we only get the owned rules and no inherited rules in the child folder when parent rule isn't inheritable.
      */
     @Test (groups = { TestGroup.REST_API, TestGroup.RULES, TestGroup.SANITY })
-    public void getInheritedRules_parent_rule_not_inheritable()
+    public void getInheritedRules_parentRuleNotInheritable()
     {
         STEP("Create a parent and child folder, each with inheriting rules");
         FolderModel parent = dataContent.usingUser(user).usingSite(site).createFolder();

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetInheritedRulesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/GetInheritedRulesTests.java
@@ -137,7 +137,7 @@ public class GetInheritedRulesTests extends RestTest
     @Test (groups = { TestGroup.REST_API, TestGroup.RULES, TestGroup.SANITY })
     public void inheritance_test()
     {
-        STEP("Create a parent and child folder, each with inheriting rules");
+        STEP("Create a parent and child folder, with an inheritable and a non-inheritable parent rule");
         FolderModel parent = dataContent.usingUser(user).usingSite(site).createFolder();
         FolderModel child = dataContent.usingUser(user).usingResource(parent).createFolder();
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/rules/RulesTestsUtils.java
@@ -213,6 +213,13 @@ public class RulesTestsUtils
         return createRuleModel(RULE_NAME_DEFAULT);
     }
 
+    public RestRuleModel createInheritableRuleModel()
+    {
+        RestRuleModel ruleModel = createRuleModel(RULE_NAME_DEFAULT);
+        ruleModel.setIsInheritable(true);
+        return ruleModel;
+    }
+
     public RestRuleModel createRuleModel(String name)
     {
         return createRuleModel(name, List.of(createAddAudioAspectAction()));

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -929,6 +929,7 @@
         <property name="validator" ref="nodeValidator"/>
         <property name="ruleService" ref="RuleService" />
         <property name="ruleLoader" ref="ruleLoader"/>
+        <property name="ruleSetLoader" ref="ruleSetLoader"/>
         <property name="actionPermissionValidator" ref="actionPermissionValidator"/>
         <property name="ruleMapper" ref="ruleMapper"/>
     </bean>

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/RulesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/RulesImplTest.java
@@ -202,7 +202,7 @@ public class RulesImplTest extends TestCase
     }
 
     @Test
-    public void testGetRules_inherited_rule_set()
+    public void testGetRules_inheritedRuleSet()
     {
         given(ruleSetMock.getInclusionType()).willReturn(InclusionType.INHERITED);
         ruleModelInherited.applyToChildren(false);

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/RulesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/RulesImplTest.java
@@ -171,7 +171,7 @@ public class RulesImplTest extends TestCase
     }
 
     @Test
-    public void testGetRules_rule_not_applied_to_children()
+    public void testGetRules_ruleNotAppliedToChildren()
     {
         given(ruleSetMock.getInclusionType()).willReturn(InclusionType.INHERITED);
         ruleModelInherited.applyToChildren(false);

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/RulesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/rules/RulesImplTest.java
@@ -174,10 +174,8 @@ public class RulesImplTest extends TestCase
     public void testGetRules_ruleNotAppliedToChildren()
     {
         given(ruleSetMock.getInclusionType()).willReturn(InclusionType.INHERITED);
-        ruleModelInherited.applyToChildren(false);
-
-        //given(ruleSetMock.getInclusionType()).willReturn(InclusionType.OWNED);
         given(ruleServiceMock.getRules(FOLDER_NODE_REF, false)).willReturn(List.of(ruleModel, ruleModelInherited));
+        ruleModelInherited.applyToChildren(false);
 
         // when
         final CollectionWithPagingInfo<Rule> rulesPage = rules.getRules(FOLDER_NODE_ID, RULE_SET_ID, INCLUDE, PAGING);


### PR DESCRIPTION
This PR introduces changes to avoid non-inheritable rules appearing in inherited rule sets. This is the fix to the following JIRA issue [https://alfresco.atlassian.net/browse/ACS-3964](https://alfresco.atlassian.net/browse/ACS-3964)