### PR TITLE
ACS-5039 Bump ATS version to 4.0.1-A2 / 3.0.1-A2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>6.0.1</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-service.version>3.0.0</dependency.alfresco-transform-service.version>
-        <dependency.alfresco-transform-core.version>4.0.0</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>3.0.1-A2</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>4.0.1-A2</dependency.alfresco-transform-core.version>
         <dependency.alfresco-greenmail.version>6.9</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>0.0.23</dependency.acs-event-model.version>
 


### PR DESCRIPTION
Bumping ATS to the latest in community-repo.

More PRs coming soon for ent-share and acs-packaging.