### PR TITLE
[MNT-22437] Remove ACS version from landing page (#1480)

### DIFF
--- a/packaging/war/src/main/webapp/index.jsp
+++ b/packaging/war/src/main/webapp/index.jsp
@@ -71,7 +71,7 @@ ModuleDetails shareServicesModule = moduleService.getModule("alfresco-share-serv
          </div>
 
          <div class="index-list">
-            <h4><%=descriptorService.getServerDescriptor().getEdition()%>&nbsp;-&nbsp;<%=descriptorService.getServerDescriptor().getVersion()%></h4>
+            <h4><%=descriptorService.getServerDescriptor().getEdition()%></h4>
             <p></p>
             <p><a href="http://docs.alfresco.com/">Online Documentation</a></p>
             <p></p>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency.jackson.version>2.14.0-rc1</dependency.jackson.version>
         <dependency.cxf.version>3.5.3</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
-        <dependency.webscripts.version>8.32</dependency.webscripts.version>
+        <dependency.webscripts.version>8.33</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.70</dependency.bouncycastle.version>
         <dependency.mockito-core.version>4.6.1</dependency.mockito-core.version>
         <dependency.assertj.version>3.23.1</dependency.assertj.version>


### PR DESCRIPTION
* [MNT-22437] Remove ACS version from landing page

* [MNT-22437] Bump surf-webscripts to 8.33

(cherry picked from commit ace46915409e2c48a0e054337b8bb0882444b8bf)

[MNT-22437]: https://alfresco.atlassian.net/browse/MNT-22437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-22437]: https://alfresco.atlassian.net/browse/MNT-22437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