### PR TITLE
RMContainerCacheManager - decouple returned set from cache instance

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/util/RMContainerCacheManager.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/util/RMContainerCacheManager.java
@@ -94,7 +94,13 @@ public class RMContainerCacheManager implements RecordsManagementModel
      */
     public Set<NodeRef> get(StoreRef storeRef)
     {
-        return cache.get(getKey(storeRef));
+        Set<NodeRef> cachedNodes = cache.get(getKey(storeRef));
+        if (cachedNodes != null)
+        {
+            // prevent outside modification of set in cache
+            cachedNodes = new HashSet<>(cachedNodes);
+        }
+        return cachedNodes;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the Hyland support case 00762774 which details a concurrent modification error in the RMAfterInvocationProvider when the `FilePlanServiceImpl.getFilePlans` method returns the cached file plan set that is then modified at the end of the `RMAfterInvocationProvider.decide` operation. When multiple RM file plan requests are handled at the same time, it can happen that one thread is currently iterating the cached file plan set in the `decide` operation while another is modifying at the end of said operation.
Support won't process the support case further due to lack of an easily reproducible step-by-step guide for this error (which is impossible due to being both timing and load dependent), despite us already providing them with the in-depth analysis of the cause of the error.