### PR TITLE
ACS-5698 Allow specifying version when performing force release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -52,7 +52,7 @@ jobs:
     if: >
       ((github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request') &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -87,7 +87,7 @@ jobs:
     if: >
       !contains(github.event.head_commit.message, '[skip repo]') &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -108,7 +108,7 @@ jobs:
     if: >
       !contains(github.event.head_commit.message, '[skip repo]') &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     strategy:
       fail-fast: false
       matrix:
@@ -153,7 +153,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip db]')) ||
       contains(github.event.head_commit.message, '[db]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     strategy:
       fail-fast: false
       matrix:
@@ -183,7 +183,7 @@ jobs:
       contains(github.event.head_commit.message, '[latest db]') ||
       contains(github.event.head_commit.message, '[db]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -209,7 +209,7 @@ jobs:
       contains(github.event.head_commit.message, '[latest db]') ||
       contains(github.event.head_commit.message, '[db]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -234,7 +234,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip db]')) ||
       contains(github.event.head_commit.message, '[db]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -259,7 +259,7 @@ jobs:
       contains(github.event.head_commit.message, '[latest db]') ||
       contains(github.event.head_commit.message, '[db]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -282,7 +282,7 @@ jobs:
     if: >
       !contains(github.event.head_commit.message, '[skip repo]') &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -303,7 +303,7 @@ jobs:
     if: >
       !contains(github.event.head_commit.message, '[skip repo]') &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     strategy:
       fail-fast: false
       matrix:
@@ -372,7 +372,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip tas]')) ||
       contains(github.event.head_commit.message, '[tas]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     strategy:
       fail-fast: false
       matrix:
@@ -439,7 +439,7 @@ jobs:
     if: >
       !contains(github.event.head_commit.message, '[skip repo]') &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v3
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.33.0
@@ -462,7 +462,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip ags]')) ||
       contains(github.event.head_commit.message, '[ags]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     strategy:
       fail-fast: false
       matrix:
@@ -493,7 +493,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip ags]')) ||
       contains(github.event.head_commit.message, '[ags on MySQL]')) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     strategy:
       fail-fast: false
       matrix:
@@ -524,7 +524,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip ags]') && !contains(github.event.head_commit.message, '[skip tas]')) ||
       (contains(github.event.head_commit.message, '[ags]') && contains(github.event.head_commit.message, '[tas]'))) &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
-      !contains(github.event.head_commit.message, '[force]')
+      !contains(github.event.head_commit.message, '[force')
     env:
       REQUIRES_LOCAL_IMAGES: true
     steps:


### PR DESCRIPTION
GitHub Actions does not provide a regex version of contains and so during the migration from Travis we lost the ability to search for tokens like `[force 7.4.1-A1]`. By loosening the match to just `[force` then we can match both types of token.