### PR TITLE
ACS-4177 Improve rendition API tests retry logic

### DIFF
--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
@@ -542,8 +542,8 @@ public class Node extends ModelRequest<Node>
                 renditionId);
         RestResponse response = restWrapper.process(request);
         int retry = 0;
-        //Multiplied by '4' because AI rendition test cases need more time (~30 seconds) - see ACS-2158
-        while (Integer.valueOf(response.getStatusCode()).equals(HttpStatus.NOT_FOUND.value()) && retry < (4 * Utility.retryCountSeconds))
+        //Multiplied by '8' because AI rendition test cases need more time (~30 seconds) - see ACS-2158
+        while (Integer.valueOf(response.getStatusCode()).equals(HttpStatus.NOT_FOUND.value()) && retry < (8 * Utility.retryCountSeconds))
         {
             Utility.waitToLoopTime(1);
             response = restWrapper.process(request);

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/Node.java
@@ -543,7 +543,7 @@ public class Node extends ModelRequest<Node>
         RestResponse response = restWrapper.process(request);
         int retry = 0;
         //Multiplied by '8' because AI rendition test cases need more time (~30 seconds) - see ACS-2158
-        while (Integer.valueOf(response.getStatusCode()).equals(HttpStatus.NOT_FOUND.value()) && retry < (8 * Utility.retryCountSeconds))
+        while (!Integer.valueOf(response.getStatusCode()).equals(HttpStatus.OK.value()) && retry < (8 * Utility.retryCountSeconds))
         {
             Utility.waitToLoopTime(1);
             response = restWrapper.process(request);

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
@@ -44,20 +44,20 @@ public abstract class RenditionIntegrationTests extends RestTest
         // 2. Create a rendition of the file using RESTAPI
         restClient.withCoreAPI().usingNode(file).createNodeRendition(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.ACCEPTED.value(),
-                "Failed to submit a request for rendition. [" + fileName+ ", " + renditionId+"] [source file, rendition ID]. ");
+                "Failed to submit a request for rendition. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID])";
 
         // 3. Verify that a rendition of the file is created and has content using RESTAPI
         RestResponse restResponse = restClient.withCoreAPI().usingNode(file).getNodeRenditionContentUntilIsCreated(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.OK.value(),
-                "Failed to produce rendition. [" + fileName+ ", " + renditionId+"] [source file, rendition ID] ");
+                "Failed to produce rendition. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
 
         // 4. Check the returned content type
         Assert.assertEquals(restClient.getResponseHeaders().getValue("Content-Type"), expectedMimeType+";charset=UTF-8",
-                "Rendition was created but it has the wrong Content-Type. [" + fileName+ ", " + renditionId + "] [source file, rendition ID]");
+                "Rendition was created but it has the wrong Content-Type. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
 
 
         Assert.assertTrue((restResponse.getResponse().body().asInputStream().available() > 0),
-                "Rendition was created but its content is empty. [" + fileName+ ", " + renditionId+"] [source file, rendition ID] ");
+                "Rendition was created but its content is empty. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
@@ -44,20 +44,20 @@ public abstract class RenditionIntegrationTests extends RestTest
         // 2. Create a rendition of the file using RESTAPI
         restClient.withCoreAPI().usingNode(file).createNodeRendition(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.ACCEPTED.value(),
-                "Failed to submit a request for rendition. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
+                "Failed to submit a request for rendition. [" + fileName + ", " + nodeId + ", " + renditionId + "] [source file, node ID, rendition ID]");
 
         // 3. Verify that a rendition of the file is created and has content using RESTAPI
         RestResponse restResponse = restClient.withCoreAPI().usingNode(file).getNodeRenditionContentUntilIsCreated(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.OK.value(),
-                "Failed to produce rendition. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
+                "Failed to produce rendition. [" + fileName + ", " + nodeId + ", " + renditionId + "] [source file, node ID, rendition ID]");
 
         // 4. Check the returned content type
         Assert.assertEquals(restClient.getResponseHeaders().getValue("Content-Type"), expectedMimeType+";charset=UTF-8",
-                "Rendition was created but it has the wrong Content-Type. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
+                "Rendition was created but it has the wrong Content-Type. [" + fileName+ ", " + nodeId + ", " + renditionId + "] [source file, node ID, rendition ID]");
 
 
         Assert.assertTrue((restResponse.getResponse().body().asInputStream().available() > 0),
-                "Rendition was created but its content is empty. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
+                "Rendition was created but its content is empty. [" + fileName + ", " + nodeId + ", " + renditionId + "] [source file, node ID, rendition ID]");
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/renditions/RenditionIntegrationTests.java
@@ -44,7 +44,7 @@ public abstract class RenditionIntegrationTests extends RestTest
         // 2. Create a rendition of the file using RESTAPI
         restClient.withCoreAPI().usingNode(file).createNodeRendition(renditionId);
         Assert.assertEquals(Integer.valueOf(restClient.getStatusCode()).intValue(), HttpStatus.ACCEPTED.value(),
-                "Failed to submit a request for rendition. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID])";
+                "Failed to submit a request for rendition. [" + fileName+ ", " + nodeId + ", " + renditionId+"] [source file, node ID, rendition ID]");
 
         // 3. Verify that a rendition of the file is created and has content using RESTAPI
         RestResponse restResponse = restClient.withCoreAPI().usingNode(file).getNodeRenditionContentUntilIsCreated(renditionId);


### PR DESCRIPTION
Improve the retry logic of the rendition API tests to reduce the chance of failing tests on https://github.com/Alfresco/terraform-alfresco-pipeline/actions.
This also addresses [ACS-4433](https://alfresco.atlassian.net/browse/ACS-4433).

[ACS-4433]: https://alfresco.atlassian.net/browse/ACS-4433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