### PR TITLE
ACS-5487 - Track Total Hits on ES

### DIFF
--- a/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
@@ -201,7 +201,10 @@ public class SearchParameters implements BasicSearchParameters
 
     private String timezone;
     
-    private int trackTotalHits = 0;
+    /**
+     * Configure the limit to track the total hits on search results
+     */
+    private int trackTotalHits;
 
     /**
      * Default constructor
@@ -1650,6 +1653,10 @@ public class SearchParameters implements BasicSearchParameters
         return trackTotalHits;
     }
 
+    /**
+     * Configure the limit to track the total hits on search results
+     * @param trackTotalHits int
+     */
     public void setTrackTotalHits(int trackTotalHits)
     {
         this.trackTotalHits = trackTotalHits;

--- a/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
@@ -201,6 +201,8 @@ public class SearchParameters implements BasicSearchParameters
 
     private String timezone;
     
+    private int trackTotalHits = 0;
+
     /**
      * Default constructor
      */
@@ -251,6 +253,7 @@ public class SearchParameters implements BasicSearchParameters
         sp.stats = this.stats;
         sp.ranges = this.ranges;
         sp.timezone = this.timezone;
+        sp.trackTotalHits = this.trackTotalHits;
         return sp;
     }
     
@@ -1641,6 +1644,15 @@ public class SearchParameters implements BasicSearchParameters
     {
         this.includeMetadata = includeMetadata;
     }
-    
+
+    public int getTrackTotalHits()
+    {
+        return trackTotalHits;
+    }
+
+    public void setTrackTotalHits(int trackTotalHits)
+    {
+        this.trackTotalHits = trackTotalHits;
+    }
 
 }

--- a/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
@@ -1654,7 +1654,9 @@ public class SearchParameters implements BasicSearchParameters
     }
 
     /**
-     * Configure the limit to track the total hits on search results
+     * Set a maximum value for the report of total hits. The reported number of hits will never exceed this limit even
+     * if more are found. If unset, the engine’s default tracking limit is applied. To remove any limit, set to -1.
+     *
      * @param trackTotalHits int
      */
     public void setTrackTotalHits(int trackTotalHits)

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/RestRequestLimitsModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/RestRequestLimitsModel.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * alfresco-tas-restapi
+ * %%
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.search;
+
+import org.alfresco.rest.core.IRestModel;
+import org.alfresco.utility.model.TestModel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RestRequestLimitsModel extends TestModel implements IRestModel<RestRequestLimitsModel>
+{
+    @JsonProperty(value = "entry")
+    RestRequestLimitsModel model;
+
+    @Override
+    public RestRequestLimitsModel onModel()
+    {
+        return model;
+    }
+    
+    public RestRequestLimitsModel(Integer permissionEvaluationTime, Integer permissionEvaluationCount,
+            Integer trackTotalHitsLimit)
+    {
+        super();
+        this.permissionEvaluationTime = permissionEvaluationTime;
+        this.permissionEvaluationCount = permissionEvaluationCount;
+        this.trackTotalHitsLimit = trackTotalHitsLimit;
+    }
+
+    private Integer permissionEvaluationTime;
+    private Integer permissionEvaluationCount;
+    private Integer trackTotalHitsLimit;
+
+    public Integer getPermissionEvaluationTime()
+    {
+        return permissionEvaluationTime;
+    }
+    public void setPermissionEvaluationTime(Integer permissionEvaluationTime)
+    {
+        this.permissionEvaluationTime = permissionEvaluationTime;
+    }
+    public Integer getPermissionEvaluationCount()
+    {
+        return permissionEvaluationCount;
+    }
+    public void setPermissionEvaluationCount(Integer permissionEvaluationCount)
+    {
+        this.permissionEvaluationCount = permissionEvaluationCount;
+    }
+    public Integer getTrackTotalHitsLimit()
+    {
+        return trackTotalHitsLimit;
+    }
+    public void setTrackTotalHitsLimit(Integer trackTotalHitsLimit)
+    {
+        this.trackTotalHitsLimit = trackTotalHitsLimit;
+    }
+}
+ 

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/RestRequestLimitsModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/RestRequestLimitsModel.java
@@ -32,8 +32,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class RestRequestLimitsModel extends TestModel implements IRestModel<RestRequestLimitsModel>
 {
-    @JsonProperty(value = "entry")
+    @JsonProperty
     RestRequestLimitsModel model;
+
+    private Integer permissionEvaluationTime;
+    private Integer permissionEvaluationCount;
+    private Integer trackTotalHitsLimit;
 
     @Override
     public RestRequestLimitsModel onModel()
@@ -49,10 +53,6 @@ public class RestRequestLimitsModel extends TestModel implements IRestModel<Rest
         this.permissionEvaluationCount = permissionEvaluationCount;
         this.trackTotalHitsLimit = trackTotalHitsLimit;
     }
