### PR TITLE
ACS7587 Fix intermittent failure

### DIFF
--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/hold/AddToHoldsBulkV1Tests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/hold/AddToHoldsBulkV1Tests.java
@@ -326,9 +326,9 @@ public class AddToHoldsBulkV1Tests extends BaseRMRestTest
             UserRole.SiteCollaborator, hold2.getId(), UserRoles.ROLE_RM_MANAGER, PERMISSION_FILING);
         users.add(userAddHoldPermission);
 
-        contentActions.removePermissionForUser(getAdminUser().getUsername(), getAdminUser().getPassword(),
+        contentActions.setPermissionForUser(getAdminUser().getUsername(), getAdminUser().getPassword(),
             testSite.getId(), addedFiles.get(0).getName(), userAddHoldPermission.getUsername(),
-            UserRole.SiteCollaborator.getRoleId(), false);
+            UserRole.SiteConsumer.getRoleId(), false);
 
         STEP("Add content from the site to the hold using the bulk API.");
         HoldBulkOperationEntry bulkOperationEntry = getRestAPIFactory().getHoldsAPI(userAddHoldPermission)
@@ -339,12 +339,12 @@ public class AddToHoldsBulkV1Tests extends BaseRMRestTest
         assertEquals(NUMBER_OF_FILES, bulkOperationEntry.getTotalItems());
 
         STEP("Wait until all files are added to the hold.");
-        await().atMost(20, TimeUnit.SECONDS).until(
+        await().atMost(30, TimeUnit.SECONDS).until(
             () -> getRestAPIFactory().getHoldsAPI(getAdminUser()).getChildren(hold2.getId()).getEntries().size()
                 == NUMBER_OF_FILES - 1);
-        await().atMost(20, TimeUnit.SECONDS).until(
+        await().atMost(30, TimeUnit.SECONDS).until(
             () -> getRestAPIFactory().getHoldsAPI(userAddHoldPermission)
-                .getBulkStatus(hold2.getId(), bulkOperationEntry.getBulkStatusId()).getStatus() == Status.DONE);
+                .getBulkStatus(hold2.getId(), bulkOperationEntry.getBulkStatusId()).getProcessedItems() == NUMBER_OF_FILES);
         List<String> holdChildrenNodeRefs = getRestAPIFactory().getHoldsAPI(userAddHoldPermission)
             .getChildren(hold2.getId()).getEntries().stream().map(HoldChildEntry::getEntry).map(
                 HoldChild::getId).toList();
@@ -361,8 +361,8 @@ public class AddToHoldsBulkV1Tests extends BaseRMRestTest
             .getBulkStatuses(hold2.getId());
         assertEquals(Arrays.asList(holdBulkStatus), holdBulkStatusCollection.getEntries().stream().map(HoldBulkStatusEntry::getEntry).toList());
 
-        //revert the permissions
-        contentActions.removePermissionForUser(getAdminUser().getUsername(), getAdminUser().getPassword(),
+        // Revert the permissions
+        contentActions.setPermissionForUser(getAdminUser().getUsername(), getAdminUser().getPassword(),
             testSite.getId(), addedFiles.get(0).getName(), userAddHoldPermission.getUsername(),
             UserRole.SiteCollaborator.getRoleId(), true);
     }


### PR DESCRIPTION
Fix for the following failure: https://github.com/Alfresco/alfresco-enterprise-repo/actions/runs/9270020015/job/25540583835#step:9:3592

Instead of removing permissions for particular user we should set only read permission (SiteConsumer) for one file to cause one error in the bulk operation. The test failed because removing read permission was respected by the search service before the bulk operation execution.