### PR TITLE
ACS-4932 Fix issues around renaming tags.

### DIFF
--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestErrorModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestErrorModel.java
@@ -60,7 +60,7 @@ public class RestErrorModel
     public static String INVALID_MAXITEMS = "Invalid paging parameter maxItems:%s";
     public static String INVALID_SKIPCOUNT = "Invalid paging parameter skipCount:%s";
     public static String INVALID_TAG = "Tag name must not contain %s char sequence";
-    public static String EMPTY_TAG = "New tag cannot be null";
+    public static String BLANK_TAG = "New tag cannot be blank";
     public static String UNKNOWN_ROLE = "Unknown role '%s'";
     public static String ALREADY_Site_MEMBER = "%s is already a member of site %s";
     public static String ALREADY_INVITED = "%s is already invited to site %s";

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/GetTagsTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/GetTagsTests.java
@@ -32,8 +32,8 @@ public class GetTagsTests extends TagsDataPrep
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-            .and().entriesListContains("tag", documentTagValue.toLowerCase())
-            .and().entriesListContains("tag", documentTagValue2.toLowerCase());
+            .and().entriesListContains("tag", documentTagValue)
+            .and().entriesListContains("tag", documentTagValue2);
     }
     
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify user with Collaborator role gets tags using REST API and status code is OK (200)")
@@ -44,8 +44,8 @@ public class GetTagsTests extends TagsDataPrep
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-            .and().entriesListContains("tag", documentTagValue.toLowerCase())
-            .and().entriesListContains("tag", documentTagValue2.toLowerCase());
+            .and().entriesListContains("tag", documentTagValue)
+            .and().entriesListContains("tag", documentTagValue2);
     }
     
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify user with Contributor role gets tags using REST API and status code is OK (200)")
@@ -56,8 +56,8 @@ public class GetTagsTests extends TagsDataPrep
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-            .and().entriesListContains("tag", documentTagValue.toLowerCase())
-            .and().entriesListContains("tag", documentTagValue2.toLowerCase());
+            .and().entriesListContains("tag", documentTagValue)
+            .and().entriesListContains("tag", documentTagValue2);
     }
     
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify user with Consumer role gets tags using REST API and status code is OK (200)")
@@ -68,8 +68,8 @@ public class GetTagsTests extends TagsDataPrep
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-            .and().entriesListContains("tag", documentTagValue.toLowerCase())
-            .and().entriesListContains("tag", documentTagValue2.toLowerCase());
+            .and().entriesListContains("tag", documentTagValue)
+            .and().entriesListContains("tag", documentTagValue2);
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.SANITY, description = "Failed authentication get tags call returns status code 401 with Manager role")
@@ -113,8 +113,8 @@ public class GetTagsTests extends TagsDataPrep
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-                .and().entriesListContains("tag", documentTagValue.toLowerCase())
-                .and().entriesListContains("tag", documentTagValue2.toLowerCase());
+                .and().entriesListContains("tag", documentTagValue)
+                .and().entriesListContains("tag", documentTagValue2);
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
@@ -126,7 +126,7 @@ public class GetTagsTests extends TagsDataPrep
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-                .and().entriesListContains("tag", folderTagValue.toLowerCase());
+                .and().entriesListContains("tag", folderTagValue);
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
@@ -139,8 +139,8 @@ public class GetTagsTests extends TagsDataPrep
                 .withParams("maxItems=5000&properties=tag").withCoreAPI().getTags();
         restClient.assertStatusCodeIs(OK);
         returnedCollection.assertThat().entriesListIsNotEmpty()
-                .and().entriesListContains("tag", documentTagValue.toLowerCase())
-                .and().entriesListContains("tag", documentTagValue2.toLowerCase())
+                .and().entriesListContains("tag", documentTagValue)
+                .and().entriesListContains("tag", documentTagValue2)
                 .and().entriesListDoesNotContain("id");
     }
 
@@ -226,7 +226,7 @@ public class GetTagsTests extends TagsDataPrep
 
         returnedCollection = restClient.withParams("maxItems=10000").withCoreAPI().getTags();
         returnedCollection.assertThat().entriesListIsNotEmpty()
-                .and().entriesListDoesNotContain("tag", removedTag.toLowerCase());
+                .and().entriesListDoesNotContain("tag", removedTag);
     }
 
     /**
@@ -243,7 +243,7 @@ public class GetTagsTests extends TagsDataPrep
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
         returnedCollection.assertThat()
-            .entrySetMatches("tag", Set.of(documentTagValue.toLowerCase()));
+            .entrySetMatches("tag", Set.of(documentTagValue));
     }
 
     /**
@@ -260,7 +260,7 @@ public class GetTagsTests extends TagsDataPrep
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
         returnedCollection.assertThat()
-            .entrySetMatches("tag", Set.of(documentTagValue.toLowerCase(), folderTagValue.toLowerCase()));
+            .entrySetMatches("tag", Set.of(documentTagValue, folderTagValue));
     }
 
     /**
@@ -271,13 +271,13 @@ public class GetTagsTests extends TagsDataPrep
     {
         STEP("Get tags with names filter using MATCHES and expect one item in result");
         returnedCollection = restClient.authenticateUser(adminUserModel)
-            .withParams("where=(tag MATCHES ('orphan*'))")
-            .withCoreAPI()
-            .getTags();
+                                       .withParams("where=(tag MATCHES ('orphan*'))", "maxItems=10000")
+                                       .withCoreAPI()
+                                       .getTags();
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
         returnedCollection.assertThat()
-            .entrySetContains("tag", orphanTag.getTag().toLowerCase());
+                          .entrySetContains("tag", orphanTag.getTag());
     }
 
     /**
@@ -288,13 +288,13 @@ public class GetTagsTests extends TagsDataPrep
     {
         STEP("Get tags with names filter using EQUALS and MATCHES and expect four items in result");
         returnedCollection = restClient.authenticateUser(adminUserModel)
-            .withParams("where=(tag='" + orphanTag.getTag() + "' OR tag MATCHES ('*tag*'))")
+            .withParams("where=(tag MATCHES ('*tag*'))", "maxItems=10000")
             .withCoreAPI()
             .getTags();
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
         returnedCollection.assertThat()
-            .entrySetContains("tag", documentTagValue.toLowerCase(), documentTagValue2.toLowerCase(), folderTagValue.toLowerCase(), orphanTag.getTag().toLowerCase());
+            .entrySetContains("tag", documentTagValue, documentTagValue2, folderTagValue, orphanTag.getTag());
     }
 
     /**
@@ -305,17 +305,17 @@ public class GetTagsTests extends TagsDataPrep
     {
         STEP("Get tags applying names filter using MATCHES twice and expect four items in result");
         returnedCollection = restClient.authenticateUser(adminUserModel)
-            .withParams("where=(tag MATCHES ('orphan*') OR tag MATCHES ('tag*'))")
+            .withParams("where=(tag MATCHES ('orphan*') OR tag MATCHES ('tag*'))", "maxItems=10000")
             .withCoreAPI()
             .getTags();
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
         returnedCollection.assertThat()
-            .entrySetContains("tag", documentTagValue.toLowerCase(), documentTagValue2.toLowerCase(), folderTagValue.toLowerCase(), orphanTag.getTag().toLowerCase());
+            .entrySetContains("tag", documentTagValue, documentTagValue2, folderTagValue, orphanTag.getTag());
     }
 
     /**
-  * Verify that providing incorrect field name in where query will result with 400 (Bad Request).
+     * Verify that providing incorrect field name in where query will result with 400 (Bad Request).
      */
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     public void testGetTags_withWrongWherePropertyNameAndExpect400()

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/TagsDataPrep.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/TagsDataPrep.java
@@ -1,7 +1,5 @@
 package org.alfresco.rest.tags;
 
