### PR TITLE
ACS-6402: Add tests covering module compatibility check for new ACS versioning schema

### DIFF
--- a/core/src/test/java/org/alfresco/util/VersionNumberTest.java
+++ b/core/src/test/java/org/alfresco/util/VersionNumberTest.java
@@ -136,4 +136,36 @@ public class VersionNumberTest extends TestCase
         assertEquals(-1, version8.compareTo(version9));
         assertEquals(-1, version9.compareTo(version10));
     }
+
+    public void testCompareNewSchema() {
+        // module min/max repo version is 23, actual ACS version is 23.1.0 which is greater than module
+        VersionNumber repoVersionMin = new VersionNumber("23");
+        VersionNumber repoVerisionActual = new VersionNumber("23.1.0");
+        assertEquals(1, repoVerisionActual.compareTo(repoVersionMin));
+
+        // module min/max repo version is 23.2, actual ACS version is 23.1.1 which is lower than module
+        repoVersionMin = new VersionNumber("23.2");
+        repoVerisionActual = new VersionNumber("23.1.1");
+        assertEquals(-1, repoVerisionActual.compareTo(repoVersionMin));
+
+        // module min/max repo version is 7.4, actual ACS version is 23.1.0 which is greater than module
+        repoVersionMin = new VersionNumber("7.4");
+        repoVerisionActual = new VersionNumber("23.1.0");
+        assertEquals(1, repoVerisionActual.compareTo(repoVersionMin));
+
+        // module min/max repo version is 24, actual ACS version is 24.1.0 which is greater than module
+        repoVersionMin = new VersionNumber("24");
+        repoVerisionActual = new VersionNumber("24.1.0");
+        assertEquals(1, repoVerisionActual.compareTo(repoVersionMin));
+
+        // module min/max repo version is 24, actual ACS version is 23.2.0 which is lower than module
+        repoVersionMin = new VersionNumber("24");
+        repoVerisionActual = new VersionNumber("23.2.0");
+        assertEquals(-1, repoVerisionActual.compareTo(repoVersionMin));
+
+        // module min/max repo version is 24.2, actual ACS version is 24.2.0 which is equal to module
+        repoVersionMin = new VersionNumber("24.2");
+        repoVerisionActual = new VersionNumber("24.2.0");
+        assertEquals(0, repoVerisionActual.compareTo(repoVersionMin));
+    }
 }

--- a/core/src/test/java/org/alfresco/util/VersionNumberTest.java
+++ b/core/src/test/java/org/alfresco/util/VersionNumberTest.java
@@ -25,6 +25,7 @@ import junit.framework.TestCase;
  * 
  * @author Roy Wetherall
  */
+@SuppressWarnings({"PMD.DetachedTestCase", "PMD.JUnit4TestShouldUseTestAnnotation"})
 public class VersionNumberTest extends TestCase
 {
     public void testCreate()


### PR DESCRIPTION
As per [this comment](https://alfresco.atlassian.net/browse/ACS-6402?focusedCommentId=1223553) in ACS-6402 - I am adding tests which explicitly cover cases we may experience after applying new versioning schema in ACS on module compatibility checks.