### PR TITLE
ACS-4970 Bump json-path to 2.8.0 and json-smart to 2.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
         <dependency.jakarta-jws-api.version>2.1.0</dependency.jakarta-jws-api.version>
         <dependency.jakarta-mail-api.version>1.6.5</dependency.jakarta-mail-api.version>
         <dependency.jakarta-json-api.version>1.1.6</dependency.jakarta-json-api.version>
-        <dependency.jakarta-json-path.version>2.7.0</dependency.jakarta-json-path.version>
-        <dependency.json-smart.version>2.4.8</dependency.json-smart.version>
+        <dependency.jakarta-json-path.version>2.8.0</dependency.jakarta-json-path.version>
+        <dependency.json-smart.version>2.4.10</dependency.json-smart.version>
         <dependency.jakarta-rpc-api.version>1.1.4</dependency.jakarta-rpc-api.version>
 
         <alfresco.googledrive.version>3.4.0-M1</alfresco.googledrive.version>


### PR DESCRIPTION
Bump json-path and json-smart to the latest available versions.