### PR TITLE
Set property values to the ones being set for sharedFileStoreConnector

### DIFF
--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -752,8 +752,8 @@ encryption.ssl.truststore.keyMetaData.location=
 ## HttpClient config for Transform Service
 #enable mtls in HttpClientFactory for Transform Service.
 httpclient.config.transform.mTLSEnabled=false
-httpclient.config.transform.maxTotalConnections=40
-httpclient.config.transform.maxHostConnections=40
+httpclient.config.transform.maxTotalConnections=20
+httpclient.config.transform.maxHostConnections=20
 httpclient.config.transform.socketTimeout=5000
 httpclient.config.transform.connectionRequestTimeout=5000
 httpclient.config.transform.connectionTimeout=5000

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -758,6 +758,10 @@ httpclient.config.transform.socketTimeout=5000
 httpclient.config.transform.connectionRequestTimeout=5000
 httpclient.config.transform.connectionTimeout=5000
 
+# Property is disabled by default for security reasons, never enable it on for production environments.
+# It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services
+httpclient.config.transform.hostnameVerificationDisabled=false
+
 # Re-encryptor properties
 encryption.reencryptor.chunkSize=100
 encryption.reencryptor.numThreads=2


### PR DESCRIPTION
since the only difference is the number of connections, which doesn't work in community-repo due to how the http clients are created per request of transform