### PR TITLE
MNT-23763 Fix image preview webscript for use with ES.

### DIFF
--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/collaboration/tagQuery.get.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/collaboration/tagQuery.get.js
@@ -48,7 +48,7 @@ function tagQuery()
    }
    query += "ASPECT:\"{http://www.alfresco.org/model/content/1.0}taggable\"";
    //MNT-2118 Share inconsistencies when displaying locked files with tags
-   query += " -ASPECT:\"{http://www.alfresco.org/model/content/1.0}workingcopy\"";
+   query += " AND -ASPECT:\"{http://www.alfresco.org/model/content/1.0}workingcopy\"";
 
    // MNT-20091 check to prevent cm:taggable with NULL
    query += " AND ISNOTNULL:\"{http://www.alfresco.org/model/content/1.0}taggable\"";
@@ -60,7 +60,7 @@ function tagQuery()
          query: query,
          language: "lucene",
          page: {
-            // query minimum rows because all usefull info will come with facets 
+            // query minimum rows because all useful info will come with facets
             maxItems: 1,
             skipCount: 0
          },

--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/categorynode.get.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/categorynode.get.js
@@ -24,7 +24,7 @@ function getCategoryNode()
       else
       {
          var queryPath = "/" + catAspect + "/" + encodePath(path);
-         categoryResults = search.luceneSearch("+PATH:\"" + queryPath + "/*\" -PATH:\"" + queryPath + "/member\"");
+         categoryResults = search.luceneSearch("+PATH:\"" + queryPath + "/*\" AND -PATH:\"" + queryPath + "/member\"");
       }
       
       // make each result an object and indicate it is selectable in the UI

--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/images.get.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/images.get.js
@@ -29,7 +29,7 @@ function main()
    {
       query = "+PATH:\"" + parsedArgs.pathNode.qnamePath + "//*\" ";
    }
-   query += "+TYPE:\"cm:content\" +@cm\\:content.mimetype:image/*";
+   query += "AND +TYPE:\"cm:content\" AND +@cm\\:content.mimetype:\"image/*\"";
    
    // Sort the list before trimming to page chunks 
    assets = search.query(


### PR DESCRIPTION
This also fixes the query logic in two other webscripts. The default boolean operator is OR but these webscripts require AND.