### PR TITLE
Governance Serivces: LinkedHashSet for stable reader/writer authorities set order + hash code for in-place group names

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java
@@ -30,6 +30,7 @@ package org.alfresco.module.org_alfresco_module_rm.security;
 import static org.alfresco.service.cmr.security.PermissionService.GROUP_PREFIX;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -229,7 +230,7 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
      */
     private Set<String> getAuthorities(String group)
     {
-        Set<String> result = new HashSet<>();
+        Set<String> result = new LinkedHashSet<>();
         result.addAll(authorityService.getContainedAuthorities(null, group, true));
         return result;
     }

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/repo/security/permissions/impl/ExtendedPermissionServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/repo/security/permissions/impl/ExtendedPermissionServiceImpl.java
@@ -308,8 +308,8 @@ public class ExtendedPermissionServiceImpl extends PermissionServiceImpl impleme
         Set<String> aclReaders = readersCache.get((Serializable) acl.getProperties());
         if (aclReaders != null) { return aclReaders; }
 
-        HashSet<String> assigned = new HashSet<>();
-        HashSet<String> readers = new HashSet<>();
+        Set<String> assigned = new LinkedHashSet<>();
+        Set<String> readers = new LinkedHashSet<>();
 
         for (AccessControlEntry ace : acl.getEntries())
         {
@@ -383,8 +383,8 @@ public class ExtendedPermissionServiceImpl extends PermissionServiceImpl impleme
         Set<String> aclWriters = writersCache.get((Serializable) acl.getProperties());
         if (aclWriters != null) { return aclWriters; }
 
-        HashSet<String> assigned = new HashSet<>();
-        HashSet<String> readers = new HashSet<>();
+        Set<String> assigned = new LinkedHashSet<>();
+        Set<String> readers = new LinkedHashSet<>();
 
         for (AccessControlEntry ace : acl.getEntries())
         {
@@ -456,7 +456,7 @@ public class ExtendedPermissionServiceImpl extends PermissionServiceImpl impleme
         Set<String> writers = getWriters(aclId);
 
         // add the current owner to the list of extended writers
-        Set<String> modifiedWrtiers = new HashSet<>(writers);
+        Set<String> modifiedWrtiers = new LinkedHashSet<>(writers);
         String owner = ownableService.getOwner(nodeRef);
         if (StringUtils.isNotBlank(owner) &&
             !owner.equals(OwnableService.NO_OWNER) &&


### PR DESCRIPTION
The (https://github.com/Alfresco/alfresco-community-repo/blob/master/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java#L504)[getAuthoritySetHashCode] operation builds a hash code of authorities from a provided set of readers/writers used by its `getIPRGroupPrefixShortName` operation. In order for the latter operation to avoid generating different group short names for identical authority sets, the order of authorities must be stable and reliable, no matter how many times the same collection of authorities is retrieved.

Using a `HashSet` explicitly does not guarantee a stable and reliable order of the authorities added to it. As a result, the calculated hash code may differ even if the same set of authorites is retrieved via `ExtendedPermissionService#getReadersAndWriters` (used in `RecordServiceImpl#createRecord' or `RecordableVersionServiceImpl#createRecordFromLatestVersion`) or `ExtendedSecurityServiceImpl#getReaders`/`ExtendedSecurityServiceImpl#getWriters` (used in `RecordAspect#onCreateChildAssociation`).

This PR switches the use of the `HashSet` to a `LinkedHashSet` to ensure a stable / reliable order based on the order the authorities as they are retrieved from the underlying ACL or existing in-place group.

This fixes an issue for a customer of mine where a high-level ACL is inherited over a vast tree of nodes, and declaring any of the contained documents as a record often creates new in-place reader/writer groups despite all reader/writer authorities being identical.