### PR TITLE
[ACS-3960]Count is only returned for a tag if it is greater than zero

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
@@ -153,7 +153,7 @@ public class TagsImpl implements Tags
         for (Pair<NodeRef, String> pair : page)
         {
             Tag selectedTag = new Tag(pair.getFirst(), pair.getSecond());
-            selectedTag.setCount(tagsByCountMap.get(selectedTag.getTag()));
+            selectedTag.setCount(tagsByCountMap.get(selectedTag.getTag())==null?0:tagsByCountMap.get(selectedTag.getTag()));
             tags.add(selectedTag);
         }
 


### PR DESCRIPTION
Count is only returned for a tag if it is greater than zero


There might be multiple differences in the file as File is having mixed endline characters. Normalize them to Windows-style ( CR LF).