### PR TITLE
ACS-5265: Removing @Experimental flag + some import cleanup

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Categories.java
@@ -32,10 +32,8 @@ import java.util.List;
 
 import org.alfresco.rest.api.model.Category;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.StoreRef;
 
-@Experimental
 public interface Categories
 {
     Category getCategoryById(StoreRef storeRef, String id, Parameters parameters);

--- a/remote-api/src/main/java/org/alfresco/rest/api/Tags.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Tags.java
@@ -32,7 +32,6 @@ import java.util.List;
 import org.alfresco.rest.api.model.Tag;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.StoreRef;
 
 public interface Tags
@@ -44,10 +43,8 @@ public interface Tags
     Tag changeTag(StoreRef storeRef, String tagId, Tag tag, Parameters parameters);
     CollectionWithPagingInfo<Tag> getTags(String nodeId, Parameters params);
 
-    @Experimental
     List<Tag> createTags(StoreRef storeRef, List<Tag> tags, Parameters parameters);
 
-    @Experimental
     default List<Tag> createTags(List<Tag> tags, Parameters parameters)
     {
         return createTags(STORE_REF_WORKSPACE_SPACESSTORE, tags, parameters);

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/CategoriesImpl.java
@@ -49,7 +49,6 @@ import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
 import org.alfresco.rest.framework.core.exceptions.InvalidNodeTypeException;
 import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
@@ -65,7 +64,6 @@ import org.alfresco.util.TypeConstraint;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
-@Experimental
 public class CategoriesImpl implements Categories
 {
     static final String INCLUDE_COUNT_PARAM = "count";

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/TagsImpl.java
@@ -36,8 +36,6 @@ import static org.alfresco.service.cmr.tagging.TaggingService.TAG_ROOT_NODE_REF;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,12 +61,9 @@ import org.alfresco.rest.framework.core.exceptions.UnsupportedResourceOperationE
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Paging;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.rest.framework.resource.parameters.SortColumn;
 import org.alfresco.rest.framework.resource.parameters.where.Query;
 import org.alfresco.rest.framework.resource.parameters.where.QueryHelper;
 import org.alfresco.rest.framework.resource.parameters.where.QueryImpl;
-import org.alfresco.service.Experimental;
-import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.repository.StoreRef;
@@ -273,7 +268,6 @@ public class TagsImpl implements Tags
         return CollectionWithPagingInfo.asPaged(params.getPaging(), tags, results.hasMoreItems(), (totalItems == null ? null : totalItems.intValue()));
     }
 
-    @Experimental
     @Override
     public List<Tag> createTags(final StoreRef storeRef, final List<Tag> tags, final Parameters parameters)
     {

--- a/remote-api/src/main/java/org/alfresco/rest/api/tags/TagsEntityResource.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/tags/TagsEntityResource.java
@@ -36,7 +36,6 @@ import org.alfresco.rest.framework.resource.EntityResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.EntityResourceAction;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.util.ParameterCheck;
 import org.springframework.beans.factory.InitializingBean;
@@ -85,7 +84,6 @@ public class TagsEntityResource implements EntityResourceAction.Read<Tag>,
 	/**
 	 * POST /tags
 	 */
-	@Experimental
 	@WebApiDescription(
 		title = "Create an orphan tag",
 		description = "Creates a tag, which is not associated with any node",

--- a/remote-api/src/test/java/org/alfresco/rest/api/CategoriesUnitTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/CategoriesUnitTests.java
@@ -30,11 +30,9 @@ import org.alfresco.rest.api.categories.CategoriesEntityResourceTest;
 import org.alfresco.rest.api.categories.NodesCategoryLinksRelationTest;
 import org.alfresco.rest.api.categories.SubcategoriesRelationTest;
 import org.alfresco.rest.api.impl.CategoriesImplTest;
-import org.alfresco.service.Experimental;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-@Experimental
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     CategoriesImplTest.class,

--- a/remote-api/src/test/java/org/alfresco/rest/api/TagsUnitTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/TagsUnitTests.java
@@ -27,11 +27,9 @@ package org.alfresco.rest.api;
 
 import org.alfresco.rest.api.impl.TagsImplTest;
 import org.alfresco.rest.api.tags.TagsEntityResourceTest;
-import org.alfresco.service.Experimental;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-@Experimental
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     TagsImplTest.class,

--- a/repository/src/main/java/org/alfresco/repo/search/impl/AbstractCategoryServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/AbstractCategoryServiceImpl.java
@@ -25,7 +25,6 @@
  */
 package org.alfresco.repo.search.impl;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -50,7 +49,6 @@ import org.alfresco.query.PagingResults;
 import org.alfresco.repo.search.IndexerAndSearcher;
 import org.alfresco.repo.search.IndexerException;
 import org.alfresco.repo.tenant.TenantService;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.dictionary.AspectDefinition;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
@@ -637,7 +635,6 @@ public abstract class AbstractCategoryServiceImpl implements CategoryService
     }
 
     @Override
-    @Experimental
     public Optional<NodeRef> getRootCategoryNodeRef(final StoreRef storeRef)
     {
         return getRootCategoryNodeRef(storeRef, ContentModel.ASPECT_GEN_CLASSIFIABLE);

--- a/repository/src/main/java/org/alfresco/repo/tagging/TaggingServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/tagging/TaggingServiceImpl.java
@@ -65,7 +65,6 @@ import org.alfresco.repo.audit.AuditComponent;
 import org.alfresco.repo.coci.CheckOutCheckInServicePolicies.OnCheckOut;
 import org.alfresco.repo.copy.CopyServicePolicies.BeforeCopyPolicy;
 import org.alfresco.repo.copy.CopyServicePolicies.OnCopyCompletePolicy;
-import org.alfresco.repo.domain.query.QueryException;
 import org.alfresco.repo.event2.EventGenerator;
 import org.alfresco.repo.node.NodeServicePolicies.BeforeDeleteNodePolicy;
 import org.alfresco.repo.node.NodeServicePolicies.OnCreateNodePolicy;
@@ -78,7 +77,6 @@ import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
 import org.alfresco.repo.transaction.TransactionListener;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.action.ActionService;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
@@ -1700,7 +1698,6 @@ public class TaggingServiceImpl implements TaggingService,
         }
     }
 
-    @Experimental
     @Override
     public List<Pair<String, NodeRef>> createTags(final StoreRef storeRef, final List<String> tagNames)
     {

--- a/repository/src/main/java/org/alfresco/service/cmr/search/CategoryService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/search/CategoryService.java
@@ -35,7 +35,6 @@ import org.alfresco.query.EmptyPagingResults;
 import org.alfresco.query.PagingRequest;
 import org.alfresco.query.PagingResults;
 import org.alfresco.service.Auditable;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.StoreRef;
@@ -283,7 +282,6 @@ public interface CategoryService
      *
      * @return NodeRef for category root node
      */
-    @Experimental
     @Auditable(parameters = {"storeRef"})
     default Optional<NodeRef> getRootCategoryNodeRef(final StoreRef storeRef)
     {

--- a/repository/src/main/java/org/alfresco/service/cmr/tagging/TaggingService.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/tagging/TaggingService.java
@@ -35,7 +35,6 @@ import org.alfresco.query.EmptyPagingResults;
 import org.alfresco.query.PagingRequest;
 import org.alfresco.query.PagingResults;
 import org.alfresco.service.Auditable;
-import org.alfresco.service.Experimental;
 import org.alfresco.service.NotAuditable;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.StoreRef;
@@ -368,7 +367,6 @@ public interface TaggingService
      * @return {@link List} of {@link Pair}s of tag names and node references.
      * @throws org.alfresco.service.cmr.repository.DuplicateChildNodeNameException if tag already exists.
      */
-    @Experimental
     @Auditable(parameters = {"tagNames"})
     default List<Pair<String, NodeRef>> createTags(StoreRef storeRef, List<String> tagNames)
     {


### PR DESCRIPTION
Removed only annotations put on Tags & Categories related code.
Folder rules are still `@Experimental` as we haven't made the API for them public.