### PR TITLE
MNT-23878: By default there was no timeout set for HttpClients, we've…

### DIFF
--- a/core/src/main/java/org/alfresco/httpclient/HttpClient4Factory.java
+++ b/core/src/main/java/org/alfresco/httpclient/HttpClient4Factory.java
@@ -92,15 +92,16 @@ public class HttpClient4Factory
         else
         {
             //Setting a connectionManager overrides these properties
-            clientBuilder.setMaxConnTotal(config.getMaxTotalConnections());
-            clientBuilder.setMaxConnPerRoute(config.getMaxHostConnections());
+            config.getMaxTotalConnections().ifPresent(v -> clientBuilder.setMaxConnTotal(v));
+            config.getMaxHostConnections().ifPresent(v -> clientBuilder.setMaxConnPerRoute(v));
         }
 
-        RequestConfig requestConfig = RequestConfig.custom()
-               .setConnectTimeout(config.getConnectionTimeout())
-               .setSocketTimeout(config.getSocketTimeout())
-               .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
-               .build();
+        RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+        config.getConnectionTimeout().ifPresent(v -> requestConfigBuilder.setConnectTimeout(v));
+        config.getConnectionRequestTimeout().ifPresent(v -> requestConfigBuilder.setConnectionRequestTimeout(v));
+        config.getSocketTimeout().ifPresent(v -> requestConfigBuilder.setSocketTimeout(v));
+
+        RequestConfig requestConfig = requestConfigBuilder.build();
 
         clientBuilder.setDefaultRequestConfig(requestConfig);
 
@@ -135,8 +136,8 @@ public class HttpClient4Factory
                    .register("http", PlainConnectionSocketFactory.getSocketFactory())
                    .build());
         }
-        poolingHttpClientConnectionManager.setMaxTotal(config.getMaxTotalConnections());
-        poolingHttpClientConnectionManager.setDefaultMaxPerRoute(config.getMaxHostConnections());
+        config.getMaxTotalConnections().ifPresent(v -> poolingHttpClientConnectionManager.setMaxTotal(v));
+        config.getMaxHostConnections().ifPresent(v -> poolingHttpClientConnectionManager.setDefaultMaxPerRoute(v));
 
         return poolingHttpClientConnectionManager;
     }

--- a/core/src/main/java/org/alfresco/httpclient/HttpClientConfig.java
+++ b/core/src/main/java/org/alfresco/httpclient/HttpClientConfig.java
@@ -112,79 +112,75 @@ public class HttpClientConfig
               .forEach(propertyName -> LOGGER.warn(String.format("For service [%s], an unsupported property [%s] is set", serviceName, propertyName)));
     }
 
-    private Integer getIntegerProperty(HttpClientPropertiesEnum property)
+    private Optional<Integer> getIntegerProperty(HttpClientPropertiesEnum property)
     {
-        return Integer.parseInt(extractValueFromConfig(property).orElse("0"));
+        Optional<String> optionalProperty = extractValueFromConfig(property);
+
+        return optionalProperty.isPresent() ? Optional.of(Integer.parseInt(optionalProperty.get())) : Optional.empty();
     }
 
-    private Boolean getBooleanProperty(HttpClientPropertiesEnum property)
+    private Optional<Boolean> getBooleanProperty(HttpClientPropertiesEnum property)
     {
-        return Boolean.parseBoolean(extractValueFromConfig(property).orElse("false"));
+        Optional<String> optionalProperty = extractValueFromConfig(property);
+
+        return optionalProperty.isPresent() ? Optional.of(Boolean.parseBoolean(optionalProperty.get())) : Optional.empty();
     }
 
     private Optional<String> extractValueFromConfig(HttpClientPropertiesEnum property)
     {
-        Optional<String> optionalProperty = Optional.ofNullable(config.get(property.name));
-        if(property.isRequired && optionalProperty.isEmpty())
-        {
-            String msg = String.format("Required property: '%s' is empty.", property.name);
-            throw new HttpClientException(msg);
-        }
-        return optionalProperty;
+        return Optional.ofNullable(config.get(property.name));
     }
 
