### PR TITLE
ACS-4034: Assign a piece of content to a category

### DIFF
--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestCategoryLinkBodyModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestCategoryLinkBodyModel.java
@@ -25,16 +25,16 @@ public class RestCategoryLinkBodyModel extends TestModel implements IRestModel<R
     */	        
 
     @JsonProperty(required = true)    
-    private String id;	    
+    private String categoryId;
 
-    public String getId()
+    public String getCategoryId()
     {
-        return this.id;
+        return categoryId;
     }
 
-    public void setId(String id)
+    public void setCategoryId(String categoryId)
     {
-        this.id = id;
-    }				
+        this.categoryId = categoryId;
+    }
 }
  

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
@@ -2,7 +2,7 @@
  * #%L
  * alfresco-tas-restapi
  * %%
- * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -26,6 +26,7 @@
 
 package org.alfresco.rest.requests;
 
+import static org.alfresco.rest.core.JsonBodyGenerator.arrayToJson;
 import static org.alfresco.rest.requests.RuleSettings.IS_INHERITANCE_ENABLED;
 import static org.springframework.http.HttpMethod.PUT;
 
@@ -33,6 +34,7 @@ import javax.json.JsonArrayBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.List;
 
 import io.restassured.http.ContentType;
 import org.alfresco.rest.core.JsonBodyGenerator;
@@ -41,6 +43,9 @@ import org.alfresco.rest.core.RestResponse;
 import org.alfresco.rest.core.RestWrapper;
 import org.alfresco.rest.exception.JsonToModelConversionException;
 import org.alfresco.rest.model.RestActionDefinitionModelsCollection;
+import org.alfresco.rest.model.RestCategoryLinkBodyModel;
+import org.alfresco.rest.model.RestCategoryModel;
+import org.alfresco.rest.model.RestCategoryModelsCollection;
 import org.alfresco.rest.model.RestCommentModel;
 import org.alfresco.rest.model.RestCommentModelsCollection;
 import org.alfresco.rest.model.RestNodeAssocTargetModel;
@@ -1105,5 +1110,29 @@ public class Node extends ModelRequest<Node>
     {
         RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, body.toJson(), "nodes/{nodeId}/rule-executions", repoModel.getNodeRef());
         return restWrapper.processModel(RestRuleExecutionModel.class, request);
+    }
+
+    /**
+     * Link content to category performing POST call on "/nodes/{nodeId}/category-links"
+     *
+     * @param categoryLink - contains category ID
+     * @return linked to category
+     */
+    public RestCategoryModel linkToCategory(RestCategoryLinkBodyModel categoryLink)
+    {
+        RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, categoryLink.toJson(), "nodes/{nodeId}/category-links", repoModel.getNodeRef());
+        return restWrapper.processModel(RestCategoryModel.class, request);
+    }
+
+    /**
+     * Link content to many categories performing POST call on "/nodes/{nodeId}/category-links"
+     *
+     * @param categoryLinks - contains categories IDs
+     * @return linked to categories
+     */
+    public RestCategoryModelsCollection linkToCategories(List<RestCategoryLinkBodyModel> categoryLinks)
+    {
+        RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, arrayToJson(categoryLinks), "nodes/{nodeId}/category-links", repoModel.getNodeRef());
+        return restWrapper.processModels(RestCategoryModelsCollection.class, request);
     }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -211,7 +211,7 @@ public class LinkToCategoriesTests extends CategoriesRestTest
     }
 
     /**
-     * Try to link content to category as a owner and expect 201
+     * Try to link content to category as owner and expect 201
      */
     @Test(groups = { TestGroup.REST_API})
     public void testLinkContentToCategory_asOwner()

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -31,23 +31,18 @@ import static org.alfresco.utility.report.log.Step.STEP;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import javax.json.Json;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.alfresco.dataprep.CMISUtil;
-import org.alfresco.rest.model.RestActionBodyExecTemplateModel;
 import org.alfresco.rest.model.RestCategoryLinkBodyModel;
 import org.alfresco.rest.model.RestCategoryModel;
 import org.alfresco.rest.model.RestCategoryModelsCollection;
-import org.alfresco.rest.model.RestCommentModel;
 import org.alfresco.rest.model.RestNodeModel;
