### PR TITLE
MNT-24321 Transfer Service Exception Handling (#2573)

### DIFF
--- a/repository/src/main/java/org/alfresco/util/json/ExceptionJsonSerializer.java
+++ b/repository/src/main/java/org/alfresco/util/json/ExceptionJsonSerializer.java
@@ -41,7 +41,8 @@ import org.json.JSONObject;
 public class ExceptionJsonSerializer implements JsonSerializer<Throwable, JSONObject>
 {
     private final static Log log = LogFactory.getLog(ExceptionJsonSerializer.class);
-    
+
+    @Deprecated
     @Override
     public Throwable deserialize(JSONObject errorJSON)
     {
@@ -90,37 +91,41 @@ public class ExceptionJsonSerializer implements JsonSerializer<Throwable, JSONOb
             {
                 errorClass = Exception.class;
             }
-            Constructor<?> constructor = null;
-            try
+
+            if (Throwable.class.isAssignableFrom(errorClass))
             {
+                Constructor<?> constructor = null;
                 try
-                {
-                    constructor = errorClass.getConstructor(String.class, Object[].class);
-                    createdObject = constructor.newInstance(errorId, errorParams);
-                }
-                catch (NoSuchMethodException e)
                 {
                     try
                     {
-                        constructor = errorClass.getConstructor(String.class);
-                        createdObject = constructor.newInstance(errorId == null ? errorMessage : errorId);
+                        constructor = errorClass.getConstructor(String.class, Object[].class);
+                        createdObject = constructor.newInstance(errorId, errorParams);
                     }
-                    catch (NoSuchMethodException e1)
+                    catch (NoSuchMethodException e)
                     {
                         try
                         {
-                            constructor = errorClass.getConstructor();
-                            createdObject = constructor.newInstance();
+                            constructor = errorClass.getConstructor(String.class);
+                            createdObject = constructor.newInstance(errorId == null ? errorMessage : errorId);
                         }
-                        catch (NoSuchMethodException e2)
+                        catch (NoSuchMethodException e1)
                         {
+                            try
+                            {
+                                constructor = errorClass.getConstructor();
+                                createdObject = constructor.newInstance();
+                            }
+                            catch (NoSuchMethodException e2)
+                            {
+                            }
                         }
                     }
                 }
-            }
-            catch(Exception ex)
-            {
-                //We don't need to do anything here. Code below will fix things up
+                catch (Exception ex)
+                {
+                    // We don't need to do anything here. Code below will fix things up
+                }
             }
             if (createdObject == null || !Throwable.class.isAssignableFrom(createdObject.getClass()))
             {


### PR DESCRIPTION
* Mark method deserialize in ExceptionJsonSerializer as deprecated
* Remove usage of jsonErrorSerializer

(cherry picked from commit c31158a11303a0da88e3ba22be387f6ef21493ae)