### PR TITLE
ACS-6073: DispositionScheduleLinkedRecordsTest - tests fail over and over again

### DIFF
--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/smoke/DispositionScheduleLinkedRecordsTest.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/smoke/DispositionScheduleLinkedRecordsTest.java
@@ -135,7 +135,7 @@ public class DispositionScheduleLinkedRecordsTest extends BaseRMRestTest {
      * <p>
      * <p/> TestRail Test C775<p/>
      **/
-    @Test(enabled = false) // disabling the test, see ACS-6073
+    @Test(enabled = false) // temporary disabled, see ACS-6073
     @AlfrescoTest(jira = "RM-1622")
     public void dispositionScheduleLinkedRecords() throws UnsupportedEncodingException {
         STEP("Create record category");
@@ -202,7 +202,7 @@ public class DispositionScheduleLinkedRecordsTest extends BaseRMRestTest {
      * Check the disposition steps for a record can be executed
      * When the record is linked to a folder with the same disposition schedule
      * */
-    @Test(enabled = false) // disabling the test, see ACS-6073
+    @Test(enabled = false) // temporary disabled, see ACS-6073
     @AlfrescoTest (jira = "RM-3060")
     public void sameDispositionScheduleLinkedRecords() throws UnsupportedEncodingException {
 

--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/smoke/DispositionScheduleLinkedRecordsTest.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/smoke/DispositionScheduleLinkedRecordsTest.java
@@ -135,7 +135,7 @@ public class DispositionScheduleLinkedRecordsTest extends BaseRMRestTest {
      * <p>
      * <p/> TestRail Test C775<p/>
      **/
-    @Test
+    @Test(enabled = false) // disabling the test, see ACS-6073
     @AlfrescoTest(jira = "RM-1622")
     public void dispositionScheduleLinkedRecords() throws UnsupportedEncodingException {
         STEP("Create record category");
@@ -202,7 +202,7 @@ public class DispositionScheduleLinkedRecordsTest extends BaseRMRestTest {
      * Check the disposition steps for a record can be executed
      * When the record is linked to a folder with the same disposition schedule
      * */
-    @Test
+    @Test(enabled = false) // disabling the test, see ACS-6073
     @AlfrescoTest (jira = "RM-3060")
     public void sameDispositionScheduleLinkedRecords() throws UnsupportedEncodingException {
 


### PR DESCRIPTION
- disabling failing tests

https://alfresco.atlassian.net/browse/ACS-6073