-import org.alfresco.rest.model.RestRatingModel;
-import org.alfresco.rest.model.RestRenditionInfoModelCollection;
-import org.alfresco.rest.model.RestRuleModel;
 import org.alfresco.rest.model.RestTagModel;
 import org.alfresco.utility.model.FileModel;
 import org.alfresco.utility.model.FolderModel;
@@ -278,19 +273,32 @@ public class LinkToCategoriesTests extends CategoriesRestTest
     }
 
     /**
-     * Try to link non-content node to category and expect 201 (Created)
+     * Try to link folder node to category and expect 201 (Created)
      */
     @Test(groups = { TestGroup.REST_API})
-    public void testLinkContentToCategory_usingTagInsteadOfContentAndExpect201()
+    public void testLinkContentToCategory_usingFolderInsteadOfContentAndExpect200()
     {
         STEP("Try to link a tag to category and expect 201");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
+        restClient.authenticateUser(user).withCoreAPI().usingNode(folder).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(CREATED);
+    }
+
+    /**
+     * Try to link non-content node to category and expect 405 (Method Not Allowed)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingTagInsteadOfContentAndExpect405()
+    {
+        STEP("Try to link a tag to category and expect 405");
         final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
         final RestTagModel tag = restClient.authenticateUser(user).withCoreAPI().usingNode(file).addTag("someTag");
         final RepoTestModel tagNode = new RepoTestModel() {};
         tagNode.setNodeRef(tag.getId());
         restClient.authenticateUser(dataUser.getAdminUser()).withCoreAPI().usingNode(tagNode).linkToCategory(categoryLink);
 
-        restClient.assertStatusCodeIs(CREATED);
+        restClient.assertStatusCodeIs(METHOD_NOT_ALLOWED);
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -211,10 +211,10 @@ public class LinkToCategoriesTests extends CategoriesRestTest
     }
 
     /**
-     * Try to link content to category as a owner and expect 403 (Forbidden)
+     * Try to link content to category as a owner and expect 201
      */
     @Test(groups = { TestGroup.REST_API})
