### PR TITLE
Map includeChildAssociations request parameter

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/NodesMetaDataGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/NodesMetaDataGet.java
@@ -175,6 +175,10 @@ public class NodesMetaDataGet extends DeclarativeWebScript
             {
                 filter.setIncludeChildIds(o.getBoolean("includeChildIds"));
             }
+            if(o.has("includeChildAssociations"))
+            {
+                filter.setIncludeChildAssociations(o.getBoolean("includeChildAssociations"));
+            }
             if(o.has("includeTxnId"))
             {
                 filter.setIncludeTxnId(o.getBoolean("includeTxnId"));


### PR DESCRIPTION
This PR provides a very minor/trivial change that will have ACS actually use the parameter `includeChildAssociations` as provided by Search Services since at least version 1.4.2 (https://github.com/Alfresco/SearchServices/commit/943fafcca383a995db221805fed2cd9036ec66e2). This will significantly reduce the overhead when indexing metadata changes on any node that contains large amount of child nodes as combined with the `includeChildIds` flag which is already handled and provided as `false` as well, this change results in the elimination of the extremely expensive `getChildAssocs` call in the `SOLRTrackingComponentImpl` `getNodesMetadata` method.