### PR TITLE
MNT-23927 Handle JsonMappingException and JsonGenerationException

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/framework/jacksonextensions/JacksonHelper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/jacksonextensions/JacksonHelper.java
@@ -104,13 +104,9 @@ public class JacksonHelper implements InitializingBean
             JsonGenerator generator = objectMapper.getFactory().createGenerator(outStream, encoding);
             writer.writeContents(generator, objectMapper);
         }
-        catch (JsonMappingException error)
+        catch (JsonMappingException | JsonGenerationException error)
         {
-            logger.error("Failed to write Json output", error);
-        } 
-        catch (JsonGenerationException generror)
-        {
-            logger.error("Failed to write Json output", generror);
+            throw new IOException("Failed to write Json output", error);
         }
     }
        

--- a/remote-api/src/test/java/org/alfresco/rest/framework/tests/core/ExecutionTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/framework/tests/core/ExecutionTests.java
@@ -262,13 +262,15 @@ public class ExecutionTests extends AbstractContextTest implements ResponseWrite
     {
         AbstractResourceWebScript executor = getExecutor();
         Map<String, String> templateVars = new HashMap();
+
+        WebScriptResponse response = mockResponse();
         templateVars.put("apiScope", "private");
         templateVars.put("apiVersion", "1");
         templateVars.put("apiName", "alfrescomock");
         templateVars.put(ResourceLocator.COLLECTION_RESOURCE, "sheep");
-        executor.execute(ApiAssistant.determineApi(templateVars), mockRequest(templateVars,new HashMap<String, List<String>>(1)), mock(WebScriptResponse.class));
+        executor.execute(ApiAssistant.determineApi(templateVars), mockRequest(templateVars,new HashMap<String, List<String>>(1)), response);
 
-        WebScriptResponse response = mockResponse();
+        response = mockResponse();
         templateVars.put(ResourceLocator.COLLECTION_RESOURCE, "bad");
         executor.execute(api, mockRequest(templateVars,new HashMap<String, List<String>>(1)), response);
         //throws a runtime exception so INTERNAL_SERVER_ERROR

--- a/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
@@ -1614,6 +1614,10 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
                 {
                     Map<Serializable, Serializable> map = (Map<Serializable, Serializable>) container;
                     Serializable mapKey = getPropertyValueById(keyPropId).getSecond();
+                    if(mapKey == null)
+                    {
+                        logger.error("Found null key for id " +  keyPropId +  " with value " + value);
+                    }
                     map.put(mapKey, value);
                 }
                 else if (container instanceof Collection<?>)


### PR DESCRIPTION
- Handle JsonMappingException and JsonGenerationException by throwing an IOException so we do not risk sending a partial JSON response
- Added logging to alert when a null key is found