### PR TITLE
ACS-4031 list category children

### DIFF
--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Categories.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Categories.java
@@ -33,7 +33,6 @@ import org.alfresco.rest.core.RestRequest;
 import org.alfresco.rest.core.RestWrapper;
 import org.alfresco.rest.model.RestCategoryModel;
 import org.alfresco.rest.model.RestCategoryModelsCollection;
-import org.alfresco.rest.model.RestRuleModelsCollection;
 import org.springframework.http.HttpMethod;
 
 public class Categories extends ModelRequest<Categories>
@@ -75,9 +74,22 @@ public class Categories extends ModelRequest<Categories>
      * @param restCategoryModel The categories to create.
      * @return Created category with additional data populated by the repository.
      */
-    public RestCategoryModel createSingleCategory(RestCategoryModel restCategoryModel) {
-        RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, restCategoryModel.toJson(), "categories/{categoryId}/subcategories", category.getId());
+    public RestCategoryModel createSingleCategory(RestCategoryModel restCategoryModel)
+    {
+        RestRequest request = RestRequest
+                .requestWithBody(HttpMethod.POST, restCategoryModel.toJson(), "categories/{categoryId}/subcategories", category.getId());
         return restWrapper.processModel(RestCategoryModel.class, request);
+    }
+
+    /**
+     * Get parent category children.
+     *
+     * @return The list of child categories.
+     */
+    public RestCategoryModelsCollection getCategoryChildren()
+    {
+        RestRequest request = RestRequest.simpleRequest(HttpMethod.GET, "categories/{categoryId}/subcategories", category.getId());
+        return restWrapper.processModels(RestCategoryModelsCollection.class, request);
     }
 
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/CreateCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/CreateCategoriesTests.java
@@ -176,7 +176,7 @@ public class CreateCategoriesTests extends RestTest
                 .assertThat().field(FIELD_ID).isNotEmpty();
 
         STEP("Create more than a hundred categories under the previously created (as admin)");
-        final int categoriesNumber = 120;
+        final int categoriesNumber = 11120;
         final List<RestCategoryModel> categoriesToCreate = getCategoriesToCreate(categoriesNumber);
         final RestCategoryModelsCollection createdSubCategories = restClient.authenticateUser(dataUser.getAdminUser())
                 .withCoreAPI()
@@ -260,7 +260,7 @@ public class CreateCategoriesTests extends RestTest
         restClient.assertStatusCodeIs(BAD_REQUEST).assertLastError().containsSummary("Node id does not refer to a valid category");
     }
 
