### PR TITLE
Security definition of getAdditionalInfo if missing

### DIFF
--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -631,6 +631,7 @@
                 org.alfresco.service.cmr.lock.LockService.getLockState=ACL_NODE.0.sys:base.ReadProperties
                 org.alfresco.service.cmr.lock.LockService.isLocked=ACL_NODE.0.sys:base.ReadProperties
                 org.alfresco.service.cmr.lock.LockService.isLockedAndReadOnly=ACL_NODE.0.sys:base.ReadProperties
+                org.alfresco.service.cmr.lock.LockService.getAdditionalInfo=ACL_NODE.0.sys:base.ReadProperties
                 org.alfresco.service.cmr.lock.LockService.*=ACL_DENY
             </value>
         </property>


### PR DESCRIPTION
We can retrieve the same information with getLockState but because getAdditionalInfo is define in LockService interface, I think it must br possible to call it directly.