### PR TITLE
ACS-4137 Produce Multi-Arch Docker images

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/Dockerfile
+++ b/amps/ags/rm-community/rm-community-repo/Dockerfile
@@ -1,3 +1,4 @@
+ARG BASE_IMAGE
 # BUILD STAGE AGS
 FROM debian:11-slim AS AGSBUILDER
 
@@ -12,7 +13,7 @@ RUN unzip -q /build/gs-api-explorer-*.war -d /build/gs-api-explorer && \
     chmod -R g-w,o= /build
 
 # ACTUAL IMAGE
-FROM alfresco/alfresco-community-repo-base:${image.tag}
+FROM ${BASE_IMAGE}
 
 # Alfresco user does not have permissions to modify webapps or configuration. Switch to root.
 # The access will be fixed after all operations are done.

--- a/amps/ags/rm-community/rm-community-repo/pom.xml
+++ b/amps/ags/rm-community/rm-community-repo/pom.xml
@@ -547,7 +547,7 @@
                <plugin>
                   <groupId>io.fabric8</groupId>
                   <artifactId>docker-maven-plugin</artifactId>
-                  <configuration combine.self="override">
+                  <configuration>
                      <images>
                         <image>
                            <name>${image.name}:${image.tag}</name>
@@ -587,8 +587,13 @@
                             <name>${local.registry}/${image.name}:${image.tag}</name>
                             <build>
                                <buildx>
+                                  <platforms>
+                                     <platform>linux/amd64</platform>
+                                     <platform>linux/arm64</platform>
+                                  </platforms>
                                   <builderName>${builder.name}</builderName>
                                </buildx>
+                               <contextDir>${project.basedir}</contextDir>
                                <args>
                                   <BASE_IMAGE>${local.registry}/${base.image}:${image.tag}</BASE_IMAGE>
                                </args>
@@ -648,11 +653,16 @@
                             <name>${image.registry}/${image.name}:${image.tag}</name>
                             <build>
                                <buildx>
+                                  <platforms>
+                                     <platform>linux/amd64</platform>
+                                     <platform>linux/arm64</platform>
+                                  </platforms>
                                   <builderName>${builder.name}</builderName>
                                </buildx>
                                <args>
                                   <BASE_IMAGE>${local.registry}/${base.image}:${image.tag}</BASE_IMAGE>
                                </args>
+                               <contextDir>${project.basedir}</contextDir>
                             </build>
                          </image>
                          <image>
@@ -660,11 +670,16 @@
                             <name>${image.name}:${image.tag}</name>
                             <build>
                                <buildx>
+                                  <platforms>
+                                     <platform>linux/amd64</platform>
+                                     <platform>linux/arm64</platform>
+                                  </platforms>
                                   <builderName>${builder.name}</builderName>
                                </buildx>
                                <args>
                                   <BASE_IMAGE>${local.registry}/${base.image}:${image.tag}</BASE_IMAGE>
                                </args>
+                               <contextDir>${project.basedir}</contextDir>
                             </build>
                          </image>
                       </images>

--- a/amps/ags/rm-community/rm-community-repo/pom.xml
+++ b/amps/ags/rm-community/rm-community-repo/pom.xml
@@ -15,6 +15,8 @@
       <app.amp.client.war.folder>${project.build.directory}/${project.build.finalName}-war</app.amp.client.war.folder>
 
       <image.name>alfresco/alfresco-governance-repository-community-base</image.name>
+      <base.image>alfresco/alfresco-community-repo-base</base.image>
+      <scripts.directory>${project.parent.parent.parent.parent.basedir}/scripts</scripts.directory>
    </properties>
 
    <dependencies>
@@ -537,9 +539,43 @@
          </build>
       </profile>
 
+      <profile>
+         <id>build-docker-images</id>
+         <!-- builds "image:latest" locally -->
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>io.fabric8</groupId>
+                  <artifactId>docker-maven-plugin</artifactId>
+                  <configuration combine.self="override">
+                     <images>
+                        <image>
+                           <name>${image.name}:${image.tag}</name>
+                           <build>
+                              <args>
+                                 <BASE_IMAGE>${base.image}:${image.tag}</BASE_IMAGE>
+                              </args>
+                              <contextDir>${project.basedir}</contextDir>
+                           </build>
+                        </image>
+                     </images>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>build-image</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>build</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+
        <profile>
-          <id>build-docker-images</id>
-          <!-- builds "image:latest" locally -->
+          <id>build-multiarch-docker-images</id>
           <build>
              <plugins>
                 <plugin>
