### PR TITLE
PRODENG-222 Fail builds based on PMD scan.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: Alfresco/ya-pmd-scan@v2.0.0
-        with:
-          fail-on-new-issues: "false"
 
   all_unit_tests_suite:
     name: "Core, Data-Model, Repository - AllUnitTestsSuite - Build and test"


### PR DESCRIPTION
Nb. The UnnecessaryImport rule has been disabled since we're not currently including the full classpath - see https://github.com/Alfresco/pmd-ruleset/pull/3