-    public void testLinkContentToCategory_asOwnerAndExpect403()
+    public void testLinkContentToCategory_asOwner()
     {
         STEP("Use admin to create a private site");
         final SiteModel privateSite = dataSite.usingAdmin().createPrivateRandomSite();
@@ -225,7 +225,7 @@ public class LinkToCategoriesTests extends CategoriesRestTest
         final FileModel privateFile = dataContent.usingUser(user).usingResource(privateFolder).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
         dataUser.removeUserFromSite(user, privateSite);
 
-        STEP("Try to link content to a category as owner and expect 403");
+        STEP("Try to link content to a category as owner and expect 201");
         final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
         restClient.authenticateUser(user).withCoreAPI().usingNode(privateFile).linkToCategory(categoryLink);
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -1,0 +1,276 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.categories;
+
+import static org.alfresco.utility.report.log.Step.STEP;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.alfresco.dataprep.CMISUtil;
+import org.alfresco.rest.model.RestCategoryLinkBodyModel;
+import org.alfresco.rest.model.RestCategoryModel;
+import org.alfresco.rest.model.RestCategoryModelsCollection;
+import org.alfresco.rest.model.RestNodeModel;
+import org.alfresco.utility.model.FileModel;
+import org.alfresco.utility.model.FolderModel;
+import org.alfresco.utility.model.SiteModel;
+import org.alfresco.utility.model.TestGroup;
+import org.alfresco.utility.model.UserModel;
+import org.apache.commons.lang3.StringUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LinkToCategoriesTests extends CategoriesRestTest
+{
+    private static final String ASPECTS_FIELD = "aspectNames";
+    private static final String PROPERTIES_FIELD = "properties";
+
+    private UserModel user;
+    private SiteModel site;
+    private FolderModel folder;
+    private FileModel file;
+    private RestCategoryModel category;
+
+    @BeforeClass(alwaysRun = true)
+    public void dataPreparation()
+    {
+        STEP("Create user and a site");
+        user = dataUser.createRandomTestUser();
+        site = dataSite.usingUser(user).createPublicRandomSite();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp()
+    {
+        STEP("Create a folder, file in it and a category under root");
+        folder = dataContent.usingUser(user).usingSite(site).createFolder();
+        file = dataContent.usingUser(user).usingResource(folder).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
+        category = prepareCategoryUnderRoot();
+    }
+
+    /**
+     * Link content to category and verify if this category is present in node's properties
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory()
+    {
+        STEP("Check if file is not linked to any category");
+        RestNodeModel fileNode = restClient.authenticateUser(user).withCoreAPI().usingNode(file).getNode();
+
+        fileNode.assertThat().field(ASPECTS_FIELD).notContains("cm:generalclassifiable");
+        fileNode.assertThat().field(PROPERTIES_FIELD).notContains("cm:categories");
+
+        STEP("Link content to created category and expect 201");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
+        final RestCategoryModel linkedCategory = restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(CREATED);
+        linkedCategory.assertThat().isEqualTo(category);
+
+        STEP("Verify if category is present in file metadata");
+        fileNode = restClient.authenticateUser(user).withCoreAPI().usingNode(file).getNode();
+
+        fileNode.assertThat().field(ASPECTS_FIELD).contains("cm:generalclassifiable");
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains("cm:categories");
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains(category.getId());
+    }
+
+    /**
+     * Link content to two categories and verify if both are present in node's properties
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToMultipleCategories()
+    {
+        STEP("Check if file is not linked to any category");
+        RestNodeModel fileNode = restClient.authenticateUser(user).withCoreAPI().usingNode(file).getNode();
+
+        fileNode.assertThat().field(ASPECTS_FIELD).notContains("cm:generalclassifiable");
+        fileNode.assertThat().field(PROPERTIES_FIELD).notContains("cm:categories");
+
+        STEP("Create second category under root");
+        final RestCategoryModel secondCategory = prepareCategoryUnderRoot();
+
+        STEP("Link content to created categories and expect 201");
+        final List<RestCategoryLinkBodyModel> categoryLinks = List.of(
+            createCategoryLinkWithId(category.getId()),
+            createCategoryLinkWithId(secondCategory.getId())
+        );
+        final RestCategoryModelsCollection linkedCategories = restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategories(categoryLinks);
+
+        restClient.assertStatusCodeIs(CREATED);
+        linkedCategories.getEntries().get(0).onModel().assertThat().isEqualTo(category);
+        linkedCategories.getEntries().get(1).onModel().assertThat().isEqualTo(secondCategory);
+
+        STEP("Verify if both categories are present in file metadata");
+        fileNode = restClient.authenticateUser(user).withCoreAPI().usingNode(file).getNode();
+
+        fileNode.assertThat().field(ASPECTS_FIELD).contains("cm:generalclassifiable");
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains("cm:categories");
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains(category.getId());
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains(secondCategory.getId());
+    }
+
+    /**
+     * Link content, which already has some linked category to new ones and verify if all categories are present in node's properties
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingContentWithAlreadyLinkedCategories()
+    {
+        STEP("Link content to created category");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+        restClient.assertStatusCodeIs(CREATED);
+
+        STEP("Create second and third category under root, link content to them and expect 201");
+        final RestCategoryModel secondCategory = prepareCategoryUnderRoot();
+        final RestCategoryModel thirdCategory = prepareCategoryUnderRoot();
+        final List<RestCategoryLinkBodyModel> categoryLinks = List.of(
+            createCategoryLinkWithId(secondCategory.getId()),
+            createCategoryLinkWithId(thirdCategory.getId())
+        );
+        final RestCategoryModelsCollection linkedCategories = restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategories(categoryLinks);
+
+        restClient.assertStatusCodeIs(CREATED);
+        linkedCategories.assertThat().entriesListCountIs(2);
+        linkedCategories.getEntries().get(0).onModel().assertThat().isEqualTo(secondCategory);
+        linkedCategories.getEntries().get(1).onModel().assertThat().isEqualTo(thirdCategory);
+
+        STEP("Verify if all three categories are present in file metadata");
+        final RestNodeModel fileNode = restClient.authenticateUser(user).withCoreAPI().usingNode(file).getNode();
+
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains("cm:categories");
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains(category.getId());
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains(secondCategory.getId());
+        fileNode.assertThat().field(PROPERTIES_FIELD).contains(thirdCategory.getId());
+    }
+
+    /**
+     * Try to link content to category as an improper user and expect 403 (Forbidden)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingUserWithoutAccessRightsAndExpect403()
+    {
+        STEP("Try to link content to a category using user without read permission and expect 403");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
+        final UserModel userWithoutRights = dataUser.createRandomTestUser();
+        restClient.authenticateUser(userWithoutRights).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(FORBIDDEN);
+    }
+
+    /**
+     * Try to link content to category using non-existing category and expect 404 (Not Found)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingNonExistingCategoryAndExpect404()
+    {
+        STEP("Try to link content to non-existing category and expect 404");
+        final String nonExistingCategoryId = "non-existing-dummy-id";
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(nonExistingCategoryId);
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(NOT_FOUND);
+    }
+
+    /**
+     * Try to link content to category passing empty list as input and expect 400 (Bad Request)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_passingEmptyListAndExpect400()
+    {
+        STEP("Try to call link content API with empty list and expect 400");
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategories(Collections.emptyList());
+
+        restClient.assertStatusCodeIs(BAD_REQUEST);
+    }
+
+    /**
+     * Try to link content to category passing invalid ID in input list and expect 400 (Bad Request)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_passingEmptyIdAndExpect400()
+    {
+        STEP("Try to call link content API with empty category ID and expect 400");
+        final String nonExistingCategoryId = StringUtils.EMPTY;
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(nonExistingCategoryId);
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(BAD_REQUEST);
+    }
+
+    /**
+     * Try to link non-content node to category and expect 400 (Bad Request)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingFolderInsteadOfContentAndExpect400()
+    {
+        STEP("Try to link folder to category and expect 400");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
+        restClient.authenticateUser(user).withCoreAPI().usingNode(folder).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(BAD_REQUEST);
+    }
+
+    /**
+     * Try to link content to non-category node and expect 400 (Bad Request)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingFolderInsteadOfCategoryAndExpect400()
+    {
+        STEP("Try to link content to non-category and expect 400");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(folder.getNodeRef());
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(BAD_REQUEST);
+    }
+
+    /**
+     * Try to link content to root category and expect 400 (Bad Request)
+     */
+    @Test(groups = { TestGroup.REST_API})
+    public void testLinkContentToCategory_usingRootCategoryAndExpect400()
+    {
+        STEP("Try to link content to root category and expect 400");
+        final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(ROOT_CATEGORY_ID);
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).linkToCategory(categoryLink);
+
+        restClient.assertStatusCodeIs(BAD_REQUEST);
+    }
+
+    private RestCategoryLinkBodyModel createCategoryLinkWithId(final String id)
+    {
+        final RestCategoryLinkBodyModel categoryLink = new RestCategoryLinkBodyModel();
+        categoryLink.setCategoryId(id);
+        return categoryLink;
+    }
+}

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -339,23 +339,4 @@ public class LinkToCategoriesTests extends CategoriesRestTest
 
         restClient.authenticateUser(user).withCoreAPI().usingNode(file).updateNode(putPermissionsBody);
     }
