### PR TITLE
ACS-4955 Restore httpclient-osgi 4.5.6

### DIFF
--- a/packaging/tests/tas-restapi/pom.xml
+++ b/packaging/tests/tas-restapi/pom.xml
@@ -16,7 +16,7 @@
         <maven.build.sourceVersion>17</maven.build.sourceVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <rest.api.explorer.branch>master</rest.api.explorer.branch>
-        <httpclient-osgi-version>4.5.14</httpclient-osgi-version>
+        <httpclient-osgi-version>4.5.6</httpclient-osgi-version>
         <org.glassfish.version>1.1.4</org.glassfish.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <scribejava-apis.version>8.3.3</scribejava-apis.version>


### PR DESCRIPTION
Causes failures in enterprise-repo AGS tests such as https://github.com/Alfresco/alfresco-enterprise-repo/actions/runs/5045123519/jobs/9050228613#logs and the Elasticsearch equivalent suite.

There are some breaking changes between 4.5.6 and 4.5.14 related to empty paths behavior in REST APIs, it might be related to that. We should rollback until we can dedicate some time for further analysis/troubleshooting.