-    private List<RestCategoryModel> getCategoriesToCreate(final int count)
+    static List<RestCategoryModel> getCategoriesToCreate(final int count)
     {
         return IntStream.range(0, count)
                 .mapToObj(i -> {

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/CreateCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/CreateCategoriesTests.java
@@ -176,7 +176,7 @@ public class CreateCategoriesTests extends RestTest
                 .assertThat().field(FIELD_ID).isNotEmpty();
 
         STEP("Create more than a hundred categories under the previously created (as admin)");
-        final int categoriesNumber = 11120;
+        final int categoriesNumber = 120;
         final List<RestCategoryModel> categoriesToCreate = getCategoriesToCreate(categoriesNumber);
         final RestCategoryModelsCollection createdSubCategories = restClient.authenticateUser(dataUser.getAdminUser())
                 .withCoreAPI()

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/GetCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/GetCategoriesTests.java
@@ -28,11 +28,20 @@ package org.alfresco.rest.categories;
 
 import static org.alfresco.utility.report.log.Step.STEP;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.alfresco.rest.RestTest;
+import org.alfresco.rest.core.RestResponse;
 import org.alfresco.rest.model.RestCategoryModel;
+import org.alfresco.rest.model.RestCategoryModelsCollection;
+import org.alfresco.utility.data.RandomData;
 import org.alfresco.utility.model.FolderModel;
 import org.alfresco.utility.model.SiteModel;
 import org.alfresco.utility.model.TestGroup;
@@ -42,6 +51,8 @@ import org.testng.annotations.Test;
 
 public class GetCategoriesTests extends RestTest
 {
+    private static final List<String> DEFAULT_ROOT_CATEGORIES = List.of("Software Document Classification", "Languages", "Regions", "Tags");
+
     private UserModel user;
 
     @BeforeClass(alwaysRun = true)
@@ -57,11 +68,29 @@ public class GetCategoriesTests extends RestTest
     @Test(groups = {TestGroup.REST_API})
     public void testGetCategoryById()
     {
-        STEP("Get category with -root- as id (which does not exist)");
+        STEP("Create a category under root category (as admin)");
         final RestCategoryModel rootCategory = new RestCategoryModel();
         rootCategory.setId("-root-");
-        restClient.authenticateUser(user).withCoreAPI().usingCategory(rootCategory).getCategory();
-        restClient.assertStatusCodeIs(NOT_FOUND);
+        final RestCategoryModel aCategory = new RestCategoryModel();
+        aCategory.setName(RandomData.getRandomName("Category"));
+        final RestCategoryModel createdCategory = restClient.authenticateUser(dataUser.getAdminUser())
+                .withCoreAPI()
+                .usingCategory(rootCategory)
+                .createSingleCategory(aCategory);
+        restClient.assertStatusCodeIs(CREATED);
+
+        createdCategory.assertThat()
+                .field("name").is(aCategory.getName());
+        createdCategory.assertThat()
+                .field("parentId").is(rootCategory.getId());
+        createdCategory.assertThat()
+                .field("hasChildren").is(false);
+
+        STEP("Get the created category (as regular user)");
+        final RestCategoryModel categoryFromGet =
+                restClient.authenticateUser(user).withCoreAPI().usingCategory(createdCategory).getCategory();
+        restClient.assertStatusCodeIs(OK);
+        categoryFromGet.assertThat().isEqualTo(createdCategory);
     }
 
     /**
@@ -72,13 +101,14 @@ public class GetCategoriesTests extends RestTest
     {
         STEP("Get category with -root- as id (which does not exist)");
         final RestCategoryModel rootCategory = new RestCategoryModel();
-        rootCategory.setId("-root-");
+        final String id = "-root-";
+        rootCategory.setId(id);
         restClient.authenticateUser(user).withCoreAPI().usingCategory(rootCategory).getCategory();
-        restClient.assertStatusCodeIs(NOT_FOUND);
+        restClient.assertStatusCodeIs(NOT_FOUND).assertLastError().containsSummary(id);
     }
 
     /**
-     * Check we get an error when passing  as category id
+     * Check we get an error when passing folder node id as category id
      */
     @Test(groups = {TestGroup.REST_API})
     public void testGetCategoryByIdProvidingFolderAsId()
@@ -91,7 +121,87 @@ public class GetCategoriesTests extends RestTest
         final RestCategoryModel rootCategory = new RestCategoryModel();
         rootCategory.setId(folder.getNodeRef());
         restClient.authenticateUser(user).withCoreAPI().usingCategory(rootCategory).getCategory();
-        restClient.assertStatusCodeIs(BAD_REQUEST);
+        restClient.assertStatusCodeIs(BAD_REQUEST).assertLastError().containsSummary("Node id does not refer to a valid category");
     }
 
+    /**
+     * Check we can get children category of a root category
+     */
+    @Test(groups = {TestGroup.REST_API})
+    public void testGetCategoryChildren()
+    {
+        STEP("Get category children with -root- as parent id");
+        final RestCategoryModel rootCategory = new RestCategoryModel();
+        rootCategory.setId("-root-");
+        RestCategoryModelsCollection childCategoriesList =
+                restClient.authenticateUser(user).withCoreAPI().usingCategory(rootCategory).getCategoryChildren();
+        restClient.assertStatusCodeIs(OK);
+
+        childCategoriesList.assertThat().entriesListIsNotEmpty();
+        assertTrue(childCategoriesList.getEntries().stream()
+                .map(RestCategoryModel::onModel)
+                .map(RestCategoryModel::getName)
+                .collect(Collectors.toList())
+                .containsAll(DEFAULT_ROOT_CATEGORIES));
+        STEP("Create a new category under root and make sure it is returned as one of root's children");
+        final RestCategoryModel aCategory = new RestCategoryModel();
+        aCategory.setName((RandomData.getRandomName("newCategoryUnderRoot")));
+        final RestCategoryModel createdCategory = restClient.authenticateUser(dataUser.getAdminUser())
+                .withCoreAPI()
+                .usingCategory(rootCategory)
+                .createSingleCategory(aCategory);
+        restClient.assertStatusCodeIs(CREATED);
+
+        childCategoriesList = restClient.authenticateUser(user).withCoreAPI().usingCategory(rootCategory).getCategoryChildren();
+        restClient.assertStatusCodeIs(OK);
+        assertTrue(childCategoriesList.getEntries().stream()
+                .map(RestCategoryModel::onModel)
+                .map(RestCategoryModel::getId)
+                .collect(Collectors.toList())
+                .contains(createdCategory.getId()));
+
+        STEP("Create 2 more categories under newCategoryUnderRoot and make sure it is returned as children");
+        final int categoriesCount = 2;
+        final List<RestCategoryModel> categoriesToCreate = CreateCategoriesTests.getCategoriesToCreate(categoriesCount);
+        final RestCategoryModelsCollection createdSubCategories = restClient.authenticateUser(dataUser.getAdminUser())
+                .withCoreAPI()
+                .usingCategory(createdCategory)
+                .createCategoriesList(categoriesToCreate);
+        restClient.assertStatusCodeIs(CREATED);
+        childCategoriesList = restClient.authenticateUser(user).withCoreAPI().usingCategory(rootCategory).getCategoryChildren();
+        restClient.assertStatusCodeIs(OK);
+        childCategoriesList.getEntries().containsAll(createdSubCategories.getEntries());
+    }
+
+    /**
+     * Check we get an error when passing folder node id as parent category id when getting children.
+     */
+    @Test(groups = {TestGroup.REST_API})
+    public void testGetCategoryChildrenProvidingFolderAsId()
+    {
+        STEP("Create a site and a folder inside it");
+        final SiteModel site = dataSite.usingUser(user).createPublicRandomSite();
+        final FolderModel folder = dataContent.usingUser(user).usingSite(site).createFolder();
+
+        STEP("Get category children with folder id passed as parent id");
+        final RestCategoryModel parentCategory = new RestCategoryModel();
+        parentCategory.setId(folder.getNodeRef());
+        restClient.authenticateUser(user).withCoreAPI().usingCategory(parentCategory).getCategoryChildren();
+        restClient.assertStatusCodeIs(BAD_REQUEST).assertLastError().containsSummary("Node id does not refer to a valid category");
+    }
+
+    /**
+     * Check we get an error when passing folder node id as parent category id when getting children.
+     */
+    @Test(groups = {TestGroup.REST_API})
+    public void testGetCategoryChildrenProvidingNonExistingParent()
+    {
+
+        STEP("Get category with folder id passed as id");
+        final RestCategoryModel parentCategory = new RestCategoryModel();
+        final String parentId = "non-existing-parent-category-id";
+        parentCategory.setId(parentId);
+        restClient.authenticateUser(user).withCoreAPI().usingCategory(parentCategory).getCategoryChildren();
+        restClient.assertStatusCodeIs(NOT_FOUND).assertLastError().containsSummary(parentId);
+    }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
@@ -29,6 +29,7 @@ package org.alfresco.rest.api;
 import java.util.List;
 
 import org.alfresco.rest.api.model.Category;
+import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -39,4 +40,6 @@ public interface Categories
     Category getCategoryById(String id, Parameters params);
 
     List<Category> createSubcategories(String parentCategoryId, List<Category> categories, Parameters parameters);
+
+    CollectionWithPagingInfo<Category> getCategoryChildren(String parentCategoryId, Parameters params);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/categories/SubcategoriesRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/categories/SubcategoriesRelation.java
@@ -35,10 +35,11 @@ import org.alfresco.rest.api.model.Category;
 import org.alfresco.rest.framework.WebApiDescription;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
+import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 
 @RelationshipResource(name = "subcategories",  entityResource = CategoriesEntityResource.class, title = "Subcategories")
-public class SubcategoriesRelation implements RelationshipResourceAction.Create<Category>
+public class SubcategoriesRelation implements RelationshipResourceAction.Create<Category>, RelationshipResourceAction.Read<Category>
 {
 
     private final Categories categories;
@@ -55,5 +56,14 @@ public class SubcategoriesRelation implements RelationshipResourceAction.Create<
     public List<Category> create(String parentCategoryId, List<Category> categoryList, Parameters parameters)
     {
         return categories.createSubcategories(parentCategoryId, categoryList, parameters);
+    }
+
+    @WebApiDescription(title = "List category direct children",
+            description = "Lists direct children of a parent category",
+            successStatus = HttpServletResponse.SC_OK)
+    @Override
+    public CollectionWithPagingInfo<Category> readAll(String parentCategoryId, Parameters params)
+    {
+        return categories.getCategoryChildren(parentCategoryId, params);
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -106,10 +106,12 @@ public class CategoriesImpl implements Categories
     public CollectionWithPagingInfo<Category> getCategoryChildren(String parentCategoryId, Parameters params)
     {
         final NodeRef parentNodeRef = getParentNodeRef(parentCategoryId);
-        final List<ChildAssociationRef> childCategoriesAssocs =
-                nodeService.getChildAssocs(parentNodeRef).stream()
-                        .filter(ca -> ca.getTypeQName().equals(ContentModel.ASSOC_SUBCATEGORIES)).collect(Collectors.toList());
-        final List<Category> categories = childCategoriesAssocs.stream().map(c -> mapToCategory(c.getChildRef())).collect(Collectors.toList());
+        final List<ChildAssociationRef> childCategoriesAssocs = nodeService.getChildAssocs(parentNodeRef).stream()
+                        .filter(ca -> ContentModel.ASSOC_SUBCATEGORIES.equals(ca.getTypeQName()))
+                        .collect(Collectors.toList());
+        final List<Category> categories = childCategoriesAssocs.stream()
+                .map(c -> mapToCategory(c.getChildRef()))
+                .collect(Collectors.toList());
         return ListPage.of(categories, params.getPaging());
     }
 

--- a/remote-api/src/test/java/org/alfresco/rest/api/categories/SubcategoriesRelationTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/categories/SubcategoriesRelationTest.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.categories;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.alfresco.rest.api.Categories;
+import org.alfresco.rest.api.model.Category;
+import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
+import org.alfresco.rest.framework.resource.parameters.Paging;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubcategoriesRelationTest
+{
+    private static final String PARENT_CATEGORY_ID = "parent-category-node-id";
+    private static final String CATEGORY_ID = "category-node-id";
+    private static final String CATEGORY_NAME = "categoryName";
+    private static final String SUBCATEGORY_NAME_PREFIX = "childCategoryName";
+
+    @Mock
+    private Categories categoriesMock;
+    @Mock
+    private Parameters parametersMock;
+
+    @InjectMocks
+    private SubcategoriesRelation objectUnderTest;
+
+    @Test
+    public void testCreateSubcategory()
+    {
+        final Category categoryToCreate = Category.builder().name(CATEGORY_NAME).create();
+        final Category category = Category.builder().name(CATEGORY_NAME).parentId(PARENT_CATEGORY_ID).hasChildren(false).id(CATEGORY_ID).create();
+        final List<Category> categoriesToCreate = List.of(categoryToCreate);
+        given(categoriesMock.createSubcategories(PARENT_CATEGORY_ID, categoriesToCreate, parametersMock)).willReturn(List.of(category));
+
+        //when
+        List<Category> categories = objectUnderTest.create(PARENT_CATEGORY_ID, categoriesToCreate, parametersMock);
+
+        then(categoriesMock).should().createSubcategories(PARENT_CATEGORY_ID, categoriesToCreate, parametersMock);
+        then(categoriesMock).shouldHaveNoMoreInteractions();
+        assertEquals(List.of(category), categories);
+    }
+
+    @Test
+    public void testGetCategoryChildren() {
+        final CollectionWithPagingInfo<Category> categoryChildren = getCategories(3);
+        given(categoriesMock.getCategoryChildren(PARENT_CATEGORY_ID, parametersMock)).willReturn(categoryChildren);
+
+        //when
+        final CollectionWithPagingInfo<Category> returnedChildren = objectUnderTest.readAll(PARENT_CATEGORY_ID, parametersMock);
+
+        then(categoriesMock).should().getCategoryChildren(PARENT_CATEGORY_ID, parametersMock);
+        then(categoriesMock).shouldHaveNoMoreInteractions();
+        assertEquals(categoryChildren, returnedChildren);
+    }
+
+    private CollectionWithPagingInfo<Category> getCategories(final int count)
+    {
+        return CollectionWithPagingInfo.asPaged(Paging.DEFAULT,
+                IntStream.range(0, count)
+                        .mapToObj(i -> Category.builder().name(SUBCATEGORY_NAME_PREFIX + "-" + i)
+                            .parentId(PARENT_CATEGORY_ID)
+                            .hasChildren(false)
+                            .id(CATEGORY_ID + "-" + i)
+                            .create())
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
@@ -231,7 +231,6 @@ public class CategoriesImplTest
         final NodeRef parentCategoryNodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, PATH_ROOT);
         given(categoryServiceMock.getRootCategoryNodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE))
                 .willReturn(Optional.of(parentCategoryNodeRef));
-        given(nodesMock.isSubClass(parentCategoryNodeRef, ContentModel.TYPE_CATEGORY, false)).willReturn(true);
         final NodeRef categoryNodeRef = prepareCategoryNodeRef();
         given(categoryServiceMock.createCategory(parentCategoryNodeRef, CATEGORY_NAME)).willReturn(categoryNodeRef);
         given(nodesMock.getNode(CATEGORY_ID)).willReturn(prepareCategoryNode());
@@ -246,7 +245,6 @@ public class CategoriesImplTest
 
         then(authorityServiceMock).should().hasAdminAuthority();
         then(authorityServiceMock).shouldHaveNoMoreInteractions();
-        then(nodesMock).should().isSubClass(parentCategoryNodeRef, ContentModel.TYPE_CATEGORY, false);
         then(nodesMock).should().getNode(CATEGORY_ID);
         then(nodesMock).shouldHaveNoMoreInteractions();
         then(nodeServiceMock).should().getPrimaryParent(categoryNodeRef);
@@ -364,6 +362,60 @@ public class CategoriesImplTest
         then(nodesMock).shouldHaveNoMoreInteractions();
         then(nodeServiceMock).shouldHaveNoInteractions();
         then(categoryServiceMock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    public void testGetRootCategoryChildren()
+    {
+        //TODO: add test logic
+    }
+
+    @Test
+    public void testGetCategoryChildren()
+    {
+        //TODO: add test logic
+    }
+
+    @Test
+    public void testGetCategoryChildren_noChildren()
+    {
+        //TODO: add test logic
+    }
+
+    @Test
+    public void testGetCategoryChildren_wrongParentNodeType()
+    {
+        final NodeRef parentCategoryNodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, PARENT_ID);
+        given(nodesMock.validateNode(PARENT_ID)).willReturn(parentCategoryNodeRef);
+        given(nodesMock.isSubClass(parentCategoryNodeRef, ContentModel.TYPE_CATEGORY, false)).willReturn(false);
+
+        //when
+        assertThrows(InvalidArgumentException.class, () -> objectUnderTest.getCategoryChildren(PARENT_ID, parametersMock));
+
+        then(nodesMock).should().validateNode(PARENT_ID);
+        then(nodesMock).should().isSubClass(parentCategoryNodeRef, ContentModel.TYPE_CATEGORY, false);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+
+        then(nodeServiceMock).shouldHaveNoInteractions();
+        then(categoryServiceMock).shouldHaveNoInteractions();
+        then(authorityServiceMock).shouldHaveNoInteractions();
+    }
+
+    @Test
+    public void testGetCategoryChildren_nonExistingParentNode()
+    {
+        given(nodesMock.validateNode(PARENT_ID)).willThrow(EntityNotFoundException.class);
+
+        //when
+        assertThrows(EntityNotFoundException.class, () -> objectUnderTest.getCategoryChildren(PARENT_ID, parametersMock));
+
+
+        then(nodesMock).should().validateNode(PARENT_ID);
+        then(nodesMock).shouldHaveNoMoreInteractions();
+
+        then(nodeServiceMock).shouldHaveNoInteractions();
+        then(categoryServiceMock).shouldHaveNoInteractions();
+        then(authorityServiceMock).shouldHaveNoInteractions();
     }
 
     private Node prepareCategoryNode()


### PR DESCRIPTION
This PR introduces a `GET: /categories/{categoryId}/subcategories` endpoint to list direct child categories of a given parent category.