### PR TITLE
[MNT-23665] Removed search controls count limit

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/security/sync/ldap/LDAPUserRegistry.java
+++ b/repository/src/main/java/org/alfresco/repo/security/sync/ldap/LDAPUserRegistry.java
@@ -1605,8 +1605,6 @@ public class LDAPUserRegistry implements UserRegistry, LDAPNameResolver, Initial
                     this.userSearchCtls = new SearchControls();
                     this.userSearchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
                     this.userSearchCtls.setReturningAttributes(LDAPUserRegistry.this.userKeys.getFirst());
-                    // MNT-14001 fix, set search limit to ensure that server will not return more search results then provided by paged result control
-                    this.userSearchCtls.setCountLimit(LDAPUserRegistry.this.queryBatchSize > 0 ? LDAPUserRegistry.this.queryBatchSize : 0);
 
                     this.next = fetchNext();
                 }


### PR DESCRIPTION
Removing the limit allows to keep the synchronization getting pages of `ldap.synchronization.queryBatchSize` entries until it's finished, otherwise, the synchronization only gets the max of users as defined in `ldap.synchronization.queryBatchSize`.

I have worked on an unit test implementation, however, I've realized it wouldn't be possible to maintain it as it was always succeeding (regardless the fix being in place or not). The reason is because the real time synchronization uses the [PersonCollection](https://github.com/Alfresco/alfresco-community-repo/blob/90e9764d63946d35ed5f1e32c294b9413cabef5b/repository/src/main/java/org/alfresco/repo/security/sync/ldap/LDAPUserRegistry.java#L1472) but the test synchronization doesn't. 

- [LDAPUserRegistry#getPersons(Date)](https://github.com/Alfresco/alfresco-community-repo/blob/90e9764d63946d35ed5f1e32c294b9413cabef5b/repository/src/main/java/org/alfresco/repo/security/sync/ldap/LDAPUserRegistry.java#L574)
- [ChainingUserRegistrySynchronizerTest#getPersons(Date)](https://github.com/Alfresco/alfresco-community-repo/blob/90e9764d63946d35ed5f1e32c294b9413cabef5b/repository/src/test/java/org/alfresco/repo/security/sync/ChainingUserRegistrySynchronizerTest.java#L1459)