@@ -548,17 +584,48 @@
                    <configuration>
                       <images>
                          <image>
-                            <name>${image.name}:${image.tag}</name>
+                            <name>${local.registry}/${image.name}:${image.tag}</name>
+                            <build>
+                               <buildx>
+                                  <builderName>${builder.name}</builderName>
+                               </buildx>
+                               <args>
+                                  <BASE_IMAGE>${local.registry}/${base.image}:${image.tag}</BASE_IMAGE>
+                               </args>
+                            </build>
                          </image>
                       </images>
                    </configuration>
                    <executions>
                       <execution>
-                         <id>build-image</id>
-                         <phase>package</phase>
+                         <id>build-push-image</id>
+                         <phase>install</phase>
                          <goals>
                             <goal>build</goal>
+                            <goal>push</goal>
                          </goals>
+                      </execution>
+                   </executions>
+                </plugin>
+                <plugin>
+                   <artifactId>exec-maven-plugin</artifactId>
+                   <groupId>org.codehaus.mojo</groupId>
+                   <executions>
+                      <execution>
+                         <id>prepare-buildx</id>
+                         <phase>generate-sources</phase>
+                         <goals>
+                            <goal>exec</goal>
+                         </goals>
+                         <configuration>
+                            <executable>${scripts.directory}/prepare_buildx.sh</executable>
+                            <arguments>
+                               <argument>${builder.name}</argument>
+                               <argument>${image.registry}</argument>
+                               <argument>${image.name}</argument>
+                               <argument>${image.tag}</argument>
+                            </arguments>
+                         </configuration>
                       </execution>
                    </executions>
                 </plugin>
@@ -578,12 +645,27 @@
                       <images>
                          <image>
                             <!-- Quay image -->
-                            <name>${image.name}:${image.tag}</name>
-                            <registry>${image.registry}</registry>
+                            <name>${image.registry}/${image.name}:${image.tag}</name>
+                            <build>
+                               <buildx>
+                                  <builderName>${builder.name}</builderName>
+                               </buildx>
+                               <args>
+                                  <BASE_IMAGE>${local.registry}/${base.image}:${image.tag}</BASE_IMAGE>
+                               </args>
+                            </build>
                          </image>
                          <image>
                             <!-- DockerHub image -->
                             <name>${image.name}:${image.tag}</name>
+                            <build>
+                               <buildx>
+                                  <builderName>${builder.name}</builderName>
+                               </buildx>
+                               <args>
+                                  <BASE_IMAGE>${local.registry}/${base.image}:${image.tag}</BASE_IMAGE>
+                               </args>
+                            </build>
                          </image>
                       </images>
                    </configuration>
@@ -598,6 +680,28 @@
                       </execution>
                    </executions>
                 </plugin>
+                 <plugin>
+                     <artifactId>exec-maven-plugin</artifactId>
+                     <groupId>org.codehaus.mojo</groupId>
+                     <executions>
+                        <execution>
+                            <id>prepare-buildx</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                               <goal>exec</goal>
+                            </goals>
+                            <configuration>
+                               <executable>${scripts.directory}/prepare_buildx.sh</executable>
+                               <arguments>
+                                  <argument>${builder.name}</argument>
+                                  <argument>${image.registry}</argument>
+                                  <argument>${image.name}</argument>
+                                  <argument>${image.tag}</argument>
+                               </arguments>
+                            </configuration>
+                        </execution>
+                     </executions>
+                 </plugin>
              </plugins>
           </build>
        </profile>

--- a/packaging/docker-alfresco/pom.xml
+++ b/packaging/docker-alfresco/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <image.name>alfresco/alfresco-community-repo-base</image.name>
+        <scripts.directory>${project.parent.parent.basedir}/scripts</scripts.directory>
     </properties>
 
     <build>
@@ -135,7 +136,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
+                        <configuration combine.self="override">
                             <images>
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
@@ -157,6 +158,62 @@
         </profile>
 
         <profile>
+            <id>build-multiarch-docker-images</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${local.registry}/${image.name}:${image.tag}</name>
+                                    <build>
+                                        <buildx>
+                                            <builderName>${builder.name}</builderName>
+                                        </buildx>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-push-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <executions>
+                            <execution>
+                                <id>prepare-buildx</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${scripts.directory}/prepare_buildx.sh</executable>
+                                    <arguments>
+                                        <argument>${builder.name}</argument>
+                                        <argument>${image.registry}</argument>
+                                        <argument>${image.name}</argument>
+                                        <argument>${image.tag}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>push-docker-images</id>
             <!-- publishes "image:latest" on Quay & DockerHub -->
             <build>
