### PR TITLE
ACS-4142 Update AOS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency.jakarta-rpc-api.version>1.1.4</dependency.jakarta-rpc-api.version>
 
         <alfresco.googledrive.version>3.3.1-DEV-LOG4J2</alfresco.googledrive.version>
-        <alfresco.aos-module.version>1.5.0-DEV-LOG4J2</alfresco.aos-module.version>
+        <alfresco.aos-module.version>1.6.0-A1</alfresco.aos-module.version>
         <alfresco.api-explorer.version>7.3.0</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
 
         <alfresco.maven-plugin.version>2.2.0</alfresco.maven-plugin.version>


### PR DESCRIPTION
We need to replace the `1.5.0-DEV-LOG4J2` version with `1.6.0-A1` version.