### PR TITLE
[MNT-24072] Retain users/groups (who are already exist and are part of AUTH.ALF zone) so parent associations can be created (#2414)

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/security/sync/ChainingUserRegistrySynchronizer.java
+++ b/repository/src/main/java/org/alfresco/repo/security/sync/ChainingUserRegistrySynchronizer.java
@@ -1001,8 +1001,10 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
             private final Map<String, String> groupsToCreate = new TreeMap<String, String>();
             private final Map<String, Set<String>> personParentAssocsToCreate = newPersonMap();
             private final Map<String, Set<String>> personParentAssocsToDelete = newPersonMap();
+            private final List<String> personToRezone = new LinkedList<>();
             private Map<String, Set<String>> groupParentAssocsToCreate = new TreeMap<String, Set<String>>();
             private final Map<String, Set<String>> groupParentAssocsToDelete = new TreeMap<String, Set<String>>();
+            private final List<String> groupToRezone = new LinkedList<>();
             private final Map<String, Set<String>> finalGroupChildAssocs = new TreeMap<String, Set<String>>();
             private List<String> personsProcessed = new LinkedList<String>();
             private Set<String> allZonePersons = Collections.emptySet();
@@ -1268,7 +1270,18 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
                     parents.add(parent);
                 }
             }
-            
+
+            private void recordParentAssociationAuthoritiesToRezone(String child)
+            {
+                if (child != null)
+                {
+                    List<String> toRezone = AuthorityType.getAuthorityType(child) == AuthorityType.USER
+                            ? this.personToRezone
+                            : this.groupToRezone;
+                    toRezone.add(child);
+                }
+            }
+
             private void validateGroupParentAssocsToCreate()
             {
                 Iterator<Map.Entry<String, Set<String>>> i = this.groupParentAssocsToCreate.entrySet().iterator();
@@ -1432,34 +1445,53 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
                     String child = entry.getKey();
                     if (!toRetain.contains(child))
                     {
-                        if (ChainingUserRegistrySynchronizer.logger.isDebugEnabled())
+                        if (!shouldRezone(child))
                         {
-                            if (groupList == null)
+                            if (ChainingUserRegistrySynchronizer.logger.isDebugEnabled())
                             {
-                                groupList = new StringBuilder(1024);
-                            }
-                            else
-                            {
-                                groupList.setLength(0);
-                            }
-                            for (String parent : entry.getValue())
-                            {
-                                if (groupList.length() > 0)
+                                if (groupList == null)
                                 {
-                                    groupList.append(", ");
+                                    groupList = new StringBuilder(1024);
                                 }
-                                groupList.append('\'').append(
-                                        ChainingUserRegistrySynchronizer.this.authorityService.getShortName(parent))
-                                        .append('\'');
+                                else
+                                {
+                                    groupList.setLength(0);
+                                }
+                                for (String parent : entry.getValue())
+                                {
+                                    if (groupList.length() > 0)
+                                    {
+                                        groupList.append(", ");
+                                    }
+                                    groupList.append('\'').append(
+                                            ChainingUserRegistrySynchronizer.this.authorityService.getShortName(parent))
+                                            .append('\'');
 
+                                }
+                                ChainingUserRegistrySynchronizer.logger.debug("Ignoring non-existent member '"
+                                        + ChainingUserRegistrySynchronizer.this.authorityService.getShortName(child)
+                                        + "' in groups {" + groupList.toString() + "}");
                             }
-                            ChainingUserRegistrySynchronizer.logger.debug("Ignoring non-existent member '"
-                                    + ChainingUserRegistrySynchronizer.this.authorityService.getShortName(child)
-                                    + "' in groups {" + groupList.toString() + "}");
+                            i.remove();
                         }
-                        i.remove();
+                        else {
+                            recordParentAssociationAuthoritiesToRezone(child);
+                        }
                     }
                 }
+            }
+
+            private boolean shouldRezone(String authorityName)
+            {
+                boolean exists = authorityService.authorityExists(authorityName);
+
+                if (exists)
+                {
+                    Set<String> zones = ChainingUserRegistrySynchronizer.this.authorityService.getAuthorityZones(authorityName);
+                    return isInZone(authorityName, zones, AuthorityService.ZONE_AUTH_ALFRESCO) && !isInZone(authorityName, zones, zoneId);
+                }
+
+                return false;
             }
 
             private void processGroups(UserRegistry userRegistry, boolean isFullSync, boolean splitTxns)
