### PR TITLE
ACS-3750 Update alfresco-build-tools to v1.32.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Prepare maven cache and check compilation"
@@ -54,11 +54,12 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v1.32.0
+        continue-on-error: true
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
       - name: "Clean Maven cache"
@@ -74,8 +75,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run tests"
@@ -111,8 +112,8 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -144,8 +145,8 @@ jobs:
         version: ['10.2.18', '10.4', '10.5']
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: Run MariaDB ${{ matrix.version }} database
@@ -170,8 +171,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run MariaDB 10.6 database"
@@ -196,8 +197,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run MySQL 8 database"
@@ -221,8 +222,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 13.7 database"
@@ -246,8 +247,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 14.4 database"
@@ -269,8 +270,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run ActiveMQ"
@@ -314,8 +315,8 @@ jobs:
             mvn-options: '-Dindex.subsystem.name=solr6'
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Set transformers tag"
@@ -373,8 +374,8 @@ jobs:
       REQUIRES_LOCAL_IMAGES: true
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -410,8 +411,8 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run Postgres 14.4 database"
@@ -439,8 +440,8 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -470,8 +471,8 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -497,8 +498,8 @@ jobs:
       REQUIRES_LOCAL_IMAGES: true
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |

--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -32,11 +32,11 @@ jobs:
       github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.32.0
         with:
           username: ${{ env.GIT_USERNAME }}
           email: ${{ env.GIT_EMAIL }}
@@ -58,11 +58,11 @@ jobs:
       github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.30.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.32.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.32.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.30.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.32.0
         with:
           username: ${{ env.GIT_USERNAME }}
           email: ${{ env.GIT_EMAIL }}


### PR DESCRIPTION
Bumping alfresco-build-tools actions to v1.32.0 and updating the veracode action accordingly.