### PR TITLE
ACS-6113: Fix secondary parents to never be set to null (#2460)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency.alfresco-transform-core.version>5.1.0-A1</dependency.alfresco-transform-core.version>
         <dependency.alfresco-transform-service.version>4.1.0-A1</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.0</dependency.alfresco-greenmail.version>
-        <dependency.acs-event-model.version>0.0.26</dependency.acs-event-model.version>
+        <dependency.acs-event-model.version>0.0.27</dependency.acs-event-model.version>
 
         <dependency.aspectj.version>1.9.20.1</dependency.aspectj.version>
         <dependency.spring.version>6.0.14</dependency.spring.version>


### PR DESCRIPTION
(cherry picked from commit 859492ae1e79a33bf2923ab28a26366ca6a7a7e4)