@@ -1634,6 +1666,7 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
                         public void process(Map.Entry<String, Set<String>> entry) throws Throwable
                         {
                             maintainAssociationCreations(entry.getKey());
+                            maintainAssociationCreationsToRezone(entry.getKey());
                         }
                     }, splitTxns);
                 }
@@ -1667,6 +1700,7 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
                         {
                             maintainAssociationDeletions(entry.getKey());
                             maintainAssociationCreations(entry.getKey());
+                            maintainAssociationCreationsToRezone(entry.getKey());
                         }
                     }, splitTxns);
                 }
@@ -1740,6 +1774,25 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
                     {
                         this.personsProcessed.add(authorityName);
                     }
+                }
+            }
+
+            private void maintainAssociationCreationsToRezone(String authorityName)
+            {
+                boolean isPerson = AuthorityType.getAuthorityType(authorityName) == AuthorityType.USER;
+
+                List<String> authorities = isPerson ? this.personToRezone : this.groupToRezone;
+                Map<String, Set<String>> parentAssocsToCreate = isPerson ? this.personParentAssocsToCreate : this.groupParentAssocsToCreate;
+
+                if (authorities != null && !authorities.isEmpty() && parentAssocsToCreate.containsKey(authorityName))
+                {
+                    if (ChainingUserRegistrySynchronizer.logger.isDebugEnabled())
+                    {
+                        ChainingUserRegistrySynchronizer.logger.debug(
+                                "Changing  '" + ChainingUserRegistrySynchronizer.this.authorityService.getShortName(authorityName)
+                                        + "' to zone '" + zoneId + "'");
+                    }
+                    updateAuthorityZones(authorityName, ChainingUserRegistrySynchronizer.this.authorityService.getAuthorityZones(authorityName), zoneSet);
                 }
             }
         } // end of Analyzer class
@@ -1906,6 +1959,7 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
                 // create cycles)
                 groupAnalyzer.maintainAssociationDeletions(personName);
                 groupAnalyzer.maintainAssociationCreations(personName);
+                groupAnalyzer.maintainAssociationCreationsToRezone(personName);
 
                 synchronized (this)
                 {
@@ -2118,10 +2172,32 @@ public class ChainingUserRegistrySynchronizer extends AbstractLifecycleBean
         zonesToAdd.removeAll(oldZones);
         if (!zonesToAdd.isEmpty())
         {
+            // Prevents the authority from being added to zones where already is
+            Set<String> currentZones = this.authorityService.getAuthorityZones(authorityName);
+            if (currentZones != null && !currentZones.isEmpty())
+            {
+                zonesToAdd.removeAll(currentZones);
+            }
             this.authorityService.addAuthorityToZones(authorityName, zonesToAdd);
         }
     }
-    
+
+    /**
+     * Checks if the supplied authority is part of a certain zone
+     *
+     * @param authorityName
+     *            the name of authority to check
+     * @param authorityZones
+     *            the zones where authority is
+     * @param zoneToCheck
+     *            the zone to check
+     * @return true in case the authority is in supplied zone
+     */
+    private boolean isInZone(String authorityName, Set<String> authorityZones, String zoneToCheck)
+    {
+        return authorityName != null && authorityZones != null && zoneToCheck != null && authorityZones.contains(zoneToCheck);
+    }
+
     @Override
     protected void onBootstrap(ApplicationEvent event)
     {


### PR DESCRIPTION
* [MNT-24072] Retain existent users and groups so parent associations can be created

* [MNT-24072] Using person/authority 'exists' methods instead

* [MNT-24072] Added code to rezone users/groups (who already exist and are part of AUTH.ALF zone) that have parent associations to create

* [MNT-24072] PMD scan changes

* [MNT-24072] Added a validation to prevent an authority from being added to zones where already is

(cherry picked from commit 71b69529c660ccc9eeecd22791999ba0b02b00f7)

[MNT-24072]: https://alfresco.atlassian.net/browse/MNT-24072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24072]: https://alfresco.atlassian.net/browse/MNT-24072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24072]: https://alfresco.atlassian.net/browse/MNT-24072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24072]: https://alfresco.atlassian.net/browse/MNT-24072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24072]: https://alfresco.atlassian.net/browse/MNT-24072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