@@ -168,8 +225,7 @@
                             <images>
                                 <!-- Quay image -->
                                 <image>
-                                    <name>${image.name}:${image.tag}</name>
-                                    <registry>${image.registry}</registry>
+                                    <name>${image.registry}/${image.name}:${image.tag}</name>
                                 </image>
                                 <!-- DockerHub image -->
                                 <image>

--- a/packaging/docker-alfresco/pom.xml
+++ b/packaging/docker-alfresco/pom.xml
@@ -136,7 +136,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <configuration combine.self="override">
+                        <configuration>
                             <images>
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
@@ -170,8 +170,13 @@
                                     <name>${local.registry}/${image.name}:${image.tag}</name>
                                     <build>
                                         <buildx>
+                                            <platforms>
+                                                <platform>linux/amd64</platform>
+                                                <platform>linux/arm64</platform>
+                                            </platforms>
                                             <builderName>${builder.name}</builderName>
                                         </buildx>
+                                        <contextDir>${project.basedir}</contextDir>
                                     </build>
                                 </image>
                             </images>
@@ -226,10 +231,28 @@
                                 <!-- Quay image -->
                                 <image>
                                     <name>${image.registry}/${image.name}:${image.tag}</name>
+                                    <build>
+                                        <buildx>
+                                            <platforms>
+                                                <platform>linux/amd64</platform>
+                                                <platform>linux/arm64</platform>
+                                            </platforms>
+                                        </buildx>
+                                        <contextDir>${project.basedir}</contextDir>
+                                    </build>
                                 </image>
                                 <!-- DockerHub image -->
                                 <image>
                                     <name>${image.name}:${image.tag}</name>
+                                    <build>
+                                        <buildx>
+                                            <platforms>
+                                                <platform>linux/amd64</platform>
+                                                <platform>linux/arm64</platform>
+                                            </platforms>
+                                        </buildx>
+                                        <contextDir>${project.basedir}</contextDir>
+                                    </build>
                                 </image>
                             </images>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
         <build-number>local</build-number>
         <image.tag>latest</image.tag>
         <image.registry>quay.io</image.registry>
+        <builder.name>entitled-builder</builder.name>
+        <local.registry>127.0.0.1:5000</local.registry>
 
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -917,6 +919,21 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.42.0</version>
+                    <configuration>
+                        <images>
+                            <image>
+                                <build>
+                                    <buildx>
+                                        <platforms>
+                                            <platform>linux/amd64</platform>
+                                            <platform>linux/arm64</platform>
+                                        </platforms>
+                                    </buildx>
+                                    <contextDir>${project.basedir}</contextDir>
+                                </build>
+                            </image>
+                        </images>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -919,21 +919,6 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.42.0</version>
-                    <configuration>
-                        <images>
-                            <image>
-                                <build>
-                                    <buildx>
-                                        <platforms>
-                                            <platform>linux/amd64</platform>
-                                            <platform>linux/arm64</platform>
-                                        </platforms>
-                                    </buildx>
-                                    <contextDir>${project.basedir}</contextDir>
-                                </build>
-                            </image>
-                        </images>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>

--- a/scripts/prepare_buildx.sh
+++ b/scripts/prepare_buildx.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+BUILDER_NAME="${1}"
+TARGET_REGISTRY="${2}"
+TARGET_IMAGE="${3}"
+IMAGE_TAG="${4}"
+
+#Create a `docker-container` builder with host networking and required flags (quay.io)
+docker --config target/docker/"${TARGET_REGISTRY}"/"${TARGET_IMAGE}"/"${IMAGE_TAG}"/docker \
+buildx create --use --name "${BUILDER_NAME}" --driver-opt network=host \
+--buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
+
+#Create a `docker-container` builder with host networking and required flags (docker.io)
+docker --config target/docker/"${TARGET_IMAGE}"/"${IMAGE_TAG}"/docker \
+buildx create --use --name "${BUILDER_NAME}" --driver-opt network=host \
+--buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
+
+#Create a `docker-container` builder with host networking and required flags (local registry)
+docker --config target/docker/127.0.0.1/5000/"${TARGET_IMAGE}"/"${IMAGE_TAG}"/docker \
+buildx create --use --name "${BUILDER_NAME}" --driver-opt network=host \
+--buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'


### PR DESCRIPTION
This PR is to recover reverted changes (ddbaabb71312505dc7dfcfbf909411ce80ed1f11) and remove the multi-arch `docker-maven-plugin` configuration as default.