### PR TITLE
ACS-4035: support for removing a piece of content from a category

### DIFF
--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
@@ -1154,7 +1154,7 @@ public class Node extends ModelRequest<Node>
      */
     public void unlinkFromCategory(String categoryId)
     {
-        RestRequest request = RestRequest.simpleRequest(HttpMethod.DELETE, "nodes/{nodeId}/category-links/{categoryId}", repoModel.getNodeRef(), categodyId);
+        RestRequest request = RestRequest.simpleRequest(HttpMethod.DELETE, "nodes/{nodeId}/category-links/{categoryId}", repoModel.getNodeRef(), categoryId);
         restWrapper.processEmptyModel(request);
     }
 }

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
@@ -1146,4 +1146,15 @@ public class Node extends ModelRequest<Node>
         RestRequest request = RestRequest.requestWithBody(HttpMethod.POST, arrayToJson(categoryLinks), "nodes/{nodeId}/category-links", repoModel.getNodeRef());
         return restWrapper.processModels(RestCategoryModelsCollection.class, request);
     }
+
+    /**
+     * Unlink content from a category performing a DELETE call on "nodes/{nodeId}/category-links/{categoryId}"
+     *
+     * @param categoryId the id of the category to be unlinked from content
+     */
+    public void unlinkFromCategory(String categoryId)
+    {
+        RestRequest request = RestRequest.simpleRequest(HttpMethod.DELETE, "nodes/{nodeId}/category-links/{categoryId}", repoModel.getNodeRef(), categodyId);
+        restWrapper.processEmptyModel(request);
+    }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -449,7 +449,7 @@ public class LinkToCategoriesTests extends CategoriesRestTest
         linkedCategories.getEntries().get(0).onModel().assertThat().isEqualTo(category);
         linkedCategories.getEntries().get(1).onModel().assertThat().isEqualTo(secondCategory);
 
-        STEP("Unlink content from created category and expect 204");
+        STEP("Unlink content from first category and expect 204");
         restClient.authenticateUser(dataContent.getAdminUser()).withCoreAPI().usingNode(file).unlinkFromCategory(category.getId());
         restClient.assertStatusCodeIs(NO_CONTENT);
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -453,7 +453,7 @@ public class LinkToCategoriesTests extends CategoriesRestTest
         restClient.authenticateUser(dataContent.getAdminUser()).withCoreAPI().usingNode(file).unlinkFromCategory(category.getId());
         restClient.assertStatusCodeIs(NO_CONTENT);
 
-        STEP("Verify that second category is present in file metadata");
+        STEP("Verify that second category is still present in file metadata");
         RestNodeModel fileNode = restClient.authenticateUser(user).withCoreAPI().usingNode(file).getNode();
 
         fileNode.assertThat().field(ASPECTS_FIELD).contains("cm:generalclassifiable");

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/categories/LinkToCategoriesTests.java
@@ -417,7 +417,7 @@ public class LinkToCategoriesTests extends CategoriesRestTest
         fileNode.assertThat().field(PROPERTIES_FIELD).contains(category.getId());
 
         STEP("Unlink content from created category and expect 204");
-        restClient.authenticateUser(dataContent.getAdminUser()).withCoreAPI().usingNode(file).unlinkFromCategory(category.getId());
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).unlinkFromCategory(category.getId());
         restClient.assertStatusCodeIs(NO_CONTENT);
 
         STEP("Verify that category isn't present in file metadata");
@@ -447,7 +447,7 @@ public class LinkToCategoriesTests extends CategoriesRestTest
         restClient.assertStatusCodeIs(CREATED);
 
         STEP("Unlink content from first category and expect 204");
-        restClient.authenticateUser(dataContent.getAdminUser()).withCoreAPI().usingNode(file).unlinkFromCategory(category.getId());
+        restClient.authenticateUser(user).withCoreAPI().usingNode(file).unlinkFromCategory(category.getId());
         restClient.assertStatusCodeIs(NO_CONTENT);
 
         STEP("Verify that second category is still present in file metadata");

--- a/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
@@ -71,4 +71,12 @@ public interface Categories
      * @return Linked to categories.
      */
     List<Category> linkNodeToCategories(String nodeId, List<Category> categoryLinks);
+
+    /**
+     * Unlink node from a category.
+     *
+     * @param nodeId Node ID.
+     * @param categoryId Category ID from which content node should be unlinked from.
+     */
+    void unlinkNodeFromCategory(String nodeId, String categoryId, Parameters parameters);
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/categories/NodesCategoryLinksRelation.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/categories/NodesCategoryLinksRelation.java
@@ -40,7 +40,9 @@ import org.alfresco.rest.framework.resource.parameters.ListPage;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
 
 @RelationshipResource(name = "category-links", entityResource = NodesEntityResource.class, title = "Category links")
