### PR TITLE
ACS-5487 - Track Total Hits on ES (#2041)

### DIFF
--- a/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
@@ -202,6 +202,11 @@ public class SearchParameters implements BasicSearchParameters
     private String timezone;
     
     /**
+     * Configure the limit to track the total hits on search results
+     */
+    private int trackTotalHits;
+
+    /**
      * Default constructor
      */
     public SearchParameters()
@@ -251,6 +256,7 @@ public class SearchParameters implements BasicSearchParameters
         sp.stats = this.stats;
         sp.ranges = this.ranges;
         sp.timezone = this.timezone;
+        sp.trackTotalHits = this.trackTotalHits;
         return sp;
     }
     
@@ -1641,6 +1647,21 @@ public class SearchParameters implements BasicSearchParameters
     {
         this.includeMetadata = includeMetadata;
     }
-    
+
+    public int getTrackTotalHits()
+    {
+        return trackTotalHits;
+    }
+
+    /**
+     * Set a maximum value for the report of total hits. The reported number of hits will never exceed this limit even
+     * if more are found. If unset, the engine’s default tracking limit is applied. To remove any limit, set to -1.
+     *
+     * @param trackTotalHits int
+     */
+    public void setTrackTotalHits(int trackTotalHits)
+    {
+        this.trackTotalHits = trackTotalHits;
+    }
 
 }

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/RestRequestLimitsModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/RestRequestLimitsModel.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Alfresco Remote API
+ * alfresco-tas-restapi
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2023 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -23,27 +23,32 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
+package org.alfresco.rest.search;
 
-package org.alfresco.rest.api.search.model;
+import org.alfresco.rest.core.IRestModel;
+import org.alfresco.utility.model.TestModel;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * POJO class representing the query Limits
- **/
-public class Limits
+public class RestRequestLimitsModel extends TestModel implements IRestModel<RestRequestLimitsModel>
 {
+    @JsonProperty
+    RestRequestLimitsModel model;
 
-    private final Integer permissionEvaluationTime;
-    private final Integer permissionEvaluationCount;
-    private final Integer trackTotalHitsLimit;
+    private Integer permissionEvaluationTime;
+    private Integer permissionEvaluationCount;
+    private Integer trackTotalHitsLimit;
 
-    @JsonCreator
-    public Limits(@JsonProperty("permissionEvaluationTime") Integer permissionEvaluationTime,
-                  @JsonProperty("permissionEvaluationCount") Integer permissionEvaluationCount,
-                  @JsonProperty("trackTotalHitsLimit") Integer trackTotalHitsLimit)
+    @Override
+    public RestRequestLimitsModel onModel()
     {
+        return model;
+    }
+    
+    public RestRequestLimitsModel(Integer permissionEvaluationTime, Integer permissionEvaluationCount,
+            Integer trackTotalHitsLimit)
+    {
+        super();
         this.permissionEvaluationTime = permissionEvaluationTime;
         this.permissionEvaluationCount = permissionEvaluationCount;
         this.trackTotalHitsLimit = trackTotalHitsLimit;
@@ -53,14 +58,25 @@ public class Limits
     {
         return permissionEvaluationTime;
     }
-
+    public void setPermissionEvaluationTime(Integer permissionEvaluationTime)
+    {
+        this.permissionEvaluationTime = permissionEvaluationTime;
+    }
     public Integer getPermissionEvaluationCount()
     {
         return permissionEvaluationCount;
     }
-
+    public void setPermissionEvaluationCount(Integer permissionEvaluationCount)
+    {
+        this.permissionEvaluationCount = permissionEvaluationCount;
+    }
     public Integer getTrackTotalHitsLimit()
     {
         return trackTotalHitsLimit;
     }
+    public void setTrackTotalHitsLimit(Integer trackTotalHitsLimit)
+    {
+        this.trackTotalHitsLimit = trackTotalHitsLimit;
+    }
 }
+ 

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/SearchRequest.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/search/SearchRequest.java
@@ -76,6 +76,7 @@ public class SearchRequest extends TestModel
     String facetFormat;
     List<String> include;
     List<SortClause> sort;
+    RestRequestLimitsModel limits;
 
     public SearchRequest()
     {
@@ -279,4 +280,15 @@ public class SearchRequest extends TestModel
 
         return this;
     }
+
+    public RestRequestLimitsModel getLimits()
+    {
+        return limits;
+    }
+
+    public void setLimits(RestRequestLimitsModel limits)
+    {
+        this.limits = limits;
+    }
+
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/SearchMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/SearchMapper.java
@@ -823,6 +823,11 @@ public class SearchMapper
                 sp.setLimitBy(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS);
                 sp.setMaxPermissionCheckTimeMillis(limits.getPermissionEvaluationTime());
             }