-
-    private RestRuleModel createRuleModel()
-    {
-        final RestActionBodyExecTemplateModel actions = new RestActionBodyExecTemplateModel();
-        actions.setActionDefinitionId("add-features");
-        actions.setParams(Map.of("aspect-name", "audio:audio"));
-
-        final RestRuleModel ruleModel = new RestRuleModel();
-        ruleModel.setName("ruleName");
-        ruleModel.setActions(List.of(actions));
-        //ruleModel.setTriggers(List.of("inbound"));
-
-        /*RestActionConstraintModel constraintDef = getConstraintsForActionParam(user, actionId, paramId);
-        RestActionConstraintDataModel constraintDataModel = constraintDef.getConstraintValues().stream().filter(constraintValue -> constraintValue.getLabel().equals(constraintLabel)).findFirst().get();
-        return constraintDataModel.getValue()*/
-
-        //ruleModel.setErrorScript("fake-script");
-        return ruleModel;
-    }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -278,19 +278,19 @@ public class LinkToCategoriesTests extends CategoriesRestTest
     }
 
     /**
-     * Try to link non-content node to category and expect 400 (Bad Request)
+     * Try to link non-content node to category and expect 201 (Created)
      */
     @Test(groups = { TestGroup.REST_API})
-    public void testLinkContentToCategory_usingTagInsteadOfContentAndExpect400()
+    public void testLinkContentToCategory_usingTagInsteadOfContentAndExpect201()
     {
-        STEP("Try to link a tag to category and expect 400");
+        STEP("Try to link a tag to category and expect 201");
         final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
         final RestTagModel tag = restClient.authenticateUser(user).withCoreAPI().usingNode(file).addTag("someTag");
         final RepoTestModel tagNode = new RepoTestModel() {};
         tagNode.setNodeRef(tag.getId());
         restClient.authenticateUser(dataUser.getAdminUser()).withCoreAPI().usingNode(tagNode).linkToCategory(categoryLink);
 
-        restClient.assertStatusCodeIs(BAD_REQUEST);
+        restClient.assertStatusCodeIs(CREATED);
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -273,12 +273,12 @@ public class LinkToCategoriesTests extends CategoriesRestTest
     }
 
     /**
-     * Try to link folder node to category and expect 201 (Created)
+     * Link folder node to category and expect 201 (Created)
      */
     @Test(groups = { TestGroup.REST_API})
