### PR TITLE
[MNT-23107] The scriptLocation property is not picked up when set in a bean definition

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/action/executer/ScriptActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ScriptActionExecuter.java
@@ -230,12 +230,12 @@ public class ScriptActionExecuter extends ActionExecuterAbstractBase
         return companyHomeRef;
     }
     
-    private boolean isValidScriptRef(Action action) {
+    private boolean isValidScriptRef(Action action)
+    {
         NodeRef scriptRef = (NodeRef) action.getParameterValue(PARAM_SCRIPTREF);
         ActionService actionService = this.serviceRegistry.getActionService();
         ActionDefinition actDef = actionService.getActionDefinition(action.getActionDefinitionName());
         ParameterDefinition parameterDef = actDef.getParameterDefintion(PARAM_SCRIPTREF);
-
         if (parameterDef != null)
         {
             String paramConstraintName = parameterDef.getParameterConstraintName();

--- a/repository/src/main/java/org/alfresco/repo/action/executer/ScriptActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ScriptActionExecuter.java
@@ -230,17 +230,20 @@ public class ScriptActionExecuter extends ActionExecuterAbstractBase
         return companyHomeRef;
     }
     
-    private boolean isValidScriptRef(Action action)
-    {
+    private boolean isValidScriptRef(Action action) {
         NodeRef scriptRef = (NodeRef) action.getParameterValue(PARAM_SCRIPTREF);
         ActionService actionService = this.serviceRegistry.getActionService();
         ActionDefinition actDef = actionService.getActionDefinition(action.getActionDefinitionName());
         ParameterDefinition parameterDef = actDef.getParameterDefintion(PARAM_SCRIPTREF);
-        String paramConstraintName = parameterDef.getParameterConstraintName();
-        if (paramConstraintName != null)
+
+        if (parameterDef != null)
         {
-            ParameterConstraint paramConstraint = actionService.getParameterConstraint(paramConstraintName);
-            return paramConstraint.isValidValue(scriptRef.toString());
+            String paramConstraintName = parameterDef.getParameterConstraintName();
+            if (paramConstraintName != null)
+            {
+                ParameterConstraint paramConstraint = actionService.getParameterConstraint(paramConstraintName);
+                return paramConstraint.isValidValue(scriptRef.toString());
+            }
         }
         return true;
     }


### PR DESCRIPTION
Added the Null check for the ParameterDefinition in the method isValidScriptRef