### PR TITLE
There was no override of properties related to HttpClientConfig, whic…

### DIFF
--- a/core/src/main/java/org/alfresco/httpclient/HttpClientConfig.java
+++ b/core/src/main/java/org/alfresco/httpclient/HttpClientConfig.java
@@ -100,7 +100,7 @@ public class HttpClientConfig
         Map<String, String> resultProperties = getHttpClientPropertiesForService(properties);
         Map<String, String> systemProperties = getHttpClientPropertiesForService(System.getProperties());
 
-        systemProperties.forEach((k, v) -> resultProperties.put(k, v)); //Override/Add to Global Properties with values from System Properties
+        systemProperties.forEach((k, v) -> resultProperties.put(k, v)); //Override/Add to Global Properties results with values from System Properties
 
         return resultProperties;
     }

--- a/core/src/main/java/org/alfresco/httpclient/HttpClientConfig.java
+++ b/core/src/main/java/org/alfresco/httpclient/HttpClientConfig.java
@@ -85,17 +85,27 @@ public class HttpClientConfig
         this.keyStore = new AlfrescoKeyStoreImpl(sslEncryptionParameters.getKeyStoreParameters(),  keyResourceLoader);
         this.trustStore = new AlfrescoKeyStoreImpl(sslEncryptionParameters.getTrustStoreParameters(), keyResourceLoader);
 
-        config = retrieveConfig(serviceName);
+        config = retrieveConfig();
         checkUnsupportedProperties(config);
     }
 
     /**
      * Method used for retrieving HttpClient config from Global Properties
-     * @param serviceName name of used service
+     * that can also have values provided/overridden through System Properties
+     *
      * @return map of properties
      */
-    private Map<String, String> retrieveConfig(String serviceName)
+    private Map<String, String> retrieveConfig()
     {
+        Map<String, String> resultProperties = getHttpClientPropertiesForService(properties);
+        Map<String, String> systemProperties = getHttpClientPropertiesForService(System.getProperties());
+
+        systemProperties.forEach((k, v) -> resultProperties.put(k, v)); //Override/Add to Global Properties with values from System Properties
+
+        return resultProperties;
+    }
+
+    private Map<String, String> getHttpClientPropertiesForService(Properties properties) {
         return properties.keySet().stream()
                 .filter(key -> key instanceof String)
                 .map(Object::toString)

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -749,10 +749,6 @@ encryption.ssl.truststore.type=JCEKS
 # configuration via metadata is deprecated
 encryption.ssl.truststore.keyMetaData.location=
 
-## HttpClient config for Transform Service
-#enable mtls in HttpClientFactory for Transform Service.
-httpclient.config.transform.mTLSEnabled=false
-
 # Re-encryptor properties
 encryption.reencryptor.chunkSize=100
 encryption.reencryptor.numThreads=2

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -749,6 +749,10 @@ encryption.ssl.truststore.type=JCEKS
 # configuration via metadata is deprecated
 encryption.ssl.truststore.keyMetaData.location=
 
+## HttpClient config for Transform Service
+#enable mtls in HttpClientFactory for Transform Service.
+httpclient.config.transform.mTLSEnabled=false
+
 # Re-encryptor properties
 encryption.reencryptor.chunkSize=100
 encryption.reencryptor.numThreads=2


### PR DESCRIPTION
…h meant that if a property wasn't present in global-properties files, it wouldn't be registered and couldn't be provided through command line. I've ammended that here