### PR TITLE
MNT-23476 Unable to unzip files in Share if it contains a document with a filename containing an accent

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
@@ -44,7 +44,6 @@ import java.util.zip.ZipException;
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.model.ApplicationModel;
 import org.alfresco.model.ContentModel;
-import org.alfresco.repo.action.ActionServiceImpl;
 import org.alfresco.repo.action.ParameterDefinitionImpl;
 import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.importer.ACPImportPackageHandler;
@@ -67,8 +66,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.InputStreamStatistics;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * Importer action executor
@@ -77,7 +74,6 @@ import org.apache.commons.logging.LogFactory;
  */
 public class ImporterActionExecuter extends ActionExecuterAbstractBase
 {
-    private static Log logger = LogFactory.getLog(ImporterActionExecuter.class);
     public static final String NAME = "import";
     public static final String PARAM_ENCODING = "encoding";
     public static final String PARAM_DESTINATION_FOLDER = "destination";
@@ -247,21 +243,17 @@ public class ImporterActionExecuter extends ActionExecuterAbstractBase
                        //       http://bugs.sun.com/bugdatabase/view_bug.do;:WuuT?bug_id=4820807
                        // We also try to use the extra encoding information if present
                        String encoding = (String) ruleAction.getParameterValue(PARAM_ENCODING);
-                       logger.info("Encoding before: "+encoding);
                        if (encoding == null)
                        {
-                           logger.info("Encoding is null ");
-                           encoding = "Cp437";
+                           encoding = "UTF-8";
                        }
                        else
                        {
                            if (encoding.equalsIgnoreCase("default"))
                            {
-                               logger.info("Encoding is default ");
-                               encoding = "Cp437";
+                               encoding = null;
                            }
                        }
-                       logger.info("Encoding after: "+encoding);
                        zipFile = new ZipFile(tempFile, encoding, false);
                        // build a temp dir name based on the ID of the noderef we are importing
                        // also use the long life temp folder as large ZIP files can take a while

--- a/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
@@ -66,6 +66,7 @@ import org.alfresco.util.TempFileProvider;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.InputStreamStatistics;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -261,7 +262,7 @@ public class ImporterActionExecuter extends ActionExecuterAbstractBase
                            }
                        }
                        logger.info("Encoding after: "+encoding);
-                       zipFile = new ZipFile(tempFile, encoding, true);
+                       zipFile = new ZipFile(tempFile, encoding, false);
                        // build a temp dir name based on the ID of the noderef we are importing
                        // also use the long life temp folder as large ZIP files can take a while
                        File alfTempDir = TempFileProvider.getLongLifeTempDir("import");
@@ -414,7 +415,8 @@ public class ImporterActionExecuter extends ActionExecuterAbstractBase
                 ZipArchiveEntry entry = e.nextElement();
                 if (!entry.isDirectory())
                 {
-                    fileName = entry.getName();
+                    fileName = entry.getName().replaceAll("\\?","_");
+                    fileName = StringUtils.stripAccents(fileName);
                     fileName = fileName.replace('/', File.separatorChar);
 
                     if (fileName.startsWith("/") || fileName.indexOf(":" + File.separator) == 1 || fileName.contains(".." + File.separator))

--- a/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
@@ -415,8 +415,7 @@ public class ImporterActionExecuter extends ActionExecuterAbstractBase
                 ZipArchiveEntry entry = e.nextElement();
                 if (!entry.isDirectory())
                 {
-                    fileName = entry.getName().replaceAll("\\?","_");
-                    fileName = StringUtils.stripAccents(fileName);
+                    fileName = StringUtils.stripAccents(entry.getName()).replaceAll("\\?","_");
                     fileName = fileName.replace('/', File.separatorChar);
 
                     if (fileName.startsWith("/") || fileName.indexOf(":" + File.separator) == 1 || fileName.contains(".." + File.separator))


### PR DESCRIPTION
Replaced the illegal characters from the filename while extracting File from zip in ImporterActionExecuter