### PR TITLE
ACS-4464 Always build application when build or prepare are called.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - name: "Prepare environment"
+      - name: "Prepare maven cache and check compilation"
         run: bash ./scripts/ci/prepare.sh
       - name: "Clean Maven cache"
         run: bash ./scripts/ci/cleanup_cache.sh

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -6,29 +6,21 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/../../"
 
 source "$(dirname "${BASH_SOURCE[0]}")/build_functions.sh"
 
-
-# Build the current project if needed
-if [[ -n ${REQUIRES_INSTALLED_ARTIFACTS} ]] || [[ -n ${REQUIRES_LOCAL_IMAGES} ]] || [[ -n ${BUILD_PROFILES} ]]; then
-
-  if [[ -n ${BUILD_PROFILES} ]]; then
-    PROFILES="${BUILD_PROFILES}"
-  else
-    if [[ "${REQUIRES_LOCAL_IMAGES}" == "true" ]]; then
-      PROFILES="-Pbuild-docker-images -Pags"
-    else
-      PROFILES="-Pags"
-    fi
-  fi
-
-  if [[ "${REQUIRES_INSTALLED_ARTIFACTS}" == "true" ]]; then
-    PHASE="install"
-  else
-    PHASE="package"
-  fi
-
-  mvn -B -V $PHASE -DskipTests -Dmaven.javadoc.skip=true $PROFILES $BUILD_OPTIONS
+if [[ -n ${BUILD_PROFILES} ]]; then
+  PROFILES="${BUILD_PROFILES}"
+elif [[ "${REQUIRES_LOCAL_IMAGES}" == "true" ]]; then
+  PROFILES="-Pbuild-docker-images -Pags"
+else
+  PROFILES="-Pags"
 fi
 
+if [[ "${REQUIRES_INSTALLED_ARTIFACTS}" == "true" ]]; then
+  PHASE="install"
+else
+  PHASE="package"
+fi
+
+mvn -B -V $PHASE -DskipTests -Dmaven.javadoc.skip=true $PROFILES $BUILD_OPTIONS
 
 popd
 set +vex

--- a/scripts/ci/prepare.sh
+++ b/scripts/ci/prepare.sh
@@ -23,9 +23,7 @@ if [ $M2_REPO_EXPIRED -eq 1 ];then
   rm -rf "$M2_REPO_DIR"
 fi
 
-if [ $M2_REPO_FILE_COUNT -lt 1000 ] || [ $ORG_ALFRESCO_M2_REPO_EXPIRED -eq 1 ] || [ $M2_REPO_EXPIRED -eq 1 ];then
-  echo "Populating maven cache."
-  export BUILD_PROFILES="-Pall-tas-tests,ags"
-  export BUILD_OPTIONS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.artifact.threads=8"
-  source "$(dirname "${BASH_SOURCE[0]}")/build.sh"
-fi
+echo "Verifying compilation and ensuring maven cache populated."
+export BUILD_PROFILES="-Pall-tas-tests,ags"
+export BUILD_OPTIONS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.artifact.threads=8"
+source "$(dirname "${BASH_SOURCE[0]}")/build.sh"


### PR DESCRIPTION
If build is called then we definitely should be building the application. When prepare is called then we want to prevent further builds running if the application doesn't compile.