### PR TITLE
MNT-24094 - improve remote-api logging on error

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/NetworkWebScriptGet.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/NetworkWebScriptGet.java
@@ -109,11 +109,11 @@ public class NetworkWebScriptGet extends ApiWebScript implements ResponseWriter
         }
         catch (ApiException | WebScriptException apiException)
         {
-            renderException(apiException, res, assistant);
+            renderException(apiException, res, req, assistant);
         }
         catch (RuntimeException runtimeException)
         {
-            renderException(runtimeException, res, assistant);
+            renderException(runtimeException, res, req, assistant);
         }
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/NetworksWebScriptGet.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/NetworksWebScriptGet.java
@@ -118,11 +118,11 @@ public class NetworksWebScriptGet extends ApiWebScript implements RecognizedPara
         }
         catch (ApiException | WebScriptException apiException)
         {
-            renderException(apiException, res, assistant);
+            renderException(apiException, res, req, assistant);
         }
         catch (RuntimeException runtimeException)
         {
-            renderException(runtimeException, res, assistant);
+            renderException(runtimeException, res, req, assistant);
         }
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/PublicApiTenantWebScriptServletRuntime.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/PublicApiTenantWebScriptServletRuntime.java
@@ -143,7 +143,7 @@ public class PublicApiTenantWebScriptServletRuntime extends TenantWebScriptServl
         else
         {
             try {
-                renderException((Exception)exception, response, apiAssistant);
+                renderException((Exception)exception, response, request, apiAssistant);
             } catch (IOException e) {
                 logger.error("Internal error", e);
                 throw new WebScriptException("Internal error", e);

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/SearchApiWebscript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/SearchApiWebscript.java
@@ -108,7 +108,7 @@ public class SearchApiWebscript extends AbstractWebScript implements RecognizedP
             renderJsonResponse(webScriptResponse, toRender, assistant.getJsonHelper());
 
         } catch (Exception exception) {
-            renderException(exception,webScriptResponse,assistant);
+            renderException(exception,webScriptResponse,webScriptRequest,assistant);
         }
     }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/SearchSQLApiWebscript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/SearchSQLApiWebscript.java
@@ -102,11 +102,11 @@ public class SearchSQLApiWebscript extends AbstractWebScript implements Recogniz
         {
             if (exception instanceof QueryParserException)
             {
-                renderException(exception,res,assistant);
+                renderException(exception,res,webScriptRequest,assistant);
             }
             else
             {
-                renderException(new WebScriptException(400, exception.getMessage()), res, assistant);
+                renderException(new WebScriptException(400, exception.getMessage()), res, webScriptRequest, assistant);
             }
         }
     }

--- a/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
@@ -180,15 +180,15 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
         }
         catch (ContentIOException cioe)
         {
-            handleContentIOException(res, cioe); 
+            handleContentIOException(res, req, cioe);
         }
         catch (AlfrescoRuntimeException | ApiException | WebScriptException xception )
         {
-            renderException(xception, res, assistant);
+            renderException(xception, res, req, assistant);
         }
         catch (RuntimeException runtimeException)
         {
-            renderException(runtimeException, res, assistant);
+            renderException(runtimeException, res, req, assistant);
         }
         finally
         {
@@ -224,17 +224,17 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
         return toReturn;
     }
 
-    private void handleContentIOException(final WebScriptResponse res, ContentIOException exception) throws IOException
+    private void handleContentIOException(final WebScriptResponse res, final WebScriptRequest req, ContentIOException exception) throws IOException
     {
         // If the Content-Length is not set back to -1 any client will expect to receive binary and will hang until it times out
         res.setHeader(HEADER_CONTENT_LENGTH, String.valueOf(-1));
         if (exception instanceof ArchivedIOException)
         {
-            renderException(new ArchivedContentException(exception.getMsgId(), exception), res, assistant);
+            renderException(new ArchivedContentException(exception.getMsgId(), exception), res, req, assistant);
         }
         else
         {
-            renderException(exception, res, assistant);
+            renderException(exception, res, req, assistant);
         }
     }
 


### PR DESCRIPTION
* Add WebScriptRequest to the methods that call the render exception so we can log more info on the request when an error occurs.
* Add request uri, user and status code to the logging
* Always log on exception but only show stack trace on debug or on internal server exception