### PR TITLE
[ACS-7646] Bump guava version to 33.1.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.5</version>
+                <version>1.4</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <dependency.commons-dbcp.version>2.9.0</dependency.commons-dbcp.version>
         <dependency.commons-io.version>2.11.0</dependency.commons-io.version>
         <dependency.gson.version>2.8.9</dependency.gson.version>
+        <dependency.guava.version>33.1.0-jre</dependency.guava.version>
         <dependency.httpclient.version>4.5.13</dependency.httpclient.version>
         <dependency.httpcore.version>4.4.15</dependency.httpcore.version>
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
@@ -789,6 +790,11 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${dependency.gson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${dependency.guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency.jackson.version>2.15.4</dependency.jackson.version>
         <dependency.cxf.version>3.5.5</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0</dependency.opencmis.version>
-        <dependency.webscripts.version>8.33</dependency.webscripts.version>
+        <dependency.webscripts.version>8.50</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.70</dependency.bouncycastle.version>
         <dependency.mockito-core.version>4.6.1</dependency.mockito-core.version>
         <dependency.assertj.version>3.23.1</dependency.assertj.version>
@@ -398,7 +398,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.4</version>
+                <version>1.5</version>
             </dependency>
 
             <dependency>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -83,6 +83,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Bumping:
- guava version to **33.1.0-jre**
- webscripts version to **8.50**

Full dependency tree: [dependency_tree.log](https://github.com/Alfresco/alfresco-community-repo/files/15130363/dependency_tree.log)
