### PR TITLE
PRODENG-222 Update to PMD 7.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       !contains(github.event.head_commit.message, '[skip tests]') &&
       !contains(github.event.head_commit.message, '[force]')
     steps:
-      - uses: Alfresco/ya-pmd-scan@v1.0.0
+      - uses: Alfresco/ya-pmd-scan@v2.0.0
         with:
           fail-on-new-issues: "false"
 


### PR DESCRIPTION
This also updates the default ruleset location from AlfrescoLabs/pmd-ruleset to Alfresco/pmd-ruleset.