### PR TITLE
Exclude jakarta.transaction-api from commons-dbcp2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -851,6 +851,17 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-dbcp2</artifactId>
                 <version>${dependency.commons-dbcp.version}</version>
+                <exclusions>
+                <!-- Exclude jakarta.transaction-api so that other repositories importing
+                     the alfresco-repository as a dependency, not having community-repo as
+                     a parent, and therefore not sharing the dependencyManagement with it,
+                     won't inherit the outdated jakarta.transaction-api version coming from
+                     this library -->
+                    <exclusion>
+                        <groupId>jakarta.transaction</groupId>
+                        <artifactId>jakarta.transaction-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -82,17 +82,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <exclusions>
-              <!-- Exclude jakarta.transaction-api so that other repositories importing
-                   the alfresco-repository as a dependency, not having community-repo as
-                   a parent, and therefore not sharing the dependencyManagement with it,
-                   won't inherit the outdated jakarta.transaction-api version coming from
-                   this library -->
-              <exclusion>
-                  <groupId>jakarta.transaction</groupId>
-                  <artifactId>jakarta.transaction-api</artifactId>
-              </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -82,6 +82,17 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
+            <exclusions>
+              <!-- Exclude jakarta.transaction-api so that other repositories importing
+                   the alfresco-repository as a dependency, not having community-repo as
+                   a parent, and therefore not sharing the dependencyManagement with it,
+                   won't inherit the outdated jakarta.transaction-api version coming from
+                   this library -->
+              <exclusion>
+                  <groupId>jakarta.transaction</groupId>
+                  <artifactId>jakarta.transaction-api</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
The outdated version of `jakarta.transaction-api` brought in by `commons-dbcp2` causes 3rd party repositories that import `alfresco-repository` to potentially use this outdated version instead of the expected `2.0.1`.

This could be fixed at the Share level and it would avoid more libraries potentially bringing in discording versions of `jakarta.transaction-api`, however fixing it there would also mean that anyone else importing `alfresco-repository` would have to make the same change. So it is safer to do it here.

Tested by building Share with the latest local SNAPSHOT of community-repo with the changes presented in this PR:
![build result](https://github.com/Alfresco/alfresco-community-repo/assets/24280982/337e0eec-fe21-4b3e-82a0-3a30425a4ff3)

**NOTE: all tests in this PR passed, we can safely ignore ReportPortal-specific failures. The build will be soon improved to disregard ReportPortal reachability errors, in a separate PR.**