+
+            if(limits.getTrackTotalHitsLimit() != null)
+            {
+                sp.setTrackTotalHits(limits.getTrackTotalHitsLimit());
+            }
         }
     }
 

--- a/remote-api/src/test/java/org/alfresco/rest/api/search/SearchMapperTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/search/SearchMapperTests.java
@@ -745,33 +745,56 @@ public class SearchMapperTests
     }
 
     @Test
-    public void fromLimits() throws Exception
+    public void fromLimits_setNull() throws Exception
     {
         SearchParameters searchParameters = new SearchParameters();
         searchMapper.setDefaults(searchParameters);
-
-        //Doesn't error
         searchMapper.fromLimits(searchParameters, null);
-        assertEquals(500, searchParameters.getLimit());
-        assertEquals(LimitBy.UNLIMITED, searchParameters.getLimitBy());
+        assertEquals("LimitBy default value should be unlimited", LimitBy.UNLIMITED, searchParameters.getLimitBy());
+        assertEquals("Limit default value should be 500", 500, searchParameters.getLimit());
+    }
 
-        searchMapper.fromLimits(searchParameters, new Limits(null, null));
-        assertEquals(LimitBy.UNLIMITED, searchParameters.getLimitBy());
-        assertEquals(500, searchParameters.getLimit());
-
-        searchMapper.fromLimits(searchParameters, new Limits(null, 34));
-        assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
-        assertEquals(34, searchParameters.getMaxPermissionChecks());
-        assertEquals(-1, searchParameters.getLimit());
-        assertEquals(-1, searchParameters.getMaxPermissionCheckTimeMillis());
-
-        searchParameters = new SearchParameters();
+    @Test
+    public void fromLimits_setAllLimitsAsNull() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
         searchMapper.setDefaults(searchParameters);
-        searchMapper.fromLimits(searchParameters, new Limits(1000, null));
+        searchMapper.fromLimits(searchParameters, new Limits(null, null, null));
+        assertEquals("LimitBy default value should be unlimited", LimitBy.UNLIMITED, searchParameters.getLimitBy());
+        assertEquals("Limit default value should be 500", 500, searchParameters.getLimit());
+    }
+
+    @Test
+    public void fromLimits_setPermissionEvaluationCount() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
+        searchMapper.setDefaults(searchParameters);
+        searchMapper.fromLimits(searchParameters, new Limits(null, 34, null));
         assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
-        assertEquals(1000, searchParameters.getMaxPermissionCheckTimeMillis());
-        assertEquals(-1, searchParameters.getLimit());
-        assertEquals(-1, searchParameters.getMaxPermissionChecks());
+        assertEquals("MaxPermissionChecks should be set", 34, searchParameters.getMaxPermissionChecks());
+        assertEquals("Limit should be -1", -1, searchParameters.getLimit());
+        assertEquals("MaxPermissionCheckTimeMillis should be -1", -1, searchParameters.getMaxPermissionCheckTimeMillis());
+    }
+
+    @Test
+    public void fromLimits_setPermissionEvaluationTime() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
+        searchMapper.setDefaults(searchParameters);
+        searchMapper.fromLimits(searchParameters, new Limits(1000, null, null));
+        assertEquals(LimitBy.NUMBER_OF_PERMISSION_EVALUATIONS, searchParameters.getLimitBy());
+        assertEquals("MaxPermissionCheckTimeMillis should be set", 1000, searchParameters.getMaxPermissionCheckTimeMillis());
+        assertEquals("Limit should be -1", -1, searchParameters.getLimit());
+        assertEquals("MaxPermissionChecks should be -1", -1, searchParameters.getMaxPermissionChecks());
+    }
+
+    @Test
+    public void fromLimits_setTrackTotalHitsLimit() throws Exception
+    {
+        SearchParameters searchParameters = new SearchParameters();
+        searchMapper.setDefaults(searchParameters);
+        searchMapper.fromLimits(searchParameters, new Limits(null, null, 10));
+        assertEquals("TrackTotalHits should be set", 10, searchParameters.getTrackTotalHits());
     }
 
     @Test


### PR DESCRIPTION
SearchParameters - added trackTotalHits (int) attribute SearchRequest - Added trackTotalHitsLimit (int) to the Limits attribute and mapped it to the SearchParameters Changed the SearchRequest model in TAS to include a new RestRequestLimitsModel that has the new trackTotalHitsLimit attribute SearchMapperTests to test the changes in the SearchParameters

(cherry picked from commit a1faf97fc517f85774e6dc35ac63ebe0882f4ca9)