### PR TITLE
ACS-3841 Add missing logs for WebDAV TAS tests

### DIFF
--- a/packaging/tests/scripts/output_tests_run.sh
+++ b/packaging/tests/scripts/output_tests_run.sh
@@ -4,4 +4,4 @@ TAS_DIRECTORY=$1
 
 cd ${TAS_DIRECTORY}
 
-cat target/reports/alfresco-tas.log | grep "*** STARTING"
+cat target/reports/alfresco-tas.log | grep -a "*** STARTING"

--- a/packaging/tests/tas-webdav/src/test/java/org/alfresco/webdav/WebDavTest.java
+++ b/packaging/tests/tas-webdav/src/test/java/org/alfresco/webdav/WebDavTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.BeforeSuite;
 @ContextConfiguration("classpath:alfresco-webdav-context.xml")
 public abstract class WebDavTest extends AbstractTestNGSpringContextTests
 {
-    private static Logger LOG = LogFactory.getLogger();
+    private static final Logger LOG = LogFactory.getLogger();
 
     @Autowired
     protected DataSite dataSite;
@@ -48,7 +48,7 @@ public abstract class WebDavTest extends AbstractTestNGSpringContextTests
     @BeforeMethod(alwaysRun=true)
     public void showStartTestInfo(Method method)
     {
-        LOG.info(String.format("*** STARTING Test: [%s] ***",method.getName()));
+        LOG.info(String.format("*** STARTING Test: [%s] ***", method.getName()));
     }
 
     @AfterMethod(alwaysRun=true)

--- a/packaging/tests/tas-webdav/src/test/java/org/alfresco/webdav/WebDavTest.java
+++ b/packaging/tests/tas-webdav/src/test/java/org/alfresco/webdav/WebDavTest.java
@@ -1,17 +1,25 @@
 package org.alfresco.webdav;
 
+import java.lang.reflect.Method;
+
 import org.alfresco.utility.data.DataContent;
 import org.alfresco.utility.data.DataSite;
 import org.alfresco.utility.data.DataUser;
+import org.alfresco.utility.LogFactory;
 import org.alfresco.utility.network.ServerHealth;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.slf4j.Logger;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
 @ContextConfiguration("classpath:alfresco-webdav-context.xml")
 public abstract class WebDavTest extends AbstractTestNGSpringContextTests
 {
+    private static Logger LOG = LogFactory.getLogger();
+
     @Autowired
     protected DataSite dataSite;
 
@@ -35,5 +43,17 @@ public abstract class WebDavTest extends AbstractTestNGSpringContextTests
         // Since alfresco 6.0 JMX connection is deprecated
         // The webdav protocol is enabled by default.
         //webDavProtocol.assertThat().protocolIsEnabled();
+    }
+
+    @BeforeMethod(alwaysRun=true)
+    public void showStartTestInfo(Method method)
+    {
+        LOG.info(String.format("*** STARTING Test: [%s] ***",method.getName()));
+    }
+
+    @AfterMethod(alwaysRun=true)
+    public void showEndTestInfo(Method method)
+    {
+        LOG.info(String.format("*** ENDING Test: [%s] ***", method.getName()));
     }
 }


### PR DESCRIPTION
While working on the Github Actions migration, I discovered a lack of executed tests logs in the `after_success` phase for **WebDAV TAS tests**. We need to implement logger as it is in other classes e.g. [IntegrationTest.java](https://github.com/Alfresco/alfresco-community-repo/blob/master/packaging/tests/tas-integration/src/test/java/org/alfresco/tas/integration/IntegrationTest.java#L97)

Here is an example job without the output for the WebDAV TAS tests: https://app.travis-ci.com/github/Alfresco/alfresco-community-repo/jobs/591283904#L1891

Here is a result after changes: https://app.travis-ci.com/github/Alfresco/alfresco-community-repo/jobs/591292739#L1891