### PR TITLE
Suggester feature in Share

### DIFF
--- a/repository/src/main/resources/alfresco/core-services-context.xml
+++ b/repository/src/main/resources/alfresco/core-services-context.xml
@@ -1342,6 +1342,8 @@
       </property>
    </bean>
 
+    <bean id="search.suggesterService" class="org.alfresco.repo.search.impl.DummySuggesterServiceImpl">
+    </bean>
    <!-- Custom property editors -->
    <bean class="org.springframework.beans.factory.config.CustomEditorConfigurer">
       <property name="propertyEditorRegistrars">


### PR DESCRIPTION
We faced an exception due to the absence of a bean named 'search.suggesterService'. After adding the 'search.suggesterService' bean, the issue has been resolved, and everything is working as expected.