-    public void testLinkContentToCategory_usingFolderInsteadOfContentAndExpect200()
+    public void testLinkFolderToCategory()
     {
-        STEP("Try to link a tag to category and expect 201");
+        STEP("Link folder node to category");
         final RestCategoryLinkBodyModel categoryLink = createCategoryLinkWithId(category.getId());
         restClient.authenticateUser(user).withCoreAPI().usingNode(folder).linkToCategory(categoryLink);
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
@@ -54,7 +54,7 @@ public interface Categories
     void deleteCategoryById(String id, Parameters parameters);
 
     /**
-     * Link node to categories.
+     * Link node to categories. Node types allowed for categorization are specified within {@link org.alfresco.util.TypeConstraint}.
      *
      * @param nodeId Node ID.
      * @param categoryLinks Category IDs to which content should be linked to.

--- a/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
@@ -54,11 +54,11 @@ public interface Categories
     void deleteCategoryById(String id, Parameters parameters);
 
     /**
-     * Link content node to categories.
+     * Link node to categories.
      *
-     * @param nodeId Content node ID.
+     * @param nodeId Node ID.
      * @param categoryLinks Category IDs to which content should be linked to.
      * @return Linked to categories.
      */
-    List<Category> linkContentNodeToCategories(String nodeId, List<Category> categoryLinks);
+    List<Category> linkNodeToCategories(String nodeId, List<Category> categoryLinks);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Remote API
  * %%
- * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -53,4 +53,12 @@ public interface Categories
 
     void deleteCategoryById(String id, Parameters parameters);
 
+    /**
+     * Link content node to categories.
+     *
+     * @param nodeId Content node ID.
+     * @param categoryLinks Category IDs to which content should be linked to.
+     * @return Linked to categories.
+     */
+    List<Category> linkContentNodeToCategories(String nodeId, List<Category> categoryLinks);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/categories/NodesCategoryLinksRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/categories/NodesCategoryLinksRelation.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.rest.api.categories;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+import org.alfresco.rest.api.Categories;
+import org.alfresco.rest.api.model.Category;
+import org.alfresco.rest.api.nodes.NodesEntityResource;
+import org.alfresco.rest.framework.WebApiDescription;
+import org.alfresco.rest.framework.resource.RelationshipResource;
+import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+
+@RelationshipResource(name = "category-links", entityResource = NodesEntityResource.class, title = "Category links")
+public class NodesCategoryLinksRelation implements RelationshipResourceAction.Create<Category>
+{
+
+    private final Categories categories;
+
+    public NodesCategoryLinksRelation(Categories categories)
+    {
+        this.categories = categories;
+    }
+
+    /**
+     * POST /nodes/{nodeId}/category-links
+     */
+    @WebApiDescription(
+        title = "Link content node to categories",
+        description = "Creates a link between a content node and categories",
+        successStatus = HttpServletResponse.SC_CREATED
+    )
+    @Override
+    public List<Category> create(String nodeId, List<Category> categoryLinks, Parameters parameters)
+    {
+        return categories.linkContentNodeToCategories(nodeId, categoryLinks);
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/categories/NodesCategoryLinksRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/categories/NodesCategoryLinksRelation.java
@@ -59,6 +59,6 @@ public class NodesCategoryLinksRelation implements RelationshipResourceAction.Cr
     @Override
     public List<Category> create(String nodeId, List<Category> categoryLinks, Parameters parameters)
     {
-        return categories.linkContentNodeToCategories(nodeId, categoryLinks);
+        return categories.linkNodeToCategories(nodeId, categoryLinks);
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -165,7 +165,6 @@ public class CategoriesImpl implements Categories
 
         final NodeRef contentNodeRef = nodes.validateNode(nodeId);
         verifyChangePermission(contentNodeRef);
-        verifyNodeType(contentNodeRef, ContentModel.TYPE_CONTENT, ContentModel.TYPE_FOLDER);
 
         final Collection<NodeRef> categoryNodeRefs = categoryLinks.stream()
             .filter(Objects::nonNull)
@@ -197,18 +196,6 @@ public class CategoriesImpl implements Categories
         if (permissionService.hasPermission(nodeRef, CHANGE_PERMISSIONS) != ALLOWED)
         {
             throw new PermissionDeniedException(NO_PERMISSION_TO_READ_CONTENT);
-        }
-    }
-
-    private void verifyNodeType(final NodeRef nodeRef, final QName... expectedTypes)
-    {
-        if (!nodes.nodeMatches(nodeRef, Set.of(expectedTypes), null))
-        {
-            throw new InvalidArgumentException(
-                String.format(
-                    INVALID_NODE_TYPE,
-                    Arrays.stream(expectedTypes).map(QName::getLocalName).collect(Collectors.joining(", "))
-                ));
         }
     }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -156,7 +156,7 @@ public class CategoriesImpl implements Categories
     }
 
     @Override
-    public List<Category> linkContentNodeToCategories(final String nodeId, final List<Category> categoryLinks)
+    public List<Category> linkNodeToCategories(final String nodeId, final List<Category> categoryLinks)
     {
         if (CollectionUtils.isEmpty(categoryLinks))
         {

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/Category.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/Category.java
@@ -45,6 +45,11 @@ public class Category
         this.id = id;
     }
 
+    public void setCategoryId(String categoryId)
+    {
+        this.id = categoryId;
+    }
+
     public String getName()
     {
         return name;

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -835,6 +835,7 @@
         <constructor-arg name="nodes" ref="nodes"/>
         <constructor-arg name="nodeService" ref="NodeService"/>
         <constructor-arg name="permissionService" ref="PermissionService"/>
+        <constructor-arg name="typeConstraint" ref="nodeTypeConstraint"/>
     </bean>
 
     <bean id="Categories" class="org.springframework.aop.framework.ProxyFactoryBean">

--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -834,6 +834,7 @@
         <constructor-arg name="categoryService" ref="CategoryService"/>
         <constructor-arg name="nodes" ref="nodes"/>
         <constructor-arg name="nodeService" ref="NodeService"/>
+        <constructor-arg name="permissionService" ref="PermissionService"/>
     </bean>
 
     <bean id="Categories" class="org.springframework.aop.framework.ProxyFactoryBean">
@@ -1102,6 +1103,10 @@
     </bean>
 
     <bean class="org.alfresco.rest.api.categories.SubcategoriesRelation">
+        <constructor-arg name="categories" ref="Categories"/>
+    </bean>
+
+    <bean class="org.alfresco.rest.api.categories.NodesCategoryLinksRelation">
         <constructor-arg name="categories" ref="Categories"/>
     </bean>
 

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
@@ -27,7 +27,6 @@
 package org.alfresco.rest.api.impl;
 
 import static org.alfresco.rest.api.Nodes.PATH_ROOT;
-import static org.alfresco.rest.api.impl.CategoriesImpl.INVALID_NODE_TYPE;
 import static org.alfresco.rest.api.impl.CategoriesImpl.NOT_A_VALID_CATEGORY;
 import static org.alfresco.rest.api.impl.CategoriesImpl.NOT_NULL_OR_EMPTY;
 import static org.alfresco.rest.api.impl.CategoriesImpl.NO_PERMISSION_TO_READ_CONTENT;
@@ -39,7 +38,6 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -792,7 +790,7 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withoutCategoryAspect()
+    public void testLinkNodeToCategories_withoutCategoryAspect()
     {
         final List<Category> categoryLinks = List.of(CATEGORY);
         final NodeRef categoryParentNodeRef = createNodeRefWithId(PARENT_ID);
@@ -801,7 +799,7 @@ public class CategoriesImplTest
         given(nodeServiceMock.getPrimaryParent(any())).willReturn(parentAssociation);
 
         // when
-        final List<Category> actualLinkedCategories = objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, categoryLinks);
+        final List<Category> actualLinkedCategories = objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, categoryLinks);
 
         then(nodesMock).should().validateNode(CONTENT_NODE_ID);
         then(permissionServiceMock).should().hasPermission(CONTENT_NODE_REF, PermissionService.CHANGE_PERMISSIONS);
@@ -825,7 +823,7 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withPresentCategoryAspect()
+    public void testLinkNodeToCategories_withPresentCategoryAspect()
     {
         final NodeRef categoryParentNodeRef = createNodeRefWithId(PARENT_ID);
         final ChildAssociationRef parentAssociation = createAssociationOf(categoryParentNodeRef, CATEGORY_NODE_REF);
@@ -834,7 +832,7 @@ public class CategoriesImplTest
         given(nodeServiceMock.hasAspect(any(), any())).willReturn(true);
 
         // when
-        final List<Category> actualLinkedCategories = objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY));
+        final List<Category> actualLinkedCategories = objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY));
 
         then(nodesMock).should().getNode(CATEGORY_ID);
         then(nodeServiceMock).should().getChildAssocs(CATEGORY_NODE_REF, RegexQNamePattern.MATCH_ALL, RegexQNamePattern.MATCH_ALL, false);
