### PR TITLE
Revert "Bump docker-maven-plugin from 0.42.0 to 0.42.1 (#1866)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -936,7 +936,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.42.1</version>
+                    <version>0.42.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This reverts commit 06fdc4302e688412e6aa9ff23e862900b0b1858c.

Seems to have broken the CI/CD in acs-packaging, let's try reverting it.