-    public Integer getConnectionTimeout()
+    public Optional<Integer> getConnectionTimeout()
     {
         return getIntegerProperty(HttpClientPropertiesEnum.CONNECTION_REQUEST_TIMEOUT);
     }
 
-    public Integer getSocketTimeout()
+    public Optional<Integer> getSocketTimeout()
     {
         return getIntegerProperty(HttpClientPropertiesEnum.SOCKET_TIMEOUT);
     }
 
-    public Integer getConnectionRequestTimeout()
+    public Optional<Integer> getConnectionRequestTimeout()
     {
         return getIntegerProperty(HttpClientPropertiesEnum.CONNECTION_REQUEST_TIMEOUT);
     }
 
-    public Integer getMaxTotalConnections()
+    public Optional<Integer> getMaxTotalConnections()
     {
         return getIntegerProperty(HttpClientPropertiesEnum.MAX_TOTAL_CONNECTIONS);
     }
 
-    public Integer getMaxHostConnections()
+    public Optional<Integer> getMaxHostConnections()
     {
         return getIntegerProperty(HttpClientPropertiesEnum.MAX_HOST_CONNECTIONS);
     }
 
-    public Boolean isMTLSEnabled()
+    public boolean isMTLSEnabled()
     {
-        return getBooleanProperty(HttpClientPropertiesEnum.MTLS_ENABLED);
+        return getBooleanProperty(HttpClientPropertiesEnum.MTLS_ENABLED).orElse(Boolean.FALSE);
     }
 
     public boolean isHostnameVerificationDisabled()
     {
-        return getBooleanProperty(HttpClientPropertiesEnum.HOSTNAME_VERIFICATION_DISABLED);
+        return getBooleanProperty(HttpClientPropertiesEnum.HOSTNAME_VERIFICATION_DISABLED).orElse(Boolean.FALSE);
     }
 
     private enum HttpClientPropertiesEnum
     {
-        CONNECTION_TIMEOUT("connectionTimeout", true),
-        SOCKET_TIMEOUT("socketTimeout", true),
-        CONNECTION_REQUEST_TIMEOUT("connectionRequestTimeout", true),
-        MAX_TOTAL_CONNECTIONS("maxTotalConnections", true),
-        MAX_HOST_CONNECTIONS("maxHostConnections", true),
-        HOSTNAME_VERIFICATION_DISABLED("hostnameVerificationDisabled", false),
-        MTLS_ENABLED("mTLSEnabled", true);
+        CONNECTION_TIMEOUT("connectionTimeout"),
+        SOCKET_TIMEOUT("socketTimeout"),
+        CONNECTION_REQUEST_TIMEOUT("connectionRequestTimeout"),
+        MAX_TOTAL_CONNECTIONS("maxTotalConnections"),
+        MAX_HOST_CONNECTIONS("maxHostConnections"),
+        HOSTNAME_VERIFICATION_DISABLED("hostnameVerificationDisabled"),
+        MTLS_ENABLED("mTLSEnabled");
 
         private final String name;
-        private final Boolean isRequired;
 
-        HttpClientPropertiesEnum(String propertyName, Boolean isRequired)
+        HttpClientPropertiesEnum(String propertyName)
         {
             this.name = propertyName;
-            this.isRequired = isRequired;
         }
 
         private static final List<String> supportedProperties = new ArrayList<>();

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -749,15 +749,6 @@ encryption.ssl.truststore.type=JCEKS
 # configuration via metadata is deprecated
 encryption.ssl.truststore.keyMetaData.location=
 
-## HttpClient config for Transform Service
-#enable mtls in HttpClientFactory for Transform Service.
-httpclient.config.transform.mTLSEnabled=false
-httpclient.config.transform.maxTotalConnections=20
-httpclient.config.transform.maxHostConnections=20
-httpclient.config.transform.socketTimeout=5000
-httpclient.config.transform.connectionRequestTimeout=5000
-httpclient.config.transform.connectionTimeout=5000
-
 # Property is disabled by default for security reasons, never enable it on for production environments.
 # It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services
 httpclient.config.transform.hostnameVerificationDisabled=false

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -752,12 +752,6 @@ encryption.ssl.truststore.keyMetaData.location=
 ## HttpClient config for Transform Service
 #enable mtls in HttpClientFactory for Transform Service.
 httpclient.config.transform.mTLSEnabled=false
-httpclient.config.transform.maxTotalConnections=
-httpclient.config.transform.maxHostConnections=
-httpclient.config.transform.socketTimeout=
-httpclient.config.transform.connectionRequestTimeout=
-httpclient.config.transform.connectionTimeout=
-
 # Property is disabled by default for security reasons, never enable it on for production environments.
 # It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services
 httpclient.config.transform.hostnameVerificationDisabled=false

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -752,11 +752,11 @@ encryption.ssl.truststore.keyMetaData.location=
 ## HttpClient config for Transform Service
 #enable mtls in HttpClientFactory for Transform Service.
 httpclient.config.transform.mTLSEnabled=false
-httpclient.config.transform.maxTotalConnections=
-httpclient.config.transform.maxHostConnections=
-httpclient.config.transform.socketTimeout=
-httpclient.config.transform.connectionRequestTimeout=
-httpclient.config.transform.connectionTimeout=
+httpclient.config.transform.maxTotalConnections=20
+httpclient.config.transform.maxHostConnections=20
+httpclient.config.transform.socketTimeout=5000
+httpclient.config.transform.connectionRequestTimeout=5000
+httpclient.config.transform.connectionTimeout=5000
 
 # Property is disabled by default for security reasons, never enable it on for production environments.
 # It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -752,11 +752,11 @@ encryption.ssl.truststore.keyMetaData.location=
 ## HttpClient config for Transform Service
 #enable mtls in HttpClientFactory for Transform Service.
 httpclient.config.transform.mTLSEnabled=false
-httpclient.config.transform.maxTotalConnections=20
-httpclient.config.transform.maxHostConnections=20
-httpclient.config.transform.socketTimeout=5000
-httpclient.config.transform.connectionRequestTimeout=5000
-httpclient.config.transform.connectionTimeout=5000
+httpclient.config.transform.maxTotalConnections=
+httpclient.config.transform.maxHostConnections=
+httpclient.config.transform.socketTimeout=
+httpclient.config.transform.connectionRequestTimeout=
+httpclient.config.transform.connectionTimeout=
 
 # Property is disabled by default for security reasons, never enable it on for production environments.
 # It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -752,9 +752,6 @@ encryption.ssl.truststore.keyMetaData.location=
 ## HttpClient config for Transform Service
 #enable mtls in HttpClientFactory for Transform Service.
 httpclient.config.transform.mTLSEnabled=false
-# Property is disabled by default for security reasons, never enable it on for production environments.
-# It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services
-httpclient.config.transform.hostnameVerificationDisabled=false
 
 # Re-encryptor properties
 encryption.reencryptor.chunkSize=100

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -749,6 +749,15 @@ encryption.ssl.truststore.type=JCEKS
 # configuration via metadata is deprecated
 encryption.ssl.truststore.keyMetaData.location=
 
+## HttpClient config for Transform Service
+#enable mtls in HttpClientFactory for Transform Service.
+httpclient.config.transform.mTLSEnabled=false
+httpclient.config.transform.maxTotalConnections=
+httpclient.config.transform.maxHostConnections=
+httpclient.config.transform.socketTimeout=
+httpclient.config.transform.connectionRequestTimeout=
+httpclient.config.transform.connectionTimeout=
+
 # Property is disabled by default for security reasons, never enable it on for production environments.
 # It will stop verification of hostnames placed in certificates returned with server responses to Repository requests towards transform services
 httpclient.config.transform.hostnameVerificationDisabled=false


### PR DESCRIPTION
… wrongly directed ourselfes with the values of currently existing mTLS (Solr/Elasticsearch) for Transform that used default http clients with infinite timeouts