### PR TITLE
Rollback Jackson from 2.17.2 to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency.spring.version>6.0.19</dependency.spring.version>
         <dependency.spring-security.version>6.3.1</dependency.spring-security.version>
         <dependency.antlr.version>3.5.3</dependency.antlr.version>
-        <dependency.jackson.version>2.17.2</dependency.jackson.version>
+        <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <dependency.cxf.version>4.0.4</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0-jakarta-1</dependency.opencmis.version>
         <dependency.webscripts.version>9.0</dependency.webscripts.version>


### PR DESCRIPTION
The Jackson upgrade would break compatibility with Azure Connector vs older ACS versions, see https://github.com/Alfresco/alfresco-azure-connector/actions/runs/9898746940/job/27346225378?pr=991 and https://hyland.atlassian.net/issues/ACS-8397