### PR TITLE
MNT-23451 filterQuery for facet Null (#1764)

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/search/model/FacetField.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/model/FacetField.java
@@ -93,7 +93,7 @@ public class FacetField
 
     public String toFilterQuery(String value)
     {
-        return field+":\""+value+"\"";
+        return ("Null".equals(value)) ? "ISNULL:\"" + field + "\"" : field + ":\"" + value + "\"";
     }
 
     public String getPrefix()


### PR DESCRIPTION
After MNT-23276, a "Null" value was introduced but the facetQuery does not reflect how to query nodes with that facet

(cherry picked from commit d46ae1634f0ffc4ac5e5082d9036b09d2452b285)