### PR TITLE
ACS-4955 Remove unused resteasy dependency

### DIFF
--- a/packaging/tests/tas-cmis/pom.xml
+++ b/packaging/tests/tas-cmis/pom.xml
@@ -58,12 +58,6 @@
     </profiles>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>4.7.1.Final</version>
-        </dependency>
-
         <!-- alfresco tester settings -->
         <dependency>
             <groupId>org.alfresco.tas</groupId>


### PR DESCRIPTION
Removing the `resteasy` dependency which seems to be unused by `tas-cmis`.