-
-    private Integer permissionEvaluationTime;
-    private Integer permissionEvaluationCount;
-    private Integer trackTotalHitsLimit;
 
     public Integer getPermissionEvaluationTime()
     {

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/SearchRequest.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/SearchRequest.java
@@ -79,6 +79,7 @@ public class SearchRequest extends TestModel
     List<SortClause> sort;
     RestRequestDefaultsModel defaults;
     List<RestRequestTemplatesModel> templates;
+    RestRequestLimitsModel limits;
 
     public SearchRequest()
     {
@@ -302,4 +303,15 @@ public class SearchRequest extends TestModel
 
         return this;
     }
+
+    public RestRequestLimitsModel getLimits()
+    {
+        return limits;
+    }
+
+    public void setLimits(RestRequestLimitsModel limits)
+    {
+        this.limits = limits;
+    }
+
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/SearchMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/SearchMapper.java
@@ -823,6 +823,11 @@ public class SearchMapper
                 sp.setLimitBy(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS);
                 sp.setMaxPermissionCheckTimeMillis(limits.getPermissionEvaluationTime());
             }
+
+            if(limits.getTrackTotalHitsLimit() != null)
+            {
+                sp.setTrackTotalHits(limits.getTrackTotalHitsLimit());
+            }
         }
     }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/model/Limits.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/model/Limits.java
@@ -37,13 +37,16 @@ public class Limits
 
     private final Integer permissionEvaluationTime;
     private final Integer permissionEvaluationCount;
+    private final Integer trackTotalHitsLimit;
 
     @JsonCreator
     public Limits(@JsonProperty("permissionEvaluationTime") Integer permissionEvaluationTime,
-                  @JsonProperty("permissionEvaluationCount") Integer permissionEvaluationCount)
+                  @JsonProperty("permissionEvaluationCount") Integer permissionEvaluationCount,
+                  @JsonProperty("trackTotalHitsLimit") Integer trackTotalHitsLimit)
     {
         this.permissionEvaluationTime = permissionEvaluationTime;
         this.permissionEvaluationCount = permissionEvaluationCount;
+        this.trackTotalHitsLimit = trackTotalHitsLimit;
     }
 
     public Integer getPermissionEvaluationTime()
@@ -54,5 +57,10 @@ public class Limits
     public Integer getPermissionEvaluationCount()
     {
         return permissionEvaluationCount;
+    }
+
+    public Integer getTrackTotalHitsLimit()
+    {
+        return trackTotalHitsLimit;
     }
 }

--- a/remote-api/src/test/java/org/alfresco/rest/api/search/SearchMapperTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/search/SearchMapperTests.java
@@ -755,11 +755,11 @@ public class SearchMapperTests
         assertEquals(500, searchParameters.getLimit());
         assertEquals(LimitBy.UNLIMITED, searchParameters.getLimitBy());
 
-        searchMapper.fromLimits(searchParameters, new Limits(null, null));
+        searchMapper.fromLimits(searchParameters, new Limits(null, null, null));
         assertEquals(LimitBy.UNLIMITED, searchParameters.getLimitBy());
         assertEquals(500, searchParameters.getLimit());
 
-        searchMapper.fromLimits(searchParameters, new Limits(null, 34));
+        searchMapper.fromLimits(searchParameters, new Limits(null, 34, null));
         assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
         assertEquals(34, searchParameters.getMaxPermissionChecks());
         assertEquals(-1, searchParameters.getLimit());
@@ -767,11 +767,16 @@ public class SearchMapperTests
 
         searchParameters = new SearchParameters();
         searchMapper.setDefaults(searchParameters);
-        searchMapper.fromLimits(searchParameters, new Limits(1000, null));
+        searchMapper.fromLimits(searchParameters, new Limits(1000, null, null));
         assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
         assertEquals(1000, searchParameters.getMaxPermissionCheckTimeMillis());
         assertEquals(-1, searchParameters.getLimit());
         assertEquals(-1, searchParameters.getMaxPermissionChecks());