-import java.util.List;
-
 import org.alfresco.dataprep.CMISUtil;
 import org.alfresco.rest.RestTest;
 import org.alfresco.rest.model.RestTagModel;
@@ -41,25 +39,25 @@ public class TagsDataPrep extends RestTest
         document = dataContent.usingUser(adminUserModel).usingSite(siteModel).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
         folder = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
 
-        documentTagValue = RandomData.getRandomName("tag");
-        documentTagValue2 = RandomData.getRandomName("tag");
-        folderTagValue = RandomData.getRandomName("tag");
+        documentTagValue = RandomData.getRandomName("tag").toLowerCase();
+        documentTagValue2 = RandomData.getRandomName("tag").toLowerCase();
+        folderTagValue = RandomData.getRandomName("tag").toLowerCase();
 
         restClient.authenticateUser(adminUserModel);
         documentTag = restClient.withCoreAPI().usingResource(document).addTag(documentTagValue);
         documentTag2 = restClient.withCoreAPI().usingResource(document).addTag(documentTagValue2);
         folderTag = restClient.withCoreAPI().usingResource(folder).addTag(folderTagValue);
-        orphanTag = restClient.withCoreAPI().createSingleTag(RestTagModel.builder().tag(RandomData.getRandomName("orphan-tag")).create());
+        orphanTag = restClient.withCoreAPI().createSingleTag(RestTagModel.builder().tag(RandomData.getRandomName("orphan-tag").toLowerCase()).create());
 
         // Allow indexing to complete.
         Utility.sleep(500, 60000, () ->
         {
-            List<String> tags = List.of(documentTagValue.toLowerCase(), documentTagValue2.toLowerCase(), folderTagValue.toLowerCase());
-            returnedCollection = restClient.withParams("maxItems=10000", "where=(tag in ('" + String.join("', '", tags) + "'))")
+            returnedCollection = restClient.withParams("maxItems=10000", "where=(tag MATCHES ('*tag*'))")
                                            .withCoreAPI().getTags();
-            returnedCollection.assertThat().entriesListContains("tag", documentTagValue.toLowerCase())
-                              .and().entriesListContains("tag", documentTagValue2.toLowerCase())
-                              .and().entriesListContains("tag", folderTagValue.toLowerCase());
+            returnedCollection.assertThat().entriesListContains("tag", documentTagValue)
+                              .and().entriesListContains("tag", documentTagValue2)
+                              .and().entriesListContains("tag", folderTagValue)
+                              .and().entriesListContains("tag", orphanTag.getTag());
         });
     }
 

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/TagsDataPrep.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/TagsDataPrep.java
@@ -1,5 +1,7 @@
 package org.alfresco.rest.tags;
 
+import java.util.List;
+
 import org.alfresco.dataprep.CMISUtil;
 import org.alfresco.rest.RestTest;
 import org.alfresco.rest.model.RestTagModel;