-public class NodesCategoryLinksRelation implements RelationshipResourceAction.Read<Category>, RelationshipResourceAction.Create<Category>
+public class NodesCategoryLinksRelation implements RelationshipResourceAction.Create<Category>,
+                                                    RelationshipResourceAction.Read<Category>,
+                                                    RelationshipResourceAction.Delete
 {
 
     private final Categories categories;
@@ -77,4 +79,19 @@ public class NodesCategoryLinksRelation implements RelationshipResourceAction.Re
     {
         return categories.linkNodeToCategories(nodeId, categoryLinks);
     }
+
+    /**
+     * DELETE /nodes/{nodeId}/category-links/{categoryId}
+     */
+    @WebApiDescription(
+            title = "Unlink content node from category",
+            description = "Removes the link between a content node and a category",
+            successStatus = HttpServletResponse.SC_NO_CONTENT
+    )
+    @Override
+    public void delete(String nodeId, String categoryId, Parameters parameters)
+    {
+        categories.unlinkNodeFromCategory(nodeId, categoryId, parameters);
+    }
+
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -217,7 +217,7 @@ public class CategoriesImpl implements Categories
 
         if (isCategoryAspectMissing(contentNodeRef))
         {
-            throw new InvalidArgumentException("Node with id: " + nodeId + "does not belong to a category");
+            throw new InvalidArgumentException("Node with id: " + nodeId + " does not belong to a category");
         }
         if (isRootCategory(categoryNodeRef))
         {

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -224,8 +224,7 @@ public class CategoriesImpl implements Categories
             throw new InvalidArgumentException(NOT_A_VALID_CATEGORY, new String[]{categoryId});
         }
 
-        final Serializable currentCategories = nodeService.getProperty(contentNodeRef, ContentModel.PROP_CATEGORIES);
-        final Collection<NodeRef> allCategories = removeCategory(currentCategories, categoryNodeRef);
+        final Collection<NodeRef> allCategories = removeCategory(contentNodeRef, categoryNodeRef);
 
         if (allCategories.size()==0)
         {
@@ -401,12 +400,13 @@ public class CategoriesImpl implements Categories
 
     /**
      * Remove specified category from present categories.
-     * @param currentCategories already present categories.
+     * @param contentNodeRef the nodeRef that contains the categories.
      * @param categoryToRemove category that should be removed.
      * @return updated category list.
      */
-    private Collection<NodeRef> removeCategory(final Serializable currentCategories, final NodeRef categoryToRemove)
+    private Collection<NodeRef> removeCategory(final NodeRef contentNodeRef, final NodeRef categoryToRemove)
     {
+        final Serializable currentCategories = nodeService.getProperty(contentNodeRef, ContentModel.PROP_CATEGORIES);
         final Collection<NodeRef> actualCategories = DefaultTypeConverter.INSTANCE.getCollection(NodeRef.class, currentCategories);
         final Collection<NodeRef> updatedCategories = new HashSet<>(actualCategories);
         updatedCategories.remove(categoryToRemove);

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -230,7 +230,7 @@ public class CategoriesImpl implements Categories
         if (allCategories.size()==0)
         {
             nodeService.removeAspect(contentNodeRef, ContentModel.ASPECT_GEN_CLASSIFIABLE);
-            nodeService.removeProperty(categoryNodeRef, ContentModel.PROP_CATEGORIES);
+            nodeService.removeProperty(contentNodeRef, ContentModel.PROP_CATEGORIES);
             return;
         }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -207,6 +207,36 @@ public class CategoriesImpl implements Categories
         return categoryNodeRefs.stream().map(this::mapToCategory).collect(Collectors.toList());
     }
 
+    @Override
+    public void unlinkNodeFromCategory(String nodeId, String categoryId, Parameters parameters)
+    {
+        final NodeRef categoryNodeRef = getCategoryNodeRef(categoryId);
+        final NodeRef contentNodeRef = nodes.validateNode(nodeId);
+        verifyChangePermission(contentNodeRef);
+        verifyNodeType(contentNodeRef);
+
+        if (isCategoryAspectMissing(contentNodeRef))
+        {
+            throw new InvalidArgumentException("Node with id: " + nodeId + "does not belong to a category");
+        }
+        if (isRootCategory(categoryNodeRef))
+        {
+            throw new InvalidArgumentException(NOT_A_VALID_CATEGORY, new String[]{categoryId});
+        }
+
+        final Serializable currentCategories = nodeService.getProperty(contentNodeRef, ContentModel.PROP_CATEGORIES);
+        final Collection<NodeRef> allCategories = removeCategory(currentCategories, categoryNodeRef);
+
+        if (allCategories.size()==0)
+        {
+            nodeService.removeAspect(contentNodeRef, ContentModel.ASPECT_GEN_CLASSIFIABLE);
+            nodeService.removeProperty(categoryNodeRef, ContentModel.PROP_CATEGORIES);
+            return;
+        }
+
+        nodeService.setProperty(contentNodeRef, ContentModel.PROP_CATEGORIES, (Serializable) allCategories);
+    }
+
     private void verifyAdminAuthority()
     {
         if (!authorityService.hasAdminAuthority())
@@ -367,6 +397,21 @@ public class CategoriesImpl implements Categories
         allCategories.addAll(newCategories);
 
         return allCategories;
+    }
+
+    /**
+     * Remove specified category from present categories.
+     * @param currentCategories already present categories.
+     * @param categoryToRemove category that should be removed.
+     * @return updated category list.
+     */
+    private Collection<NodeRef> removeCategory(final Serializable currentCategories, final NodeRef categoryToRemove)
+    {
+        final Collection<NodeRef> actualCategories = DefaultTypeConverter.INSTANCE.getCollection(NodeRef.class, currentCategories);
+        final Collection<NodeRef> updatedCategories = new HashSet<>(actualCategories);
+        updatedCategories.remove(categoryToRemove);
+
+        return updatedCategories;
     }
 
     /**

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -208,7 +208,7 @@ public class CategoriesImpl implements Categories
     }
 
     @Override
-    public void unlinkNodeFromCategory(String nodeId, String categoryId, Parameters parameters)
+    public void unlinkNodeFromCategory(final String nodeId, final String categoryId, Parameters parameters)
     {
         final NodeRef categoryNodeRef = getCategoryNodeRef(categoryId);
         final NodeRef contentNodeRef = nodes.validateNode(nodeId);

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
@@ -1034,8 +1034,24 @@ public class CategoriesImplTest
         then(permissionServiceMock).shouldHaveNoMoreInteractions();
         then(typeConstraint).should().matches(CONTENT_NODE_REF);
         then(typeConstraint).shouldHaveNoMoreInteractions();
+        then(nodeServiceMock).should().hasAspect(CONTENT_NODE_REF,ContentModel.ASPECT_GEN_CLASSIFIABLE);
         then(nodeServiceMock).should().getProperty(CONTENT_NODE_REF, ContentModel.PROP_CATEGORIES);
         then(nodeServiceMock).should().setProperty(eq(CONTENT_NODE_REF),eq(ContentModel.PROP_CATEGORIES),any());
+    }
+
+    @Test
+    public void testUnlinkNodeFromCategory_missingCategoryAspect()
+    {
+        given(nodeServiceMock.hasAspect(CONTENT_NODE_REF, ContentModel.ASPECT_GEN_CLASSIFIABLE)).willReturn(false);
+
+        //when
+        final Throwable actualException = catchThrowable(() -> objectUnderTest.unlinkNodeFromCategory(CONTENT_NODE_ID,CATEGORY_ID, parametersMock));
+
+        then(nodeServiceMock).should().hasAspect(CONTENT_NODE_REF,ContentModel.ASPECT_GEN_CLASSIFIABLE);
+        then(nodeServiceMock).shouldHaveNoMoreInteractions();
+        assertThat(actualException)
+                .isInstanceOf(InvalidArgumentException.class)
+                .hasMessageContaining("does not belong to a category");
     }
 
     @Test

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/CategoriesImplTest.java
@@ -1021,6 +1021,24 @@ public class CategoriesImplTest
     }
 
     @Test
+    public void testUnlinkNodeFromCategory()
+    {
+        given(nodeServiceMock.hasAspect(CONTENT_NODE_REF,ContentModel.ASPECT_GEN_CLASSIFIABLE)).willReturn(true);
+
+        // when
+        objectUnderTest.unlinkNodeFromCategory(CONTENT_NODE_ID, CATEGORY_ID, parametersMock);
+
+        then(nodesMock).should().validateNode(CATEGORY_ID);
+        then(nodesMock).should().validateNode(CONTENT_NODE_ID);
+        then(permissionServiceMock).should().hasPermission(CONTENT_NODE_REF, PermissionService.CHANGE_PERMISSIONS);
+        then(permissionServiceMock).shouldHaveNoMoreInteractions();
+        then(typeConstraint).should().matches(CONTENT_NODE_REF);
+        then(typeConstraint).shouldHaveNoMoreInteractions();
+        then(nodeServiceMock).should().getProperty(CONTENT_NODE_REF, ContentModel.PROP_CATEGORIES);
+        then(nodeServiceMock).should().setProperty(eq(CONTENT_NODE_REF),eq(ContentModel.PROP_CATEGORIES),any());
+    }
+
+    @Test
     public void testListCategoriesForNode()
     {
         final NodeRef categoryParentNodeRef = createNodeRefWithId(PARENT_ID);


### PR DESCRIPTION
Remove a piece of content from a category - DELETE /nodes/{nodeId}/category-links/{categoryId}
[https://alfresco.atlassian.net/browse/ACS-4035](https://alfresco.atlassian.net/browse/ACS-4035)