### PR TITLE
MNT-24270 Disable Faceting when we have unknown nodes in the search results

### DIFF
--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/search/search.lib.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/search/search.lib.js
@@ -674,6 +674,11 @@ function processResults(nodes, maxPageResults, startIndex, rootNode, meta)
       }
    }
 
+   if (failed != 0 && logger.isWarnLoggingEnabled() == true)
+   {
+      logger.warn("Faceting disabled as hits are innacurate due to unknown nodeRefs returned");
+   }
+
    if (logger.isLoggingEnabled())
       logger.log("Filtered resultset to length: " + results.length + ". Discarded item count: " + failed);
 
@@ -684,9 +689,9 @@ function processResults(nodes, maxPageResults, startIndex, rootNode, meta)
          totalRecords: results.length,
          totalRecordsUpper: nodes.length - failed,
          startIndex: startIndex,
-         numberFound: meta ? meta.numberFound : -1
+         numberFound: meta ? meta.numberFound - failed : -1
       },
-      facets: meta ? meta.facets : null,
+      facets: (meta && failed == 0) ? meta.facets : null,
       highlighting: meta ? meta.highlighting : null,
       items: results,
       spellcheck: meta ? meta.spellcheck : null
@@ -741,6 +746,11 @@ function processResultsSinglePage(nodes, startIndex, rootNode, meta)
       }
    }
 
+   if (failed != 0 && logger.isWarnLoggingEnabled() == true)
+   {
+      logger.warn("Faceting disabled as hits are innacurate due to unknown nodeRefs returned");
+   }
+
    if (logger.isLoggingEnabled())
       logger.log("Filtered resultset to length: " + results.length + ". Discarded item count: " + failed);
 
@@ -751,9 +761,9 @@ function processResultsSinglePage(nodes, startIndex, rootNode, meta)
          totalRecords: results.length,
          totalRecordsUpper: -1,
          startIndex: startIndex,
-         numberFound: meta ? meta.numberFound : -1
+         numberFound: meta ? meta.numberFound - failed : -1
       },
-      facets: meta ? meta.facets : null,
+      facets: (meta && failed == 0) ? meta.facets : null,
       highlighting: meta ? meta.highlighting : null,
       items: results,
       spellcheck: meta ? meta.spellcheck : null

--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/search/search.lib.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/search/search.lib.js
@@ -674,7 +674,7 @@ function processResults(nodes, maxPageResults, startIndex, rootNode, meta)
       }
    }
 
-   if (failed != 0 && logger.isWarnLoggingEnabled() == true)
+   if (failed !== 0 && logger.isWarnLoggingEnabled() === true)
    {
       logger.warn("Faceting disabled as hits are innacurate due to unknown nodeRefs returned");
    }
@@ -691,7 +691,7 @@ function processResults(nodes, maxPageResults, startIndex, rootNode, meta)
          startIndex: startIndex,
          numberFound: meta ? meta.numberFound - failed : -1
       },
-      facets: (meta && failed == 0) ? meta.facets : null,
+      facets: (meta && failed === 0) ? meta.facets : null,
       highlighting: meta ? meta.highlighting : null,
       items: results,
       spellcheck: meta ? meta.spellcheck : null
@@ -746,7 +746,7 @@ function processResultsSinglePage(nodes, startIndex, rootNode, meta)
       }
    }
 
-   if (failed != 0 && logger.isWarnLoggingEnabled() == true)
+   if (failed !== 0 && logger.isWarnLoggingEnabled() === true)
    {
       logger.warn("Faceting disabled as hits are innacurate due to unknown nodeRefs returned");
    }
@@ -763,7 +763,7 @@ function processResultsSinglePage(nodes, startIndex, rootNode, meta)
          startIndex: startIndex,
          numberFound: meta ? meta.numberFound - failed : -1
       },
-      facets: (meta && failed == 0) ? meta.facets : null,
+      facets: (meta && failed === 0) ? meta.facets : null,
       highlighting: meta ? meta.highlighting : null,
       items: results,
       spellcheck: meta ? meta.spellcheck : null

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -357,7 +357,7 @@ public class ResultMapper
                                     .filter(facetQuery -> fq.getKey().equals(facetQuery.getLabel())).findFirst();
                             filterQuery = found.isPresent() ? found.get().getQuery() : fq.getKey();
                         }
-                        facetResults.add(new FacetQueryContext(fq.getKey(), filterQuery, disableFaceting ? 0 : fq.getValue()));
+                        facetResults.add(new FacetQueryContext(fq.getKey(), filterQuery, fq.getValue()));
                     }
                 }
             }
@@ -385,16 +385,16 @@ public class ResultMapper
             facets.addAll(stats);
         }
 
-        //Spelling
+        // Spelling
         SpellCheckResult spell = resultSet.getSpellCheckResult();
         if (spell != null && spell.getResultName() != null && !spell.getResults().isEmpty())
         {
-            spellCheckContext = new SpellCheckContext(spell.getResultName(),spell.getResults());
+            spellCheckContext = new SpellCheckContext(spell.getResultName(), spell.getResults());
         }
 
-        //Put it all together
-        context = new SearchContext(resultSet.getLastIndexedTxId(), facets, facetResults, ffcs, spellCheckContext, searchRequestContext.includeRequest()?searchQuery:null);
-        return isNullContext(context)?null:context;
+        // Put it all together
+        context = new SearchContext(resultSet.getLastIndexedTxId(), facets, facetResults, ffcs, spellCheckContext, searchRequestContext.includeRequest() ? searchQuery : null);
+        return isNullContext(context) ? null : context;
     }
 
     public static boolean hasGroup(SearchQuery searchQuery)

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -333,10 +333,10 @@ public class ResultMapper
             throw new IllegalArgumentException("searchQuery can't be null");
         }
 
-        if(!disableFaceting)
+        if (!disableFaceting)
         {
-            //Facet queries
-            if(facetQueries!= null && !facetQueries.isEmpty())
+            // Facet queries
+            if (facetQueries != null && !facetQueries.isEmpty())
             {
                 // If group by field populated in query facet return bucketing into facet field.
                 List<GenericFacetResponse> facetQueryForFields = getFacetBucketsFromFacetQueries(facetQueries, searchQuery);

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -654,7 +654,7 @@ public class ResultMapper
         }
 
         return new GenericBucket(buck.getFirst(), filterQuery, null,
-                new HashSet<Metric>(Arrays.asList(new SimpleMetric(METRIC_TYPE.count, String.valueOf(buck.getSecond())))), null,
+                new HashSet<>(Arrays.asList(new SimpleMetric(METRIC_TYPE.count, String.valueOf(buck.getSecond())))), null,
                 bucketInfo);
     }
 
@@ -676,7 +676,7 @@ public class ResultMapper
 
             if (foundSet.isPresent())
             {
-                return new Pair<String, IntervalSet>(found.get().getField(), foundSet.get());
+                return new Pair<>(found.get().getField(), foundSet.get());
             }
         }
 


### PR DESCRIPTION
Unknown nodes can appear in the search results if the nodes where deleted or permissions changed while the index is not yet up to date or if we disabled permission checks on the search engine. 

In this case the total items will not match the number of entries that are returned and the facet hits will be wrong. Changes made were:
 - In v1, correct the total items and don't return facets, facet queries, facet fields, pivots, etc when we detect unknown nodes in the results
 - In alfresco-share-services, correct the total items based in the failed nodes count and don't send facets
 - Added test