### PR TITLE
Update of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ Please use [**this guide**](CONTRIBUTING.md) to make a contribution to the proje
 
 ## Helpful links
 
-- [Alfresco Content Services Documentation ](https://docs.alfresco.com/content-services/latest/)
+- [Alfresco Content Services Documentation](https://docs.alfresco.com/content-services/latest/)
 - [Alfresco Content Application Repository](https://github.com/Alfresco/alfresco-content-app)
 - [Alfresco Platform](https://www.hyland.com/en/products/alfresco-platform)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@
 1. [Content](#content)
 2. [Artifacts](#artifacts)
 3. [Setup](#setting-up-and-building-your-development-environment)
-4. [Connection with ACA](#connection-with-alfresco-content-app)
-5. [Branches](#branches)
-6. [Contributing](#contributing-guide)
-7. [Helpful Links](#helpful-links)
+4. [Branches](#branches)
+5. [Contributing](#contributing-guide)
+6. [Helpful Links](#helpful-links)
 
 
 ## Content
@@ -105,10 +104,6 @@ The SNAPSHOT versions of the artifact are not published.
 See the [**Development Tomcat Environment**](https://github.com/Alfresco/acs-community-packaging/tree/master/dev/README.md)
 page which will show you how to try out your repository changes in a local Tomcat instance or using Docker containers. 
 
-## Connection with Alfresco Content App
-After you have set up correctly your environment you may want to connect it with Alfresco Content Application.
-To do this - see this [**link**](https://github.com/Alfresco/alfresco-content-app).
-
 ## Branches
 
 This project has a branch for each ACS release. For example the code in ACS 6.2.2 is a
@@ -130,5 +125,4 @@ Please use [**this guide**](CONTRIBUTING.md) to make a contribution to the proje
 ## Helpful links
 
 - [Alfresco Content Services Documentation](https://docs.alfresco.com/content-services/latest/)
-- [Alfresco Content Application Repository](https://github.com/Alfresco/alfresco-content-app)
 - [Alfresco Platform](https://www.hyland.com/en/products/alfresco-platform)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 3. [Setup](#setting-up-and-building-your-development-environment)
 4. [Branches](#branches)
 5. [Contributing](#contributing-guide)
-6. [Helpful Links](#helpful-links)
+6. [Helpful links](#helpful-links)
 
 
 ## Content

--- a/README.md
+++ b/README.md
@@ -2,38 +2,58 @@
 
 [![Build Status](https://github.com/Alfresco/alfresco-community-repo/actions/workflows/master_release.yml/badge.svg?branch=master)](https://github.com/Alfresco/alfresco-community-repo/actions/workflows/master_release.yml)
 
-#### Alfresco Core
+## Table of Contents
+1. [Content](#content)
+2. [Artifacts](#artifacts)
+3. [Setup](#setting-up-and-building-your-development-environment)
+4. [Connection with ACA](#connection-with-alfresco-content-app)
+5. [Branches](#branches)
+6. [Contributing](#contributing-guide)
+7. [Helpful Links](#helpful-links)
 
-Alfresco Core is a library packaged as a jar file which contains the following:
+
+## Content
+Alfresco Community Repository contains following libraries:
+
+### Alfresco Core
+Core is a library packaged as a jar file which contains the following:
+
 * Various helpers and utils
 * Canned queries interface and supporting classes
 * Generic encryption supporting classes
 
-#### Alfresco Data Model
-Data model is a library packaged as a jar file which  contains the following:
+### Alfresco Data Model
+
+Data Model is a library packaged as a jar file which  contains the following:
+
 * Dictionary, Repository and Search Services interfaces
 * Models for data types and Dictionary implementation
 * Parsers
 
-#### Alfresco Repository
+### Alfresco Repository
 
 Repository is a library packaged as a jar file which contains the following:
+
 * DAOs and SQL scripts
 * Various Service implementations
 * Utility classes
 
-#### Alfresco Remote API
+### Alfresco Remote API
 
 Remote API is a library packaged as a jar file which contains the following:
+
 * REST API framework
 * WebScript implementations including [V1 REST APIs](https://hub.alfresco.com/t5/alfresco-content-services-blog/v1-rest-api-10-things-you-should-know/ba-p/287692)
 * [OpenCMIS](https://chemistry.apache.org/java/opencmis.html) implementations
 
-#### Artifacts
+## Artifacts
+
 The artifacts can be obtained by:
-* downloading from [Alfresco maven repository](https://artifacts.alfresco.com/nexus/content/groups/public)
+* downloading from [Alfresco maven repository](https://artifacts.alfresco.com/nexus/#browse/browse:public)
 * as Maven dependency by adding the dependency to your pom file:
-~~~
+
+~~~xml
+
 <dependency>
   <groupId>org.alfresco</groupId>
   <artifactId>alfresco-core</artifactId>
@@ -64,34 +84,51 @@ The artifacts can be obtained by:
     <version>version</version>
     <type>war</type>
 </dependency>
+
 ~~~
+
 and Alfresco maven repository:
-~~~
+
+~~~xml
+
 <repository>
   <id>alfresco-maven-repo</id>
   <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
 </repository>
+
 ~~~
+
 The SNAPSHOT versions of the artifact are not published.
 
 ## Setting up and building your development environment
-See the [Development Tomcat Environment](https://github.com/Alfresco/acs-community-packaging/tree/master/dev/README.md)
-page which will show you how to try out your repository changes in a local tomcat instance.
-If you wish to use Docker images, take a look at the aliases ending in `D` and the docker-compose files in this
-project's test modules.    
+
+See the [**Development Tomcat Environment**](https://github.com/Alfresco/acs-community-packaging/tree/master/dev/README.md)
+page which will show you how to try out your repository changes in a local Tomcat instance or using Docker containers. 
+
+## Connection with Alfresco Content App
+After you have set up correctly your environment you may want to connect it with Alfresco Content Application.
+To do this - see this [**link**](https://github.com/Alfresco/alfresco-content-app).
 
 ## Branches
-This project has a branch for each ACS release. For example the code in ACS 6.2.1 is a
-branch called `releases/6.2.2`. In addition to the original 6.2.2 release it will also contain Hot Fixes
-added later. The latest unreleased code is on the `master` branch. There are also `.N` branches, such as 
-`releases/7.1.N` on which we gather unreleased fixes for future service pack releases. They do not indicate
+
+This project has a branch for each ACS release. For example the code in ACS 6.2.2 is a
+branch called **`release/6.2.2`**. In addition to the original 6.2.2 release it will also contain Hot Fixes
+added later. The latest unreleased code is on the **`master`** branch. There are also **`.N`** branches, such as 
+**`release/7.1.N`** on which we gather unreleased fixes for future service pack releases. They do not indicate
 that one is planned.
 
 For historic reasons the version of artifacts created on each branch do not match the ACS version.
-For example artifact in ACS 7.2.0 will be `14.<something>`.
+For example artifact in ACS 7.2.0 will be **`14.<something>`**.
 
-The enterprise projects which extend the `alfresco-community-repo` use the same branch names and leading
+The enterprise projects which extend the **`alfresco-community-repo`** use the same branch names and leading
 artifact version number.
 
-### Contributing guide
-Please use [this guide](CONTRIBUTING.md) to make a contribution to the project.
+## Contributing guide
+
+Please use [**this guide**](CONTRIBUTING.md) to make a contribution to the project.
+
+## Helpful links
+
+- [Alfresco Content Services Documentation ](https://docs.alfresco.com/content-services/latest/)
+- [Alfresco Content Application Repository](https://github.com/Alfresco/alfresco-content-app)
+- [Alfresco Platform](https://www.hyland.com/en/products/alfresco-platform)


### PR DESCRIPTION
Changed:
    - Deleted unnecessary sentence at Tomcat part and repeated words in Content part,
    - Fixed misspelling of branch names (releases/<version> -> release/<version>),
    - Fixed link to maven repository (previous link returns a 400 Error),
    - Improved visibility of text in `xyz` apostrophes by bolding.
Added: 
    - Table of contents, 
    - Content point, 
    - Xml formatting, 
    - Connecting with ACA point, 
    - Helpful links point.