@@ -853,7 +851,7 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withMultipleCategoryIds()
+    public void testLinkNodeToCategories_withMultipleCategoryIds()
     {
         final String secondCategoryId = "second-category-id";
         final String secondCategoryName = "secondCategoryName";
@@ -868,7 +866,7 @@ public class CategoriesImplTest
         given(nodeServiceMock.getPrimaryParent(any())).willReturn(categoryParentAssociation, secondCategoryParentAssociation);
 
         // when
-        final List<Category> actualLinkedCategories = objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, categoryLinks);
+        final List<Category> actualLinkedCategories = objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, categoryLinks);
 
         then(nodesMock).should().validateNode(CATEGORY_ID);
         then(nodesMock).should().validateNode(secondCategoryId);
@@ -886,7 +884,7 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withPreviouslyLinkedCategories()
+    public void testLinkNodeToCategories_withPreviouslyLinkedCategories()
     {
         final String otherCategoryId = "other-category-id";
         final NodeRef otherCategoryNodeRef = createNodeRefWithId(otherCategoryId);
@@ -899,7 +897,7 @@ public class CategoriesImplTest
         given(nodeServiceMock.getProperty(any(), eq(ContentModel.PROP_CATEGORIES))).willReturn(previousCategories);
 
         // when
-        final List<Category> actualLinkedCategories = objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY));
+        final List<Category> actualLinkedCategories = objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY));
 
         final Serializable expectedCategories = (Serializable) Set.of(otherCategoryNodeRef, CATEGORY_NODE_REF);
         then(nodeServiceMock).should().setProperty(CONTENT_NODE_REF, ContentModel.PROP_CATEGORIES, expectedCategories);
