### PR TITLE
[ACS-6935] Update tika version to 2.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency.slf4j.version>2.0.9</dependency.slf4j.version>
         <dependency.log4j.version>2.20.0</dependency.log4j.version>
         <dependency.groovy.version>3.0.19</dependency.groovy.version>
-        <dependency.tika.version>2.9.1</dependency.tika.version>
+        <dependency.tika.version>2.9.2</dependency.tika.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.2.5</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>


### PR DESCRIPTION
Bumping tika version to 2.9.2.

Dependency Tree: 
+- org.apache.tika:tika-parser-mail-module:jar:2.9.2:compile
[INFO] |  |  +- org.apache.tika:tika-parser-mail-commons:jar:2.9.2:compile
[INFO] |  |  |  +- org.apache.james:apache-mime4j-core:jar:0.8.11:compile
[INFO] |  |  |  |  \- (commons-io:commons-io:jar:2.14.0:compile - version managed from 2.11.0; omitted for duplicate)
[INFO] |  |  |  \- org.apache.james:apache-mime4j-dom:jar:0.8.11:compile
[INFO] |  |  |     +- (org.apache.james:apache-mime4j-core:jar:0.8.11:compile - omitted for duplicate)

Full dependency tree: [tree.log](https://github.com/Alfresco/alfresco-community-repo/files/14929671/tree.log)
