### PR TITLE
 ACS-5925 Switch from IDS 2.0.0 to Keycloak 21.1.2 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
           - testSuite: AppContext04TestSuite
             compose-profile: with-transform-core-aio
           - testSuite: AppContext05TestSuite
-            compose-profile: with-ids
+            compose-profile: with-sso
             mvn-options: '-Didentity-service.auth-server-url=http://${HOST_IP}:8999/auth -Dauthentication.chain=identity-service1:identity-service,alfrescoNtlm1:alfrescoNtlm'
           - testSuite: AppContext06TestSuite
             compose-profile: with-transform-core-aio

--- a/scripts/ci/docker-compose/docker-compose.yaml
+++ b/scripts/ci/docker-compose/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - "8090:8090"
   postgres:
     image: postgres:15.4
-    profiles: ["default", "with-transform-core-aio", "postgres", "with-mtls-transform-core-aio", "with-ids"]
+    profiles: ["default", "with-transform-core-aio", "postgres", "with-mtls-transform-core-aio", "with-sso"]
     environment:
       - POSTGRES_PASSWORD=alfresco
       - POSTGRES_USER=alfresco
@@ -19,7 +19,7 @@ services:
     ports:
       - "5433:5432"
   activemq:
-    profiles: ["default", "with-transform-core-aio", "activemq", "with-mtls-transform-core-aio", "with-ids"]
+    profiles: ["default", "with-transform-core-aio", "activemq", "with-mtls-transform-core-aio", "with-sso"]
     image: alfresco/alfresco-activemq:5.18.3-jre17-rockylinux8
     ports:
       - "5672:5672" # AMQP
@@ -58,8 +58,8 @@ services:
       CLIENT_SSL_TRUST_STORE_PASSWORD: "password"
       CLIENT_SSL_TRUST_STORE_TYPE: "JCEKS"
   alfresco-identity-service:
-    profiles: ["with-ids"]
-    image: quay.io/alfresco/alfresco-identity-service:2.0.0
+    profiles: ["with-sso"]
+    image: quay.io/keycloak/keycloak:21.1.2
     environment:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=admin

--- a/scripts/ci/docker-compose/docker-compose.yaml
+++ b/scripts/ci/docker-compose/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       CLIENT_SSL_TRUST_STORE: "file:/tengineAIO.truststore"
       CLIENT_SSL_TRUST_STORE_PASSWORD: "password"
       CLIENT_SSL_TRUST_STORE_TYPE: "JCEKS"
-  alfresco-identity-service:
+  keycloak:
     profiles: ["with-sso"]
     image: quay.io/keycloak/keycloak:21.1.2
     environment:


### PR DESCRIPTION
Switching from IDS 2.0.0 to Keycloak 21.1.2 as a test component due to IDS reaching End of Life status.