### PR TITLE
Bug fix: Integrity violations - invalid property value found on "cm:name" during upload of folder with empty space

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/upload/upload.post.js
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/upload/upload.post.js
@@ -232,6 +232,8 @@ function main()
          exitUpload(400, "Required parameters are missing");
          return;
       }
+      
+      filename = filename.trim();
 
       /**
        * Site or Non-site?

--- a/repository/src/main/resources/alfresco/bootstrap/webscripts/upload.post.js
+++ b/repository/src/main/resources/alfresco/bootstrap/webscripts/upload.post.js
@@ -30,6 +30,8 @@ if (filename == undefined || content == undefined)
 }
 else
 {
+  filename = filename.trim()
+
   // create document in company home for uploaded file
   upload = companyhome.createFile("upload" + companyhome.children.length + "_" + filename) ;
   upload.properties.content.write(content);


### PR DESCRIPTION
In recent months I am frequently encountering the error I highlighted in this post:
https://hub.alfresco.com/t5/alfresco-content-services-forum/integrity-violations-invalid-property-value-found-on-quot-cm/m-p/315150

Thanks to _menczingerm_ I found out what the problem is:

This is the constrait for `cm:name property` from the `contentModel.xml`
 
```
<constraints>
   <constraint name="cm:filename" type="REGEX">
      <parameter name="expression"><value><![CDATA[(.*[\"\*\\\>\<\?\/\:\|]+.*)|(.*[\.]?.*[\.]+$)|(.*[ ]+$)]]></value></parameter>
      <parameter name="requiresMatch"><value>false</value></parameter>
   </constraint>
   <constraint name="cm:userNameConstraint" type="org.alfresco.repo.dictionary.constraint.UserNameConstraint" />
   <constraint name="cm:authorityNameConstraint" type="org.alfresco.repo.dictionary.constraint.AuthorityNameConstraint" />
   <constraint name="cm:storeSelectorConstraint" type="REGISTERED">
      <parameter name="registeredName"><value>defaultStoreSelector</value></parameter>
   </constraint>
</constraints>
```
 
Tested via RestApi and CMIS browserbind calls and as expected Alfresco will trim the space from the end of the filename, when you try to upload a folder in Share UI then it do not trim the spaces at the end of the folder name so you will receive this error.

`Constraint: 002013695 Value '2020 ACCERT. RES. MINORI X ACQUISIZ. CITT. ITA ' is not valid as a file name. This property must be a valid file name.`

The space is the problem at the end of the filename,  i am forced to preprocess the file/folder name values before the upload.

This error appears very often in my installations, these two lines of perfectly backward-compatibility code should solve the problem easily and without touching the java code.

Please consider accepting the PR or include your own solution to the problem.
Thank you.