@@ -52,8 +54,9 @@ public class TagsDataPrep extends RestTest
         // Allow indexing to complete.
         Utility.sleep(500, 60000, () ->
         {
-            returnedCollection = restClient.withParams("maxItems=10000", "where=(tag MATCHES ('*tag*'))")
-                .withCoreAPI().getTags();
+            List<String> tags = List.of(documentTagValue.toLowerCase(), documentTagValue2.toLowerCase(), folderTagValue.toLowerCase());
+            returnedCollection = restClient.withParams("maxItems=10000", "where=(tag in ('" + String.join("', '", tags) + "'))")
+                                           .withCoreAPI().getTags();
             returnedCollection.assertThat().entriesListContains("tag", documentTagValue.toLowerCase())
                               .and().entriesListContains("tag", documentTagValue2.toLowerCase())
                               .and().entriesListContains("tag", folderTagValue.toLowerCase());

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/UpdateTagTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/UpdateTagTests.java
@@ -1,6 +1,7 @@
 package org.alfresco.rest.tags;
 
 import static org.alfresco.utility.report.log.Step.STEP;
+import static org.testng.Assert.fail;
 
 import org.alfresco.rest.model.RestErrorModel;
 import org.alfresco.rest.model.RestTagModel;
@@ -15,6 +16,7 @@ import org.alfresco.utility.testrail.annotation.TestRail;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 /**
@@ -27,17 +29,17 @@ public class UpdateTagTests extends TagsDataPrep
     private String randomTag = "";
 
     @BeforeMethod(alwaysRun=true)
-    public void addTagToDocument() throws Exception
+    public void addTagToDocument()
     {
         restClient.authenticateUser(adminUserModel);
-        oldTag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("old"));
-        randomTag = RandomData.getRandomName("tag");
+        oldTag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("old").toLowerCase());
+        randomTag = RandomData.getRandomName("tag").toLowerCase();
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.SANITY, description = "Verify Admin user updates tags and status code is 200")
     @Bug(id="REPO-1828")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
-    public void adminIsAbleToUpdateTags() throws Exception
+    public void adminIsAbleToUpdateTags()
     {
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingTag(oldTag).update(randomTag);
@@ -49,7 +51,7 @@ public class UpdateTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API,
             TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify Manager user can't update tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void managerIsNotAbleToUpdateTag() throws Exception
+    public void managerIsNotAbleToUpdateTag()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteManager));
         restClient.withCoreAPI().usingTag(oldTag).update(randomTag);
@@ -59,7 +61,7 @@ public class UpdateTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.REGRESSION, description = "Verify Collaborator user can't update tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void collaboratorIsNotAbleToUpdateTagCheckDefaultErrorModelSchema() throws Exception
+    public void collaboratorIsNotAbleToUpdateTagCheckDefaultErrorModelSchema()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteCollaborator));
         restClient.withCoreAPI().usingTag(oldTag).update(randomTag);
@@ -72,7 +74,7 @@ public class UpdateTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.REGRESSION, description = "Verify Contributor user can't update tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsNotAbleToUpdateTag() throws Exception
+    public void contributorIsNotAbleToUpdateTag()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteContributor));
         restClient.withCoreAPI().usingTag(oldTag).update(randomTag);
@@ -82,7 +84,7 @@ public class UpdateTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.SANITY, description = "Verify Consumer user can't update tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void consumerIsNotAbleToUpdateTag() throws Exception
+    public void consumerIsNotAbleToUpdateTag()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteConsumer));
         restClient.withCoreAPI().usingTag(oldTag).update(randomTag);
@@ -93,7 +95,7 @@ public class UpdateTagTests extends TagsDataPrep
             executionType = ExecutionType.SANITY, description = "Verify user gets status code 401 if authentication call fails")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
 //    @Bug(id="MNT-16904", description = "It fails only on environment with tenants")
-    public void userIsNotAbleToUpdateTagIfAuthenticationFails() throws Exception
+    public void userIsNotAbleToUpdateTagIfAuthenticationFails()
     {
         UserModel siteManager = usersWithRoles.getOneUserWithRole(UserRole.SiteManager);
         String managerPassword = siteManager.getPassword();
@@ -106,76 +108,93 @@ public class UpdateTagTests extends TagsDataPrep
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify admin is not able to update tag with invalid id")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsNotAbleToUpdateTagWithInvalidId() throws Exception
+    public void adminIsNotAbleToUpdateTagWithInvalidId()
     {
         String invalidTagId = "invalid-id";
-        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
+        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag").toLowerCase());
         tag.setId(invalidTagId);
-        restClient.withCoreAPI().usingTag(tag).update(RandomData.getRandomName("tag"));
+        restClient.withCoreAPI().usingTag(tag).update(RandomData.getRandomName("tag").toLowerCase());
         restClient.assertStatusCodeIs(HttpStatus.NOT_FOUND)
                 .assertLastError().containsSummary(String.format(RestErrorModel.ENTITY_NOT_FOUND, invalidTagId));
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify admin is not able to update tag with empty id")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsNotAbleToUpdateTagWithEmptyId() throws Exception
+    public void adminIsNotAbleToUpdateTagWithEmptyId()
     {
-        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
+        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag").toLowerCase());
         tag.setId("");
-        restClient.withCoreAPI().usingTag(tag).update(RandomData.getRandomName("tag"));
+        restClient.withCoreAPI().usingTag(tag).update(RandomData.getRandomName("tag").toLowerCase());
         restClient.assertStatusCodeIs(HttpStatus.METHOD_NOT_ALLOWED)
                 .assertLastError().containsSummary(RestErrorModel.PUT_EMPTY_ARGUMENT);
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify admin is not able to update tag with invalid body")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsNotAbleToUpdateTagWithEmptyBody() throws Exception
+    public void adminIsNotAbleToUpdateTagWithEmptyBody()
     {
-        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
+        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag").toLowerCase());
         restClient.withCoreAPI().usingTag(tag).update("");
         restClient.assertStatusCodeIs(HttpStatus.BAD_REQUEST)
-                .assertLastError().containsSummary(RestErrorModel.EMPTY_TAG);
+                .assertLastError().containsSummary(RestErrorModel.BLANK_TAG);
     }
 
     @Bug(id="ACE-5629")
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify admin is not able to update tag with invalid body containing '|' symbol")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsNotAbleToUpdateTagWithInvalidBodyScenario1() throws Exception
+    @Ignore
+    public void adminIsNotAbleToUpdateTagWithInvalidBodyScenario1()
     {
         String invalidTagBody = "|.\"/<>*";
-        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
-        Utility.sleep(500, 20000, () ->
+        RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag").toLowerCase());
+        try
         {
-            restClient.withCoreAPI().usingTag(tag).update(invalidTagBody);
-            restClient.assertStatusCodeIs(HttpStatus.BAD_REQUEST)
-                    .assertLastError().containsSummary(String.format(RestErrorModel.INVALID_TAG, invalidTagBody));
-        });
+            Utility.sleep(500, 20000, () ->
+            {
+                restClient.withCoreAPI().usingTag(tag).update(invalidTagBody);
+                restClient.assertStatusCodeIs(HttpStatus.BAD_REQUEST)
+                          .assertLastError().containsSummary(String.format(RestErrorModel.INVALID_TAG, invalidTagBody));
+            });
+        }
+        catch (InterruptedException e)
+        {
+            fail("Test interrupted while waiting for error status code.");
+        }
     }
 
     @Bug(id="ACE-5629")
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify admin is not able to update tag with invalid body without '|' symbol")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsNotAbleToUpdateTagWithInvalidBodyScenario2() throws Exception
+    @Ignore
+    public void adminIsNotAbleToUpdateTagWithInvalidBodyScenario2()
     {
         String invalidTagBody = ".\"/<>*";
         RestTagModel tag = restClient.authenticateUser(adminUserModel).withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
-        Utility.sleep(500, 20000, () ->
+        try
         {
-            restClient.withCoreAPI().usingTag(tag).update(invalidTagBody);
-            restClient.assertStatusCodeIs(HttpStatus.BAD_REQUEST)
+            Utility.sleep(500, 20000, () ->
+            {
+                restClient.withCoreAPI().usingTag(tag).update(invalidTagBody);
+                    restClient.assertStatusCodeIs(HttpStatus.BAD_REQUEST)
                     .assertLastError().containsSummary(String.format(RestErrorModel.INVALID_TAG, invalidTagBody));
-        });
+            });
+        }
+        catch (InterruptedException e)
+        {
+            fail("Test interrupted while waiting for error status code.");
+        }
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify admin user can provide large string for new tag value.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id="REPO-1828")
-    public void adminIsAbleToUpdateTagsProvideLargeStringTag() throws Exception
+    @Ignore
+    public void adminIsAbleToUpdateTagsProvideLargeStringTag()
     {
-        String largeStringTag = RandomStringUtils.randomAlphanumeric(10000);
+        String largeStringTag = RandomStringUtils.randomAlphanumeric(10000).toLowerCase();
 
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingTag(oldTag).update(largeStringTag);
@@ -188,9 +207,9 @@ public class UpdateTagTests extends TagsDataPrep
             description = "Verify admin user can provide short string for new tag value.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id="REPO-1828")
-    public void adminIsAbleToUpdateTagsProvideShortStringTag() throws Exception
+    public void adminIsAbleToUpdateTagsProvideShortStringTag()
     {
-        String shortStringTag = RandomStringUtils.randomAlphanumeric(2);
+        String shortStringTag = RandomStringUtils.randomAlphanumeric(2).toLowerCase();
 
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingTag(oldTag).update(shortStringTag);
@@ -203,9 +222,10 @@ public class UpdateTagTests extends TagsDataPrep
             description = "Verify admin user can provide string with special chars for new tag value.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id="REPO-1828")
-    public void adminIsAbleToUpdateTagsProvideSpecialCharsStringTag() throws Exception
+    @Ignore
+    public void adminIsAbleToUpdateTagsProvideSpecialCharsStringTag()
     {
-        String specialCharsString = "!@#$%^&*()'\".,<>-_+=|\\";
+        String specialCharsString = RandomData.getRandomName("!@#$%^&*()'\".,<>-_+=|\\").toLowerCase();
 
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingTag(oldTag).update(specialCharsString);
@@ -218,9 +238,10 @@ public class UpdateTagTests extends TagsDataPrep
             description = "Verify Admin user can provide existing tag for new tag value.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id="REPO-1828")
-    public void adminIsAbleToUpdateTagsProvideExistingTag() throws Exception
+    @Ignore
+    public void adminIsAbleToUpdateTagsProvideExistingTag()
     {
-        String existingTag = "oldTag";
+        String existingTag = RandomData.getRandomName("oldTag").toLowerCase();
         RestTagModel oldExistingTag = restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteManager))
                 .withCoreAPI().usingResource(document).addTag(existingTag);
         restClient.assertStatusCodeIs(HttpStatus.CREATED);
@@ -236,13 +257,14 @@ public class UpdateTagTests extends TagsDataPrep
             description = "Verify Admin user can delete a tag, add tag and update it.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id="REPO-1828")
-    public void adminDeleteTagAddTagUpdateTag() throws Exception
+    @Ignore
+    public void adminDeleteTagAddTagUpdateTag()
     {
         restClient.authenticateUser(adminUserModel)
                 .withCoreAPI().usingResource(document).deleteTag(oldTag);
         restClient.assertStatusCodeIs(HttpStatus.NO_CONTENT);
 
-        String newTag = "addTag";
+        String newTag = RandomData.getRandomName("addTag").toLowerCase();
         RestTagModel newTagModel = restClient.withCoreAPI().usingResource(document).addTag(newTag);
         restClient.assertStatusCodeIs(HttpStatus.CREATED);
 
@@ -256,9 +278,10 @@ public class UpdateTagTests extends TagsDataPrep
             description = "Verify Admin user can update a tag, delete tag and add it.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id="REPO-1828")
-    public void adminUpdateTagDeleteTagAddTag() throws Exception
+    @Ignore
+    public void adminUpdateTagDeleteTagAddTag()
     {
-        String newTag = "addTag";
+        String newTag = RandomData.getRandomName("addTag").toLowerCase();
 
         returnedModel = restClient.authenticateUser(adminUserModel).withCoreAPI().usingTag(oldTag).update(newTag);
         restClient.assertStatusCodeIs(HttpStatus.OK);
@@ -278,11 +301,11 @@ public class UpdateTagTests extends TagsDataPrep
     public void adminIsAbleToUpdateOrphanTag()
     {
         STEP("Update orphan tag and expect 200");
-        final String newTagName = RandomData.getRandomName("new");
+        final String newTagName = RandomData.getRandomName("new").toLowerCase();
         returnedModel = restClient.authenticateUser(adminUserModel).withCoreAPI().usingTag(orphanTag).update(newTagName);
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
-        returnedModel.assertThat().field("tag").is(newTagName.toLowerCase());
+        returnedModel.assertThat().field("tag").is(newTagName);
         returnedModel.assertThat().field("id").isNotNull();
     }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/UpdateTagTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/UpdateTagTests.java
@@ -282,7 +282,7 @@ public class UpdateTagTests extends TagsDataPrep
         returnedModel = restClient.authenticateUser(adminUserModel).withCoreAPI().usingTag(orphanTag).update(newTagName);
 
         restClient.assertStatusCodeIs(HttpStatus.OK);
-        returnedModel.assertThat().field("tag").is(newTagName);
+        returnedModel.assertThat().field("tag").is(newTagName.toLowerCase());
         returnedModel.assertThat().field("id").isNotNull();
     }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/nodes/AddTagTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/nodes/AddTagTests.java
@@ -33,13 +33,13 @@ public class AddTagTests extends TagsDataPrep
     @BeforeMethod(alwaysRun = true)
     public void generateRandomTag()
     {
-        tagValue = RandomData.getRandomName("tag");
+        tagValue = RandomData.getRandomName("tag").toLowerCase();
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, 
             description = "Verify admin user adds tags with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsAbleToAddTag() throws Exception
+    public void adminIsAbleToAddTag()
     {
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingResource(document).addTag(tagValue);
@@ -51,7 +51,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.SANITY, 
             description = "Verify Manager user adds tags with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
-    public void managerIsAbleToTagAFile() throws Exception
+    public void managerIsAbleToTagAFile()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteManager));
         returnedModel = restClient.withCoreAPI().usingResource(document).addTag(tagValue);
@@ -63,7 +63,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, 
             description = "Verify Collaborator user adds tags with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void collaboratorIsAbleToTagAFile() throws Exception
+    public void collaboratorIsAbleToTagAFile()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteCollaborator));
         returnedModel = restClient.withCoreAPI().usingResource(document).addTag(tagValue);
@@ -75,7 +75,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, 
             description = "Verify Contributor user doesn't have permission to add tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsNotAbleToAddTagToAnotherContent() throws Exception
+    public void contributorIsNotAbleToAddTagToAnotherContent()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteContributor));
         restClient.withCoreAPI().usingResource(document).addTag(tagValue);
@@ -85,7 +85,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, 
             description = "Verify Contributor user adds tags to his content with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsAbleToAddTagToHisContent() throws Exception
+    public void contributorIsAbleToAddTagToHisContent()
     {
         userModel = usersWithRoles.getOneUserWithRole(UserRole.SiteContributor);
         restClient.authenticateUser(userModel);
@@ -99,7 +99,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, 
             description = "Verify Consumer user doesn't have permission to add tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void consumerIsNotAbleToTagAFile() throws Exception
+    public void consumerIsNotAbleToTagAFile()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteConsumer));
         restClient.withCoreAPI().usingResource(document).addTag(tagValue);
@@ -110,7 +110,7 @@ public class AddTagTests extends TagsDataPrep
             description = "Verify user gets status code 401 if authentication call fails")    
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
 //    @Bug(id="MNT-16904", description = "It fails only on environment with tenants")
-    public void userIsNotAbleToAddTagIfAuthenticationFails() throws Exception
+    public void userIsNotAbleToAddTagIfAuthenticationFails()
     {
         UserModel siteManager = usersWithRoles.getOneUserWithRole(UserRole.SiteManager);
         String managerPassword = siteManager.getPassword();
@@ -124,7 +124,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that adding empty tag returns status code 400")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void emptyTagTest() throws Exception
+    public void emptyTagTest()
     {
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingResource(document).addTag("");
@@ -134,7 +134,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that adding tag with user that has no permissions returns status code 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagWithUserThatDoesNotHavePermissions() throws Exception
+    public void addTagWithUserThatDoesNotHavePermissions()
     {
         restClient.authenticateUser(dataUser.createRandomTestUser());
         returnedModel = restClient.withCoreAPI().usingResource(document).addTag(tagValue);
@@ -144,7 +144,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that adding tag to a node that does not exist returns status code 404")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagToInexistentNode() throws Exception
+    public void addTagToInexistentNode()
     {
         String oldNodeRef = document.getNodeRef();
         String nodeRef = RandomStringUtils.randomAlphanumeric(10);
@@ -159,7 +159,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.SANITY,
             description = "Verify that manager is able to tag a folder")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
-    public void managerIsAbleToTagAFolder() throws Exception
+    public void managerIsAbleToTagAFolder()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteManager));
@@ -171,7 +171,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that tagged file can be tagged again")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagToATaggedFile() throws Exception
+    public void addTagToATaggedFile()
     {
         restClient.authenticateUser(adminUserModel);
 
@@ -195,7 +195,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that user cannot add invalid tag")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addInvalidTag() throws Exception
+    public void addInvalidTag()
     {
         restClient.authenticateUser(adminUserModel);
         returnedModel = restClient.withCoreAPI().usingResource(document).addTag("-1~!|@#$%^&*()_=");
@@ -205,7 +205,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that contributor is able to tag a folder created by self")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsAbleToTagAFolderCreatedBySelf() throws Exception
+    public void contributorIsAbleToTagAFolderCreatedBySelf()
     {
         FolderModel folderModel = dataContent.usingUser(usersWithRoles.getOneUserWithRole(UserRole.SiteContributor)).usingSite(siteModel).createFolder();
 
@@ -218,7 +218,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that collaborator is able to tag a folder")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void collaboratorIsAbleToTagAFolder() throws Exception
+    public void collaboratorIsAbleToTagAFolder()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
 
@@ -231,7 +231,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that consumer is not able to tag a folder. Check default error model schema.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void consumerIsNotAbleToTagAFolder() throws Exception
+    public void consumerIsNotAbleToTagAFolder()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
 
@@ -246,7 +246,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that tagged folder can be tagged again")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagToATaggedFolder() throws Exception
+    public void addTagToATaggedFolder()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
 
@@ -269,11 +269,11 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Using collaborator provide more than one tag element")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void provideMoreThanOneTagElement() throws Exception
+    public void provideMoreThanOneTagElement()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
-        String tagValue1 = RandomData.getRandomName("tag1");
-        String tagValue2 = RandomData.getRandomName("tag2");
+        String tagValue1 = RandomData.getRandomName("tag1").toLowerCase();
+        String tagValue2 = RandomData.getRandomName("tag2").toLowerCase();
 
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteCollaborator));
 
@@ -288,7 +288,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that manager cannot add tag with special characters.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagWithSpecialCharacters() throws Exception
+    public void addTagWithSpecialCharacters()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();
         String specialCharsTag = "!@#$%^&*()'\".,<>-_+=|\\";
@@ -301,7 +301,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that you cannot tag a comment and it returns status code 405")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagToAComment() throws Exception
+    public void addTagToAComment()
     {
         FileModel file = dataContent.usingSite(siteModel).usingUser(adminUserModel).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
         String comment = "comment for a tag";
@@ -316,7 +316,7 @@ public class AddTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that you cannot tag a tag and it returns status code 405")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void addTagToATag() throws Exception
+    public void addTagToATag()
     {
         FileModel file = dataContent.usingSite(siteModel).usingUser(adminUserModel).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
 
@@ -325,5 +325,18 @@ public class AddTagTests extends TagsDataPrep
         file.setNodeRef(returnedModel.getId());
         restClient.withCoreAPI().usingResource(file).addTag(tagValue);
         restClient.assertStatusCodeIs(HttpStatus.METHOD_NOT_ALLOWED).assertLastError().containsSummary(RestErrorModel.CANNOT_TAG);
+    }
+
+    @TestRail (section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
+            description = "Verify the tag name is converted to lower case before being applied")
+    @Test (groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
+    public void tagNameIsConvertedToLowerCase()
+    {
+        restClient.authenticateUser(adminUserModel);
+        String tagName = RandomData.getRandomName("TaG-oNe");
+        returnedModel = restClient.withCoreAPI().usingResource(document).addTag(tagName);
+        restClient.assertStatusCodeIs(HttpStatus.CREATED);
+        returnedModel.assertThat().field("tag").is(tagName.toLowerCase())
+                     .and().field("id").isNotEmpty();
     }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/nodes/AddTagsTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/nodes/AddTagsTests.java
@@ -30,14 +30,14 @@ public class AddTagsTests extends TagsDataPrep
     @BeforeMethod(alwaysRun = true)
     public void generateRandomTagsList()
     {
-        tag1 = RandomData.getRandomName("tag");
-        tag2 = RandomData.getRandomName("tag");
+        tag1 = RandomData.getRandomName("tag").toLowerCase();
+        tag2 = RandomData.getRandomName("tag").toLowerCase();
     }
 
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify admin user adds multiple tags with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsAbleToAddTags() throws Exception
+    public void adminIsAbleToAddTags()
     {
         restClient.authenticateUser(adminUserModel);
         returnedCollection = restClient.withCoreAPI().usingResource(document).addTags(tag1, tag2);
@@ -49,7 +49,7 @@ public class AddTagsTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.SANITY,
             description = "Verify Manager user adds multiple tags with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
-    public void managerIsAbleToAddTags() throws Exception
+    public void managerIsAbleToAddTags()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteManager));
         returnedCollection = restClient.withCoreAPI().usingResource(document).addTags(tag1, tag2);
@@ -61,7 +61,7 @@ public class AddTagsTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.SANITY, description = "Verify Collaborator user adds multiple tags with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void collaboratorIsAbleToAddTags() throws Exception
+    public void collaboratorIsAbleToAddTags()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteCollaborator));
         returnedCollection = restClient.withCoreAPI().usingResource(document).addTags(tag1, tag2);
@@ -73,7 +73,7 @@ public class AddTagsTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Contributor user doesn't have permission to add multiple tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsNotAbleToAddTagsToAnotherContent() throws Exception
+    public void contributorIsNotAbleToAddTagsToAnotherContent()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteContributor));
         restClient.withCoreAPI().usingResource(document).addTags(tag1, tag2);
@@ -83,7 +83,7 @@ public class AddTagsTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Contributor user adds multiple tags to his content with Rest API and status code is 201")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsAbleToAddTagsToHisContent() throws Exception
+    public void contributorIsAbleToAddTagsToHisContent()
     {
         userModel = usersWithRoles.getOneUserWithRole(UserRole.SiteContributor);
         restClient.authenticateUser(userModel);
@@ -97,7 +97,7 @@ public class AddTagsTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Consumer user doesn't have permission to add multiple tags with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void consumerIsNotAbleToAddTags() throws Exception
+    public void consumerIsNotAbleToAddTags()
     {
         restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteConsumer)).withCoreAPI().usingResource(document).addTags(tag1, tag2);
         restClient.assertStatusCodeIs(HttpStatus.FORBIDDEN).assertLastError().containsSummary(RestErrorModel.PERMISSION_WAS_DENIED);
@@ -107,7 +107,7 @@ public class AddTagsTests extends TagsDataPrep
             description = "Verify user gets status code 401 if authentication call fails")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
 //    @Bug(id="MNT-16904", description = "It fails only on environment with tenants")
-    public void userIsNotAbleToAddTagsIfAuthenticationFails() throws Exception
+    public void userIsNotAbleToAddTagsIfAuthenticationFails()
     {
         UserModel siteManager = usersWithRoles.getOneUserWithRole(UserRole.SiteManager);
         String managerPassword = siteManager.getPassword();
@@ -120,7 +120,7 @@ public class AddTagsTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API,
             TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, description = "Verify include count parameter")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void getTagsUsingCountParam() throws Exception
+    public void getTagsUsingCountParam()
     {
         FileModel file = dataContent.usingSite(siteModel).usingUser(adminUserModel).createContent(CMISUtil.DocumentType.TEXT_PLAIN);
         String tagName = RandomData.getRandomName("tag");

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/nodes/DeleteTagTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/tags/nodes/DeleteTagTests.java
@@ -15,6 +15,7 @@ import org.alfresco.utility.testrail.ExecutionType;
 import org.alfresco.utility.testrail.annotation.TestRail;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.http.HttpStatus;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 /**
@@ -29,7 +30,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION, 
             description = "Verify Admin user deletes tags with Rest API and status code is 204")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminIsAbleToDeleteTags() throws Exception
+    public void adminIsAbleToDeleteTags()
     {
         restClient.authenticateUser(adminUserModel);
         tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -43,7 +44,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.SANITY,
             description = "Verify Manager user deletes tags created by admin user with Rest API and status code is 204")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
-    public void managerIsAbleToDeleteTags() throws Exception
+    public void managerIsAbleToDeleteTags()
     {
         restClient.authenticateUser(adminUserModel);
         tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -56,7 +57,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Collaborator user deletes tags created by admin user with Rest API and status code is 204")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void collaboratorIsAbleToDeleteTags() throws Exception
+    public void collaboratorIsAbleToDeleteTags()
     {
         restClient.authenticateUser(adminUserModel);
         tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -69,7 +70,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Contributor user can't delete tags created by admin user with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsNotAbleToDeleteTagsForAnotherUserContent() throws Exception
+    public void contributorIsNotAbleToDeleteTagsForAnotherUserContent()
     {
         restClient.authenticateUser(adminUserModel);
         tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -82,7 +83,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Contributor user deletes tags created by him with Rest API and status code is 204")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void contributorIsAbleToDeleteTagsForHisContent() throws Exception
+    public void contributorIsAbleToDeleteTagsForHisContent()
     {
         userModel = usersWithRoles.getOneUserWithRole(UserRole.SiteContributor);
         restClient.authenticateUser(userModel);
@@ -96,7 +97,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify Consumer user can't delete tags created by admin user with Rest API and status code is 403")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void consumerIsNotAbleToDeleteTags() throws Exception
+    public void consumerIsNotAbleToDeleteTags()
     {
         restClient.authenticateUser(adminUserModel);
         tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -110,7 +111,7 @@ public class DeleteTagTests extends TagsDataPrep
             description = "Verify user gets status code 401 if authentication call fails")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.SANITY })
 //    @Bug(id="MNT-16904", description = "It fails only on environment with tenants")
-    public void userIsNotAbleToDeleteTagIfAuthenticationFails() throws Exception
+    public void userIsNotAbleToDeleteTagIfAuthenticationFails()
     {
         restClient.authenticateUser(adminUserModel);
         tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -127,7 +128,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that if user has no permission to remove tag returned status code is 403. Check default error model schema")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void deleteTagWithUserWithoutPermissionCheckDefaultErrorModelSchema() throws Exception
+    public void deleteTagWithUserWithoutPermissionCheckDefaultErrorModelSchema()
     {
         restClient.authenticateUser(adminUserModel);
         RestTagModel tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -144,7 +145,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that if node does not exist returned status code is 404")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void deleteTagForANonexistentNode() throws Exception
+    public void deleteTagForANonexistentNode()
     {
         restClient.authenticateUser(adminUserModel);
         RestTagModel tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -159,7 +160,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that if tag does not exist returned status code is 404")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void deleteTagThatDoesNotExist() throws Exception
+    public void deleteTagThatDoesNotExist()
     {
         restClient.authenticateUser(adminUserModel);
         RestTagModel tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -172,7 +173,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that if tag id is empty returned status code is 405")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void deleteTagWithEmptyId() throws Exception
+    public void deleteTagWithEmptyId()
     {
         restClient.authenticateUser(adminUserModel);
         RestTagModel tag = restClient.withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -185,7 +186,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS }, executionType = ExecutionType.REGRESSION,
             description = "Verify that folder tag can be deleted")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void deleteFolderTag() throws Exception
+    public void deleteFolderTag()
     {
         FolderModel folderModel = dataContent.usingUser(adminUserModel).usingSite(siteModel).createFolder();;
         restClient.authenticateUser(adminUserModel);
@@ -200,7 +201,8 @@ public class DeleteTagTests extends TagsDataPrep
             executionType = ExecutionType.REGRESSION, description = "Verify Manager user can't delete deleted tag.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
     @Bug(id = "ACE-5455")
-    public void managerCannotDeleteDeletedTag() throws Exception
+    @Ignore
+    public void managerCannotDeleteDeletedTag()
     {
         tag = restClient.authenticateUser(adminUserModel)
                 .withCoreAPI().usingResource(document).addTag(RandomData.getRandomName("tag"));
@@ -216,7 +218,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.REGRESSION, description = "Verify Collaborator user can delete long tag.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void userCollaboratorCanDeleteLongTag() throws Exception
+    public void userCollaboratorCanDeleteLongTag()
     {
         String longTag = RandomStringUtils.randomAlphanumeric(800);
 
@@ -231,7 +233,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.REGRESSION, description = "Verify Manager user can delete short tag.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void managerCanDeleteShortTag() throws Exception
+    public void managerCanDeleteShortTag()
     {
         String shortTag = RandomStringUtils.randomAlphanumeric(10);
 
@@ -246,7 +248,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.REGRESSION, description = "Verify Admin can delete tag then add it again.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void adminRemovesTagAndAddsItAgain() throws Exception
+    public void adminRemovesTagAndAddsItAgain()
     {
         String tagValue = RandomStringUtils.randomAlphanumeric(10);
 
@@ -267,7 +269,7 @@ public class DeleteTagTests extends TagsDataPrep
     @TestRail(section = { TestGroup.REST_API, TestGroup.TAGS },
             executionType = ExecutionType.REGRESSION, description = "Verify Manager user can delete tag added by another user.")
     @Test(groups = { TestGroup.REST_API, TestGroup.TAGS, TestGroup.REGRESSION })
-    public void managerCanDeleteTagAddedByAnotherUser() throws Exception
+    public void managerCanDeleteTagAddedByAnotherUser()
     {
         tag = restClient.authenticateUser(usersWithRoles.getOneUserWithRole(UserRole.SiteCollaborator))
                 .withCoreAPI().usingResource(document).addTag(RandomStringUtils.randomAlphanumeric(10));

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
@@ -30,6 +30,7 @@ import static java.util.stream.Collectors.toList;
 import static org.alfresco.rest.antlr.WhereClauseParser.EQUALS;
 import static org.alfresco.rest.antlr.WhereClauseParser.IN;
 import static org.alfresco.rest.antlr.WhereClauseParser.MATCHES;
+import static org.alfresco.service.cmr.tagging.TaggingService.TAG_ROOT_NODE_REF;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -83,7 +84,6 @@ public class TagsImpl implements Tags
 	private static final String PARAM_WHERE_TAG = "tag";
 	static final String NOT_A_VALID_TAG = "An invalid parameter has been supplied";
 	static final String NO_PERMISSION_TO_MANAGE_A_TAG = "Current user does not have permission to manage a tag";
-	private final NodeRef tagParentNodeRef = new NodeRef("workspace://SpacesStore/tag:tag-root");
 
     private Nodes nodes;
 	private NodeService nodeService;
@@ -214,7 +214,7 @@ public class TagsImpl implements Tags
     	{
 	    	NodeRef existingTagNodeRef = validateTag(storeRef, tagId);
 	    	String existingTagName = taggingService.getTagName(existingTagNodeRef);
-	    	String newTagName = tag.getTag();
+	    	String newTagName = tag.getTag().toLowerCase();
 	    	NodeRef newTagNodeRef = taggingService.changeTag(storeRef, existingTagName, newTagName);
 	    	return new Tag(newTagNodeRef, newTagName);
     	}
@@ -329,7 +329,7 @@ public class TagsImpl implements Tags
 
 	private NodeRef checkTagRootAsNodePrimaryParent(String tagId, NodeRef tagNodeRef)
 	{
-		if ( tagNodeRef == null || !nodeService.getPrimaryParent(tagNodeRef).getParentRef().equals(tagParentNodeRef))
+		if ( tagNodeRef == null || !nodeService.getPrimaryParent(tagNodeRef).getParentRef().equals(TAG_ROOT_NODE_REF))
 		{
 			throw new EntityNotFoundException(tagId);
 		}

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
@@ -214,7 +214,7 @@ public class TagsImpl implements Tags
     	{
 	    	NodeRef existingTagNodeRef = validateTag(storeRef, tagId);
 	    	String existingTagName = taggingService.getTagName(existingTagNodeRef);
-	    	String newTagName = tag.getTag().toLowerCase();
+	    	String newTagName = tag.getTag();
 	    	NodeRef newTagNodeRef = taggingService.changeTag(storeRef, existingTagName, newTagName);
 	    	return new Tag(newTagNodeRef, newTagName);
     	}

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/Tag.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/Tag.java
@@ -26,6 +26,7 @@
 package org.alfresco.rest.api.model;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.alfresco.rest.framework.resource.UniqueId;
@@ -50,7 +51,7 @@ public class Tag implements Comparable<Tag>
 	public Tag(NodeRef nodeRef, String tag)
 	{
 		this.nodeRef = nodeRef;
-		this.tag = tag;
+		setTag(tag);
 	}
 
 	@JsonProperty("id")
@@ -72,7 +73,7 @@ public class Tag implements Comparable<Tag>
 
 	public void setTag(String tag)
 	{
-		this.tag = tag;
+		this.tag = Optional.ofNullable(tag).map(String::toLowerCase).orElse(null);
 	}
 	
 	public Integer getCount()

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/TagsImplTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/TagsImplTest.java
@@ -157,21 +157,21 @@ public class TagsImplTest
     {
         NodeRef tagNodeA = new NodeRef("tag://A/");
         NodeRef tagNodeB = new NodeRef("tag://B/");
-        List<Pair<NodeRef, String>> tagPairs = List.of(new Pair<>(tagNodeA, "tagA"), new Pair<>(tagNodeB, "tagB"));
+        List<Pair<NodeRef, String>> tagPairs = List.of(new Pair<>(tagNodeA, "taga"), new Pair<>(tagNodeB, "tagb"));
 
         given(parametersMock.getPaging()).willReturn(pagingMock);
         given(taggingServiceMock.getTags(any(StoreRef.class), any(PagingRequest.class), any(), any())).willReturn(pagingResultsMock);
         given(pagingResultsMock.getTotalResultCount()).willReturn(new Pair<>(Integer.MAX_VALUE, 0));
         given(pagingResultsMock.getPage()).willReturn(tagPairs);
         given(parametersMock.getInclude()).willReturn(List.of("count"));
-        // Only tagA is included in the returned list since tagB is not in use.
-        given(taggingServiceMock.findTaggedNodesAndCountByTagName(STORE_REF_WORKSPACE_SPACESSTORE)).willReturn(List.of(new Pair<>("tagA", 5)));
+        // Only taga is included in the returned list since tagb is not in use.
+        given(taggingServiceMock.findTaggedNodesAndCountByTagName(STORE_REF_WORKSPACE_SPACESSTORE)).willReturn(List.of(new Pair<>("taga", 5)));
 
         final CollectionWithPagingInfo<Tag> actualTags = objectUnderTest.getTags(STORE_REF_WORKSPACE_SPACESSTORE, parametersMock);
 
         then(taggingServiceMock).should().findTaggedNodesAndCountByTagName(STORE_REF_WORKSPACE_SPACESSTORE);
-        final List<Tag> expectedTags = List.of(Tag.builder().tag("tagA").nodeRef(tagNodeA).count(5).create(),
-                                               Tag.builder().tag("tagB").nodeRef(tagNodeB).count(0).create());
+        final List<Tag> expectedTags = List.of(Tag.builder().tag("taga").nodeRef(tagNodeA).count(5).create(),
+                                               Tag.builder().tag("tagb").nodeRef(tagNodeB).count(0).create());
         assertEquals(expectedTags, actualTags.getCollection());
     }
 
@@ -450,17 +450,17 @@ public class TagsImplTest
         NodeRef tagNodeB = new NodeRef("tag://B/");
         given(nodesMock.validateOrLookupNode(CONTENT_NODE_ID)).willReturn(CONTENT_NODE_REF);
         given(typeConstraintMock.matches(CONTENT_NODE_REF)).willReturn(true);
-        List<Pair<String, NodeRef>> pairs = List.of(new Pair<>("tagA", new NodeRef("tag://A/")), new Pair<>("tagB", new NodeRef("tag://B/")));
+        List<Pair<String, NodeRef>> pairs = List.of(new Pair<>("taga", new NodeRef("tag://A/")), new Pair<>("tagb", new NodeRef("tag://B/")));
         List<String> tagNames = pairs.stream().map(Pair::getFirst).collect(toList());
         List<Tag> tags = tagNames.stream().map(name -> Tag.builder().tag(name).create()).collect(toList());
         given(taggingServiceMock.addTags(CONTENT_NODE_REF, tagNames)).willReturn(pairs);
-        given(taggingServiceMock.findTaggedNodesAndCountByTagName(STORE_REF_WORKSPACE_SPACESSTORE)).willReturn(List.of(new Pair<>("tagA", 4)));
+        given(taggingServiceMock.findTaggedNodesAndCountByTagName(STORE_REF_WORKSPACE_SPACESSTORE)).willReturn(List.of(new Pair<>("taga", 4)));
         given(parametersMock.getInclude()).willReturn(List.of("count"));
 
         List<Tag> actual = objectUnderTest.addTags(CONTENT_NODE_ID, tags, parametersMock);
 
-        final List<Tag> expected = List.of(Tag.builder().tag("tagA").nodeRef(tagNodeA).count(5).create(),
-                Tag.builder().tag("tagB").nodeRef(tagNodeB).count(1).create());
+        final List<Tag> expected = List.of(Tag.builder().tag("taga").nodeRef(tagNodeA).count(5).create(),
+                Tag.builder().tag("tagb").nodeRef(tagNodeB).count(1).create());
         assertEquals("Unexpected tags returned.", expected, actual);
     }
 
@@ -489,7 +489,7 @@ public class TagsImplTest
     {
         given(nodesMock.validateOrLookupNode(CONTENT_NODE_ID)).willReturn(CONTENT_NODE_REF);
         given(parametersMock.getPaging()).willReturn(pagingMock);
-        List<Pair<NodeRef, String>> pairs = List.of(new Pair<>(new NodeRef("tag://A/"), "tagA"), new Pair<>(new NodeRef("tag://B/"), "tagB"));
+        List<Pair<NodeRef, String>> pairs = List.of(new Pair<>(new NodeRef("tag://A/"), "taga"), new Pair<>(new NodeRef("tag://B/"), "tagb"));
         given(taggingServiceMock.getTags(eq(CONTENT_NODE_REF), any(PagingRequest.class))).willReturn(pagingResultsMock);
         given(pagingResultsMock.getTotalResultCount()).willReturn(new Pair<>(null, null));
         given(pagingResultsMock.getPage()).willReturn(pairs);

--- a/repository/src/main/java/org/alfresco/repo/tagging/TaggingServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/tagging/TaggingServiceImpl.java
@@ -96,6 +96,7 @@ import org.alfresco.util.ISO9075;
 import org.alfresco.util.Pair;
 import org.alfresco.util.ParameterCheck;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -526,9 +527,9 @@ public class TaggingServiceImpl implements TaggingService,
     		throw new TaggingException("Existing tag cannot be null");
     	}
     	
-    	if (newTag == null)
+    	if (newTag == null || StringUtils.isBlank(newTag))
     	{
-    		throw new TaggingException("New tag cannot be null");
+    		throw new TaggingException("New tag cannot be blank");
     	}
 
     	existingTag = existingTag.toLowerCase();

--- a/repository/src/main/java/org/alfresco/service/cmr/tagging/TaggingService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/tagging/TaggingService.java
@@ -48,6 +48,8 @@ import org.alfresco.util.Pair;
 @AlfrescoPublicApi
 public interface TaggingService
 {
+    NodeRef TAG_ROOT_NODE_REF = new NodeRef("workspace://SpacesStore/tag:tag-root");
+
     /**
      * Indicates whether the tag already exists
      * 

--- a/repository/src/main/resources/alfresco/tagging-services-context.xml
+++ b/repository/src/main/resources/alfresco/tagging-services-context.xml
@@ -37,13 +37,13 @@
     <bean id="taggingService" class="org.alfresco.repo.tagging.TaggingServiceImpl" init-method="init">
     	<property name="nodeService" ref="NodeService"/>
         <property name="nodeServiceInternal" ref="nodeService"/>
-    	<property name="categoryService" ref="CategoryService"/>
-    	<property name="searchService" ref="SearchService"/>
-    	<property name="actionService" ref="ActionService"/>
-    	<property name="contentService" ref="ContentService"/>
-    	<property name="namespaceService" ref="NamespaceService"/>
-    	<property name="policyComponent" ref="policyComponent"/>
-    	<property name="auditComponent" ref="auditComponent"/>
+        <property name="categoryService" ref="CategoryService"/>
+        <property name="searchService" ref="SearchService"/>
+        <property name="actionService" ref="ActionService"/>
+        <property name="contentService" ref="ContentService"/>
+        <property name="namespaceService" ref="NamespaceService"/>
+        <property name="policyComponent" ref="policyComponent"/>
+        <property name="auditComponent" ref="auditComponent"/>
     </bean>
     
     <bean id="update-tagscope" class="org.alfresco.repo.tagging.UpdateTagScopesActionExecuter" parent="action-executer">

--- a/repository/src/main/resources/alfresco/tagging-services-context.xml
+++ b/repository/src/main/resources/alfresco/tagging-services-context.xml
@@ -44,6 +44,7 @@
         <property name="namespaceService" ref="NamespaceService"/>
         <property name="policyComponent" ref="policyComponent"/>
         <property name="auditComponent" ref="auditComponent"/>
+        <property name="eventGenerator" ref="eventGeneratorV2"/>
     </bean>
     
     <bean id="update-tagscope" class="org.alfresco.repo.tagging.UpdateTagScopesActionExecuter" parent="action-executer">


### PR DESCRIPTION
This change refactors the existing code so that:
* The tag id is not changed by the rename
* The tag is renamed in the index (Solr or ES)
* All documents are updated with the new tag name in the index (Solr or ES)
* The tag scopes are updated.