### PR TITLE
[MNT-23396] [MNT-23391] Change call stack depth limit to be only applied to custom scripts / Clean scope only for custom scripts (#1592)

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/jscript/AlfrescoScriptContext.java
+++ b/repository/src/main/java/org/alfresco/repo/jscript/AlfrescoScriptContext.java
@@ -25,6 +25,8 @@
  */
 package org.alfresco.repo.jscript;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mozilla.javascript.Context;
 
 /**
@@ -36,8 +38,36 @@ public class AlfrescoScriptContext extends Context
 {
     private long startTime;
     private long threadId;
-    private long startMemory;
+    private long startMemory = -1;
     private boolean limitsEnabled = false;
+    private AlfrescoScriptThreadMxBeanWrapper threadMxBeanWrapper = null;
+
+    public void setStartMemory()
+    {
+        if (isMemoryLimitSupported())
+        {
+            startMemory = threadMxBeanWrapper.getThreadAllocatedBytes(threadId);
+        }
+    }
+
+    public long getUsedMemory()
+    {
+        long usedMemory = -1;
+
+        if (isMemoryLimitSupported())
+        {
+            long currentAllocatedBytes = threadMxBeanWrapper.getThreadAllocatedBytes(threadId);
+            usedMemory = currentAllocatedBytes - startMemory;
+        }
+
+        return usedMemory;
+    }
+
+    public boolean isMemoryLimitSupported()
+    {
+        AlfrescoScriptThreadMxBeanWrapper tmxw = getThreadMxBeanWrapper();
+        return tmxw != null && tmxw.isThreadAllocatedMemorySupported();
+    }
 
     public long getStartTime()
     {
@@ -77,5 +107,20 @@ public class AlfrescoScriptContext extends Context
     public void setLimitsEnabled(boolean limitsEnabled)
     {
         this.limitsEnabled = limitsEnabled;
+    }
+
+    public AlfrescoScriptThreadMxBeanWrapper getThreadMxBeanWrapper()
+    {
+        if (threadMxBeanWrapper == null)
+        {
+            threadMxBeanWrapper = new AlfrescoScriptThreadMxBeanWrapper();
+        }
+
+        return threadMxBeanWrapper;
+    }
+
+    public void setThreadMxBeanWrapper(AlfrescoScriptThreadMxBeanWrapper threadMxBeanWrapper)
+    {
+        this.threadMxBeanWrapper = threadMxBeanWrapper;
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/jscript/AlfrescoScriptThreadMxBeanWrapper.java
+++ b/repository/src/main/java/org/alfresco/repo/jscript/AlfrescoScriptThreadMxBeanWrapper.java
@@ -54,7 +54,7 @@ public class AlfrescoScriptThreadMxBeanWrapper
         return -1;
     }
 
-    public void checkThreadAllocatedMemory()
+    private void checkThreadAllocatedMemory()
     {
         try
         {

--- a/repository/src/main/java/org/alfresco/repo/jscript/RhinoScriptProcessor.java
+++ b/repository/src/main/java/org/alfresco/repo/jscript/RhinoScriptProcessor.java
@@ -614,13 +614,29 @@ public class RhinoScriptProcessor extends BaseProcessor implements ScriptProcess
         }
         finally
         {
-            unsetScope(model, scope);
+            if (!secure)
+            {
+                unsetScope(model, scope);
+            }
             Context.exit();
             
             if (callLogger.isDebugEnabled())
             {
                 long endTime = System.nanoTime();
-                callLogger.debug(debugScriptName+" End " + (endTime - startTime)/1000000 + " ms");
+
+                String logMessage = debugScriptName + " End " + (endTime - startTime) / 1000000 + " ms";
+
+                if (cx instanceof AlfrescoScriptContext)
+                {
+                    AlfrescoScriptContext acx = (AlfrescoScriptContext) cx;
+                    long usedMemory = acx.getUsedMemory();
+                    if (usedMemory > 0)
+                    {
+                        logMessage += " - Used memory: " + usedMemory + " bytes";
+                    }
+                }
+
+                callLogger.debug(logMessage);
             }
         }
     }

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1365,4 +1365,4 @@ scripts.execution.maxStackDepth=-1
 scripts.execution.maxMemoryUsedInBytes=-1
 
 # Number of instructions that will trigger the observer
-scripts.execution.observerInstructionCount=-1
+scripts.execution.observerInstructionCount=5000


### PR DESCRIPTION
* [MNT-23396] Change call stack depth limit to be only applied to custom scripts (as memory and time limits)

* [MNT-23396] Changed how memory usage is obtained

* [MNT-23391] Only clean scope if script is not considered secure (custom script)

(cherry picked from commit 95ab83d2b1bebf78271395cbadb17f80ba989d4e)

[MNT-23396]: https://alfresco.atlassian.net/browse/MNT-23396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-23396]: https://alfresco.atlassian.net/browse/MNT-23396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-23391]: https://alfresco.atlassian.net/browse/MNT-23391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