### PR TITLE
ACS-2699 Update logic around + and - for lucene queries.

### DIFF
--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneConjunction.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneConjunction.java
@@ -60,7 +60,7 @@ public class LuceneConjunction<Q, S, E extends Throwable> extends BaseConjunctio
     {
         QueryParserExpressionAdaptor<Q, E> expressionAdaptor = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
         boolean must = false;
-        boolean must_not = false;
+        boolean mustNot = false;
         for (Constraint constraint : getConstraints())
         {
             if (constraint instanceof LuceneQueryBuilderComponent)
@@ -83,7 +83,7 @@ public class LuceneConjunction<Q, S, E extends Throwable> extends BaseConjunctio
                         break;
                     case EXCLUDE:
                         expressionAdaptor.addExcluded(constraintQuery, constraint.getBoost());
-                        must_not = true;
+                        mustNot = true;
                         break;
                     }
                 }
@@ -93,7 +93,7 @@ public class LuceneConjunction<Q, S, E extends Throwable> extends BaseConjunctio
                 throw new UnsupportedOperationException();
             }
         }
-        if(!must && must_not)
+        if(!must && mustNot)
         {
             expressionAdaptor.addRequired(luceneContext.getLuceneQueryParserAdaptor().getMatchAllNodesQuery());
         }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneConjunction.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneConjunction.java
@@ -58,7 +58,6 @@ public class LuceneConjunction<Q, S, E extends Throwable> extends BaseConjunctio
     public Q addComponent(Set<String> selectors, Map<String, Argument> functionArgs, QueryBuilderContext<Q, S, E> luceneContext, FunctionEvaluationContext functionContext)
             throws E
     {
-       
         QueryParserExpressionAdaptor<Q, E> expressionAdaptor = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
         boolean must = false;
         boolean must_not = false;
@@ -87,20 +86,17 @@ public class LuceneConjunction<Q, S, E extends Throwable> extends BaseConjunctio
                         must_not = true;
                         break;
                     }
-                    
                 }
             }
             else
             {
                 throw new UnsupportedOperationException();
             }
-            if(!must &&  must_not)
-            {
-                expressionAdaptor.addRequired(luceneContext.getLuceneQueryParserAdaptor().getMatchAllNodesQuery());
-            }
+        }
+        if(!must && must_not)
+        {
+            expressionAdaptor.addRequired(luceneContext.getLuceneQueryParserAdaptor().getMatchAllNodesQuery());
         }
         return expressionAdaptor.getQuery();
-
     }
-
 }

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQuery.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQuery.java
@@ -70,7 +70,7 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
         QueryParserExpressionAdaptor<Q, E> expressionBuilder = luceneContext.getLuceneQueryParserAdaptor().getExpressionAdaptor();
 
         boolean must = false;
-        boolean must_not = false;
+        boolean mustNot = false;
 
         if (selectors != null)
         {
@@ -118,7 +118,7 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
                         break;
                     case EXCLUDE:
                         expressionBuilder.addExcluded(constraintQuery, constraint.getBoost());
-                        must_not = true;
+                        mustNot = true;
                         break;
                     }
                 }
@@ -129,7 +129,7 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
             }
         }
 
-        if (!must && must_not)
+        if (!must && mustNot)
         {
             expressionBuilder.addRequired(luceneContext.getLuceneQueryParserAdaptor().getMatchAllNodesQuery());
         }
@@ -158,10 +158,10 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
     {
         if ((getOrderings() == null) || (getOrderings().size() == 0))
         {
-            return Collections.<SortDefinition>emptyList();
+            return Collections.emptyList();
         }
 
-        ArrayList<SortDefinition> definitions = new ArrayList<SortDefinition>(getOrderings().size());
+        List<SortDefinition> definitions = new ArrayList<>(getOrderings().size());
 
         for (Ordering ordering : getOrderings())
         {

--- a/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQuery.java
+++ b/data-model/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/lucene/LuceneQuery.java
@@ -40,12 +40,10 @@ import org.alfresco.repo.search.impl.querymodel.PropertyArgument;
 import org.alfresco.repo.search.impl.querymodel.Selector;
 import org.alfresco.repo.search.impl.querymodel.Source;
 import org.alfresco.repo.search.impl.querymodel.impl.BaseQuery;
-import org.alfresco.repo.search.impl.querymodel.impl.SimpleConstraint;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.PropertyAccessor;
 import org.alfresco.repo.search.impl.querymodel.impl.functions.Score;
 import org.alfresco.service.cmr.search.SearchParameters.SortDefinition;
 import org.alfresco.service.cmr.search.SearchParameters.SortDefinition.SortType;
-import org.alfresco.util.Pair;
 
 /**
  * @author andyh
@@ -74,8 +72,6 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
         boolean must = false;
         boolean must_not = false;
 
-        ArrayList<Pair<Constraint, Q>> queriestoConjoin = new ArrayList<>();
-        
         if (selectors != null)
         {
             for (String selector : selectors)
@@ -86,7 +82,6 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
                     @SuppressWarnings("unchecked")
                     LuceneQueryBuilderComponent<Q, S, E> luceneQueryBuilderComponent = (LuceneQueryBuilderComponent<Q, S, E>) current;
                     Q selectorQuery = luceneQueryBuilderComponent.addComponent(selectors, null, luceneContext, functionContext);
-                    queriestoConjoin.add(new Pair<Constraint, Q>(new SimpleConstraint(org.alfresco.repo.search.impl.querymodel.Constraint.Occur.MANDATORY), selectorQuery));
                     if (selectorQuery != null)
                     {
                         expressionBuilder.addRequired(selectorQuery);
@@ -108,8 +103,7 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
                 @SuppressWarnings("unchecked")
                 LuceneQueryBuilderComponent<Q, S, E> luceneQueryBuilderComponent = (LuceneQueryBuilderComponent<Q, S, E>) constraint;
                 Q constraintQuery = luceneQueryBuilderComponent.addComponent(selectors, null, luceneContext, functionContext);
-                queriestoConjoin.add(new Pair<Constraint, Q>(constraint, constraintQuery));
-                
+
                 if (constraintQuery != null)
                 {
                     switch (constraint.getOccur())
@@ -141,7 +135,6 @@ public class LuceneQuery<Q, S, E extends Throwable> extends BaseQuery implements
         }
 
         return expressionBuilder.getQuery();
-
     }
 
     /*


### PR DESCRIPTION
Remove unused list of constraints.

Only add match all clause once if necessary.