### PR TITLE
ACS-2967: While LocalPipelineTransform was reported to cause a warnin…

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalFailoverTransform.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalFailoverTransform.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2019-2022 Alfresco Software Limited
+ * Copyright (C) 2019 - 2022 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of


### PR DESCRIPTION
…g issue, actually it is already fixed, LocalFailoverTransform however caused same warning