@@ -910,12 +908,12 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withInvalidNodeId()
+    public void testLinkNodeToCategories_withInvalidNodeId()
     {
         given(nodesMock.validateNode(CONTENT_NODE_ID)).willThrow(EntityNotFoundException.class);
 
         // when
-        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY)));
+        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY)));
 
         then(nodesMock).should().validateNode(CONTENT_NODE_ID);
         then(permissionServiceMock).shouldHaveNoInteractions();
@@ -925,12 +923,12 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withoutPermission()
+    public void testLinkNodeToCategories_withoutPermission()
     {
         given(permissionServiceMock.hasPermission(any(), any())).willReturn(AccessStatus.DENIED);
 
         // when
-        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY)));
+        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY)));
 
         then(nodesMock).should().validateNode(CONTENT_NODE_ID);
         then(permissionServiceMock).should().hasPermission(CONTENT_NODE_REF, PermissionService.CHANGE_PERMISSIONS);
@@ -941,12 +939,12 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withEmptyLinks()
+    public void testLinkNodeToCategories_withEmptyLinks()
     {
         final List<Category> categoryLinks = Collections.emptyList();
 
         // when
-        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, categoryLinks));
+        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, categoryLinks));
 
         then(nodesMock).shouldHaveNoInteractions();
         then(permissionServiceMock).shouldHaveNoInteractions();