+
+        searchParameters = new SearchParameters();
+        searchMapper.setDefaults(searchParameters);
+        searchMapper.fromLimits(searchParameters, new Limits(null, null, 10));
+        assertEquals(10, searchParameters.getTrackTotalHits());
     }
 
     @Test

--- a/remote-api/src/test/java/org/alfresco/rest/api/search/SearchMapperTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/search/SearchMapperTests.java
@@ -745,38 +745,56 @@ public class SearchMapperTests
     }
 
     @Test
-    public void fromLimits() throws Exception
+    public void fromLimits_setNull() throws Exception
     {
         SearchParameters searchParameters = new SearchParameters();
         searchMapper.setDefaults(searchParameters);
-
-        //Doesn't error
         searchMapper.fromLimits(searchParameters, null);
-        assertEquals(500, searchParameters.getLimit());
-        assertEquals(LimitBy.UNLIMITED, searchParameters.getLimitBy());
+        assertEquals("LimitBy default value should be unlimited", LimitBy.UNLIMITED, searchParameters.getLimitBy());
+        assertEquals("Limit default value should be 500", 500, searchParameters.getLimit());
+    }
 
+    @Test
+    public void fromLimits_setAllLimitsAsNull() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
+        searchMapper.setDefaults(searchParameters);
         searchMapper.fromLimits(searchParameters, new Limits(null, null, null));
-        assertEquals(LimitBy.UNLIMITED, searchParameters.getLimitBy());
-        assertEquals(500, searchParameters.getLimit());
+        assertEquals("LimitBy default value should be unlimited", LimitBy.UNLIMITED, searchParameters.getLimitBy());
+        assertEquals("Limit default value should be 500", 500, searchParameters.getLimit());
+    }
 
+    @Test
+    public void fromLimits_setPermissionEvaluationCount() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
+        searchMapper.setDefaults(searchParameters);
         searchMapper.fromLimits(searchParameters, new Limits(null, 34, null));
         assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
-        assertEquals(34, searchParameters.getMaxPermissionChecks());
-        assertEquals(-1, searchParameters.getLimit());
-        assertEquals(-1, searchParameters.getMaxPermissionCheckTimeMillis());
+        assertEquals("MaxPermissionChecks should be set", 34, searchParameters.getMaxPermissionChecks());
+        assertEquals("Limit should be -1", -1, searchParameters.getLimit());
+        assertEquals("MaxPermissionCheckTimeMillis should be -1", -1, searchParameters.getMaxPermissionCheckTimeMillis());
+    }
 
-        searchParameters = new SearchParameters();
+    @Test
+    public void fromLimits_setPermissionEvaluationTime() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
         searchMapper.setDefaults(searchParameters);
         searchMapper.fromLimits(searchParameters, new Limits(1000, null, null));
         assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
-        assertEquals(1000, searchParameters.getMaxPermissionCheckTimeMillis());
-        assertEquals(-1, searchParameters.getLimit());
-        assertEquals(-1, searchParameters.getMaxPermissionChecks());
+        assertEquals("MaxPermissionCheckTimeMillis should be set", 1000, searchParameters.getMaxPermissionCheckTimeMillis());
+        assertEquals("Limit should be -1", -1, searchParameters.getLimit());
+        assertEquals("MaxPermissionChecks should be -1", -1, searchParameters.getMaxPermissionChecks());
+    }
 
-        searchParameters = new SearchParameters();
+    @Test
+    public void fromLimits_setTrackTotalHitsLimit() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
         searchMapper.setDefaults(searchParameters);
         searchMapper.fromLimits(searchParameters, new Limits(null, null, 10));
-        assertEquals(10, searchParameters.getTrackTotalHits());
+        assertEquals("TrackTotalHits should be set", 10, searchParameters.getTrackTotalHits());
     }
 
     @Test


### PR DESCRIPTION
 - SearchParameters - added trackTotalHits (int) attribute
 - SearchRequest - Added trackTotalHitsLimit (int) to the Limits attribute and mapped it to the SearchParameters
 - Changed the SearchRequest model in TAS to include a new RestRequestLimitsModel that has the new trackTotalHitsLimit attribute
 - SearchMapperTests to test the changes in the SearchParameters 