### PR TITLE
[ACS-5506] Fix string to node ref cast exception

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/GroupsImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/GroupsImpl.java
@@ -147,7 +147,7 @@ public class GroupsImpl implements Groups
         }
 
         Map<QName, Serializable> props = new HashMap<>();
-        if (StringUtils.isNotEmpty(group.getDescription()))
+        if (group.getDescription() != null)
         {
             props.put(ContentModel.PROP_DESCRIPTION, group.getDescription());
         }
@@ -170,7 +170,7 @@ public class GroupsImpl implements Groups
 
         try
         {
-            if (StringUtils.isNotEmpty(group.getDescription()))
+            if (group.getDescription() != null)
             {
                 authorityService.setAuthorityDisplayNameAndDescription(groupId, group.getDisplayName(), group.getDescription());
             }

--- a/repository/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/ACLEntryAfterInvocationProvider.java
+++ b/repository/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/ACLEntryAfterInvocationProvider.java
@@ -269,7 +269,18 @@ public class ACLEntryAfterInvocationProvider implements AfterInvocationProvider,
             }
             else if (Pair.class.isAssignableFrom(returnedObject.getClass()))
             {
-                return decide(authentication, object, config, (Pair) returnedObject);
+                Pair<?, ?> pair = (Pair<?, ?>) returnedObject;
+                if (pair.getSecond() != null && NodeRef.class.isAssignableFrom(pair.getSecond().getClass()))
+                {
+                    return decide(authentication, object, config, pair);
+                } else
+                {
+                    if (log.isDebugEnabled())
+                    {
+                        log.debug("Uncontrolled object - access allowed for " + object.getClass().getName());
+                    }
+                    return returnedObject;
+                }
             }
             else if (ChildAssociationRef.class.isAssignableFrom(returnedObject.getClass()))
             {

--- a/repository/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/ACLEntryAfterInvocationProvider.java
+++ b/repository/src/main/java/org/alfresco/repo/security/permissions/impl/acegi/ACLEntryAfterInvocationProvider.java
@@ -269,18 +269,7 @@ public class ACLEntryAfterInvocationProvider implements AfterInvocationProvider,
             }
             else if (Pair.class.isAssignableFrom(returnedObject.getClass()))
             {
-                Pair<?, ?> pair = (Pair<?, ?>) returnedObject;
-                if (pair.getSecond() != null && NodeRef.class.isAssignableFrom(pair.getSecond().getClass()))
-                {
-                    return decide(authentication, object, config, pair);
-                } else
-                {
-                    if (log.isDebugEnabled())
-                    {
-                        log.debug("Uncontrolled object - access allowed for " + object.getClass().getName());
-                    }
-                    return returnedObject;
-                }
+                return decide(authentication, object, config, (Pair) returnedObject);
             }
             else if (ChildAssociationRef.class.isAssignableFrom(returnedObject.getClass()))
             {
@@ -435,6 +424,11 @@ public class ACLEntryAfterInvocationProvider implements AfterInvocationProvider,
     @SuppressWarnings("rawtypes")
     private Pair decide(Authentication authentication, Object object, ConfigAttributeDefinition config, Pair returnedObject) throws AccessDeniedException
     {
+        if (returnedObject.getSecond() != null && !NodeRef.class.isAssignableFrom(returnedObject.getSecond().getClass()))
+        {
+            return returnedObject;
+        }
+
         NodeRef nodeRef = (NodeRef) returnedObject.getSecond();
         decide(authentication, object, config, nodeRef);
         // the noderef was allowed


### PR DESCRIPTION
Added a fix for `String` to `NodeRef` cast exception when `returnedObject` contains pair of strings.