### PR TITLE
Bump docker-maven-plugin from 0.42.0 to 0.42.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -936,7 +936,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.42.0</version>
+                    <version>0.42.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Again. It seems the new dmp patch version wasn't causing the issue, that seems related to yum unavailability instead. cc: @mstrankowski 
This reverts commit 2fcf1bd2d59d20727812df03891b3ac7f3a95edd.