### PR TITLE
ACS-6650 Avoid running SAST scan on DependaBot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
     needs: [prepare]
     if: >
       (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'pull_request') &&
+      github.actor != 'dependabot[bot]' &&
       !contains(github.event.head_commit.message, '[skip tests]') &&
       !contains(github.event.head_commit.message, '[force')
     steps:


### PR DESCRIPTION
Skipping SAST scan on DependaBot PRs as it won't provide any additional insights and requires sharing more secrets with DependaBot than we're willing to.