@@ -957,7 +955,7 @@ public class CategoriesImplTest
     }
 
     @Test
-    public void testLinkContentNodeToCategories_withInvalidCategoryIds()
+    public void testLinkNodeToCategories_withInvalidCategoryIds()
     {
         final Category categoryLinkWithNullId = Category.builder().id(null).create();
         final Category categoryLinkWithEmptyId = Category.builder().id(StringUtils.EMPTY).create();
@@ -967,7 +965,7 @@ public class CategoriesImplTest
         categoryLinks.add(categoryLinkWithEmptyId);
 
         // when
-        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, categoryLinks));
+        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkNodeToCategories(CONTENT_NODE_ID, categoryLinks));
 
         then(nodeServiceMock).shouldHaveNoInteractions();
         assertThat(actualException)

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
@@ -122,7 +122,6 @@ public class CategoriesImplTest
         given(nodesMock.validateNode(CATEGORY_ID)).willReturn(CATEGORY_NODE_REF);
         given(nodesMock.validateNode(CONTENT_NODE_ID)).willReturn(CONTENT_NODE_REF);
         given(nodesMock.isSubClass(any(), any(), anyBoolean())).willReturn(true);
-        given(nodesMock.nodeMatches(any(), any(), isNull())).willReturn(true);
         given(permissionServiceMock.hasPermission(any(), any())).willReturn(AccessStatus.ALLOWED);
     }
 
@@ -807,7 +806,6 @@ public class CategoriesImplTest
         then(nodesMock).should().validateNode(CONTENT_NODE_ID);
         then(permissionServiceMock).should().hasPermission(CONTENT_NODE_REF, PermissionService.CHANGE_PERMISSIONS);
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
-        then(nodesMock).should().nodeMatches(CONTENT_NODE_REF, Set.of(ContentModel.TYPE_CONTENT, ContentModel.TYPE_FOLDER), null);
         then(nodesMock).should().validateNode(CATEGORY_ID);
         then(nodesMock).should().getNode(CATEGORY_ID);
         then(nodesMock).should().isSubClass(CATEGORY_NODE_REF, ContentModel.TYPE_CATEGORY, false);
@@ -940,21 +938,6 @@ public class CategoriesImplTest
         assertThat(actualException)
             .isInstanceOf(PermissionDeniedException.class)
             .hasMessageContaining(NO_PERMISSION_TO_READ_CONTENT);
-    }
-
-    @Test
-    public void testLinkContentNodeToCategories_withInvalidNodeType()
-    {
-        given(nodesMock.nodeMatches(any(), any(), isNull())).willReturn(false);
-
-        // when
-        final Throwable actualException = catchThrowable(() -> objectUnderTest.linkContentNodeToCategories(CONTENT_NODE_ID, List.of(CATEGORY)));
-
-        then(nodesMock).should().nodeMatches(CONTENT_NODE_REF, Set.of(ContentModel.TYPE_CONTENT, ContentModel.TYPE_FOLDER), null);
-        then(nodeServiceMock).shouldHaveNoInteractions();
-        assertThat(actualException)
-            .isInstanceOf(InvalidArgumentException.class)
-            .hasMessageContaining(INVALID_NODE_TYPE, ContentModel.TYPE_CONTENT.getLocalName() + ", " + ContentModel.TYPE_FOLDER.getLocalName());
     }
 
     @Test


### PR DESCRIPTION
POST /nodes/{nodeId}/category-links
https://alfresco.atlassian.net/browse/ACS-4034
- added also one TAS test for update category covering repeated name case

[ACS-4034]: https://alfresco.atlassian.net/browse/ACS-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