### PR TITLE
[MNT-24513] Immutable user (IDS): allow to change enabled status (#2789)

### DIFF
--- a/remote-api/src/main/resources/alfresco/public-rest-context.xml
+++ b/remote-api/src/main/resources/alfresco/public-rest-context.xml
@@ -743,6 +743,7 @@
         <property name="thumbnailService" ref="ThumbnailService" />
         <property name="resetPasswordService" ref="resetPasswordService" />
         <property name="userRegistrySynchronizer" ref="userRegistrySynchronizer" />
+        <property name="allowImmutableEnabledUpdate" value="${allow.immutable.user.enabled.status.update}" />
     </bean>
 
     <bean id="People" class="org.springframework.aop.framework.ProxyFactoryBean">

--- a/repository/src/main/java/org/alfresco/repo/security/authentication/AuthenticationContextImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/AuthenticationContextImpl.java
@@ -36,7 +36,11 @@ import net.sf.acegisecurity.UserDetails;
 import net.sf.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import net.sf.acegisecurity.providers.dao.User;
 
+import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.tenant.TenantService;
+import org.alfresco.service.cmr.security.AuthenticationService;
+import org.alfresco.service.cmr.security.MutableAuthenticationService;
+import org.alfresco.service.cmr.security.PersonService;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -49,10 +53,28 @@ public class AuthenticationContextImpl implements AuthenticationContext
     private final Log logger = LogFactory.getLog(getClass());
     
     private TenantService tenantService;
+    private PersonService personService;
+    private AuthenticationService authenticationService;
+    private Boolean allowImmutableEnabledUpdate;
 
     public void setTenantService(TenantService tenantService)
     {
         this.tenantService = tenantService;
+    }
+
+    public void setPersonService(PersonService personService)
+    {
+        this.personService = personService;
+    }
+
+    public void setAuthenticationService(AuthenticationService authenticationService)
+    {
+        this.authenticationService = authenticationService;
+    }
+
+    public void setAllowImmutableEnabledUpdate(Boolean allowImmutableEnabledUpdate)
+    {
+        this.allowImmutableEnabledUpdate = allowImmutableEnabledUpdate;
     }
 
     /**
@@ -70,7 +92,7 @@ public class AuthenticationContextImpl implements AuthenticationContext
         {
             // Apply the same validation that ACEGI would have to the user details - we may be going through a 'back
             // door'.
-            if (!ud.isEnabled())
+            if (isDisabled(userId, ud))
             {
                 throw new DisabledException("User is disabled");
             }
@@ -112,6 +134,43 @@ public class AuthenticationContextImpl implements AuthenticationContext
             // Support for logging tenantdomain / username (via log4j NDC)
             AuthenticationUtil.logNDC(ud.getUsername());
         }
+    }
+
+    private boolean isDisabled(String userId, UserDetails ud)
+    {
+        boolean isDisabled = !ud.isEnabled();
+        boolean isSystemUser = isSystemUserName(userId);
+
+        if (allowImmutableEnabledUpdate && !isSystemUser)
+        {
+            try
+            {
+                boolean isImmutable = isImmutableAuthority(userId);
+                boolean isPersonEnabled = personService.isEnabled(userId);
+                isDisabled = isDisabled || (isImmutable && !isPersonEnabled);
+            }
+            catch (Exception e)
+            {
+                if (logger.isWarnEnabled())
+                {
+                    logger.warn("Failed to determine if person is enabled: " + userId + ", using user details status: " + isDisabled);
+                }
+            }
+        }
+
+        return isDisabled;
+    }
+
+    private boolean isImmutableAuthority(String authorityName)
+    {
+        return AuthenticationUtil.runAsSystem(new RunAsWork<Boolean>()
+        {
+            @Override public Boolean doWork() throws Exception
+            {
+                MutableAuthenticationService mutableAuthenticationService = (MutableAuthenticationService) authenticationService;
+                return !mutableAuthenticationService.isAuthenticationMutable(authorityName);
+            }
+        });
     }
 
     public Authentication setSystemUserAsCurrentUser()

--- a/repository/src/main/resources/alfresco/authentication-services-context.xml
+++ b/repository/src/main/resources/alfresco/authentication-services-context.xml
@@ -258,6 +258,15 @@
         <property name="tenantService">
             <ref bean="tenantService" />
         </property>
+        <property name="personService">
+            <ref bean="personService" />
+        </property>
+        <property name="authenticationService">
+            <ref bean="AuthenticationService" />
+        </property>
+        <property name="allowImmutableEnabledUpdate">
+            <value>${allow.immutable.user.enabled.status.update}</value>
+        </property>
     </bean>
 
     <!-- Simple Authentication component that rejects all authentication requests -->

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -434,6 +434,9 @@ repo.remote.endpoint=/service
 # persisted.
 create.missing.people=${server.transaction.allow-writes}
 
+# Allow an immutable user to have its enabled status changed
+allow.immutable.user.enabled.status.update=false
+
 # Create home folders (unless disabled, see next property) as people are created (true) or create them lazily (false)
 home.folder.creation.eager=true
 # Disable home folder creation - if true then home folders are not created (neither eagerly nor lazily)


### PR DESCRIPTION
* [MNT-24513] Immutable user: allow enabled status change

* [MNT-24513] Created 'allow.immutable.user.enabled.status.update' to control whether an immutabled user enabled status can be changed or not

* [MNT-24513] Regardless user details enabled status, the person nodeRef enabled status is also checked

* [MNT-24513] Prevent LDAP users from being disabled. Changed variable name.

(cherry picked from commit 8a61badabc1f3f7e36af345e70906ea4d8394cef)

[MNT-24513]: https://hyland.atlassian.net/browse/MNT-24513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24513]: https://hyland.atlassian.net/browse/MNT-24513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24513]: https://hyland.atlassian.net/browse/MNT-24513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNT-24513]: https://hyland.atlassian.net/browse/MNT-24513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