### PR TITLE
ACS-8670 Deal with upcoming GitHub Actions deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1265,7 +1265,7 @@ jobs:
           exit 1
       - name: "Configure AWS credentials"
         if: ${{ always() }}
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AGS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AGS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Prepare maven cache and check compilation"
@@ -62,12 +62,12 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v6.1.0
         continue-on-error: true
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
@@ -85,10 +85,10 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v5.6.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v6.1.0
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           repository: "Alfresco/veracode-baseline-archive"
@@ -118,7 +118,7 @@ jobs:
         run: zip readable_output.zip results.json
       - name: Upload Artifact
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Veracode Pipeline-Scan Results (Human Readable)
           path: readable_output.zip
@@ -135,9 +135,9 @@ jobs:
       !contains(github.event.head_commit.message, '[skip tests]') &&
       !contains(github.event.head_commit.message, '[force]')
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - uses: Alfresco/ya-pmd-scan@v4.0.0
         with:
           classpath-build-command: "mvn test-compile -ntp -Pags -pl \"-:alfresco-community-repo-docker\""
@@ -168,14 +168,14 @@ jobs:
             testAttributes: "-Dtest=AllMmtUnitTestSuite"
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.testModule }}
@@ -206,7 +206,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -248,9 +248,9 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -262,7 +262,7 @@ jobs:
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile ${{ matrix.compose-profile }} up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.testSuite }}
@@ -293,7 +293,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -326,9 +326,9 @@ jobs:
         version: ['10.2.18', '10.4', '10.5']
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: Run MariaDB ${{ matrix.version }} database
@@ -337,7 +337,7 @@ jobs:
           MARIADB_VERSION: ${{ matrix.version }}
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.version }}
@@ -368,7 +368,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -397,9 +397,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run MariaDB 10.6 database"
@@ -408,7 +408,7 @@ jobs:
           MARIADB_VERSION: 10.6
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -439,7 +439,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -468,9 +468,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run MySQL 8 database"
@@ -479,7 +479,7 @@ jobs:
           MYSQL_VERSION: 8
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -510,7 +510,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -538,9 +538,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 13.12 database"
@@ -549,7 +549,7 @@ jobs:
           POSTGRES_VERSION: 13.12
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -580,7 +580,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -608,9 +608,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 14.9 database"
@@ -619,7 +619,7 @@ jobs:
           POSTGRES_VERSION: 14.9
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -650,7 +650,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -678,9 +678,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 15.4 database"
@@ -689,7 +689,7 @@ jobs:
           POSTGRES_VERSION: 15.4
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -720,7 +720,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -746,16 +746,16 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run ActiveMQ"
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile activemq up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.13.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -786,7 +786,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.13.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -846,9 +846,9 @@ jobs:
             mvn-options: '-Dencryption.ssl.keystore.location=${CI_WORKSPACE}/keystores/alfresco/alfresco.keystore -Dencryption.ssl.truststore.location=${CI_WORKSPACE}/keystores/alfresco/alfresco.truststore'
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Set transformers tag"
@@ -870,7 +870,7 @@ jobs:
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile ${{ matrix.compose-profile }} up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.testSuite }} ${{ matrix.idp }}
@@ -901,7 +901,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -959,9 +959,9 @@ jobs:
       REQUIRES_LOCAL_IMAGES: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -976,7 +976,7 @@ jobs:
         run: mvn install -pl :alfresco-community-repo-integration-test -am -DskipTests -Pall-tas-tests
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.test-name }}
@@ -1014,7 +1014,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.tests.outcome }}
@@ -1040,16 +1040,16 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run Postgres 15.4 database"
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile postgres up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -1080,7 +1080,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -1114,9 +1114,9 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -1124,7 +1124,7 @@ jobs:
           bash ./scripts/ci/build.sh
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} 0${{ matrix.part }} - (PostgreSQL) ${{ matrix.test-name }}
@@ -1160,9 +1160,9 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -1170,7 +1170,7 @@ jobs:
           bash ./scripts/ci/build.sh
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} 0${{ matrix.part }} - (MySQL) ${{ matrix.test-name }}
@@ -1202,9 +1202,9 @@ jobs:
       REQUIRES_LOCAL_IMAGES: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -1218,7 +1218,7 @@ jobs:
           mvn -B install -pl :alfresco-governance-services-automation-community-rest-api -am -Pags -Pall-tas-tests -DskipTests
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -1250,7 +1250,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v5.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -1292,9 +1292,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Prepare maven cache and check compilation"
@@ -62,12 +62,12 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v7.0.0
         continue-on-error: true
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
@@ -85,10 +85,10 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v7.0.0
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           repository: "Alfresco/veracode-baseline-archive"
@@ -135,9 +135,9 @@ jobs:
       !contains(github.event.head_commit.message, '[skip tests]') &&
       !contains(github.event.head_commit.message, '[force]')
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - uses: Alfresco/ya-pmd-scan@v4.0.0
         with:
           classpath-build-command: "mvn test-compile -ntp -Pags -pl \"-:alfresco-community-repo-docker\""
@@ -168,14 +168,14 @@ jobs:
             testAttributes: "-Dtest=AllMmtUnitTestSuite"
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.testModule }}
@@ -206,7 +206,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -248,9 +248,9 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -262,7 +262,7 @@ jobs:
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile ${{ matrix.compose-profile }} up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.testSuite }}
@@ -293,7 +293,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -326,9 +326,9 @@ jobs:
         version: ['10.2.18', '10.4', '10.5']
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: Run MariaDB ${{ matrix.version }} database
@@ -337,7 +337,7 @@ jobs:
           MARIADB_VERSION: ${{ matrix.version }}
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.version }}
@@ -368,7 +368,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -397,9 +397,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run MariaDB 10.6 database"
@@ -408,7 +408,7 @@ jobs:
           MARIADB_VERSION: 10.6
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -439,7 +439,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -468,9 +468,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run MySQL 8 database"
@@ -479,7 +479,7 @@ jobs:
           MYSQL_VERSION: 8
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -510,7 +510,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -538,9 +538,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 13.12 database"
@@ -549,7 +549,7 @@ jobs:
           POSTGRES_VERSION: 13.12
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -580,7 +580,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -608,9 +608,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 14.9 database"
@@ -619,7 +619,7 @@ jobs:
           POSTGRES_VERSION: 14.9
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -650,7 +650,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -678,9 +678,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run PostgreSQL 15.4 database"
@@ -689,7 +689,7 @@ jobs:
           POSTGRES_VERSION: 15.4
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -720,7 +720,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -746,16 +746,16 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run ActiveMQ"
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile activemq up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -786,7 +786,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -846,9 +846,9 @@ jobs:
             mvn-options: '-Dencryption.ssl.keystore.location=${CI_WORKSPACE}/keystores/alfresco/alfresco.keystore -Dencryption.ssl.truststore.location=${CI_WORKSPACE}/keystores/alfresco/alfresco.truststore'
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Set transformers tag"
@@ -870,7 +870,7 @@ jobs:
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile ${{ matrix.compose-profile }} up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.testSuite }} ${{ matrix.idp }}
@@ -901,7 +901,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -959,9 +959,9 @@ jobs:
       REQUIRES_LOCAL_IMAGES: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -976,7 +976,7 @@ jobs:
         run: mvn install -pl :alfresco-community-repo-integration-test -am -DskipTests -Pall-tas-tests
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} - ${{ matrix.test-name }}
@@ -1014,7 +1014,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.tests.outcome }}
@@ -1040,16 +1040,16 @@ jobs:
       !contains(github.event.head_commit.message, '[force')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Run Postgres 15.4 database"
         run: docker compose -f ./scripts/ci/docker-compose/docker-compose.yaml --profile postgres up -d
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -1080,7 +1080,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -1114,9 +1114,9 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -1124,7 +1124,7 @@ jobs:
           bash ./scripts/ci/build.sh
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} 0${{ matrix.part }} - (PostgreSQL) ${{ matrix.test-name }}
@@ -1160,9 +1160,9 @@ jobs:
       REQUIRES_INSTALLED_ARTIFACTS: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -1170,7 +1170,7 @@ jobs:
           bash ./scripts/ci/build.sh
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }} 0${{ matrix.part }} - (MySQL) ${{ matrix.test-name }}
@@ -1202,9 +1202,9 @@ jobs:
       REQUIRES_LOCAL_IMAGES: true
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |
@@ -1218,7 +1218,7 @@ jobs:
           mvn -B install -pl :alfresco-governance-services-automation-community-rest-api -am -Pags -Pall-tas-tests -DskipTests
       - name: "Prepare Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-prepare@v7.0.0
         id: rp-prepare
         with:
           rp-launch-prefix: ${{ env.RP_LAUNCH_PREFIX }}
@@ -1250,7 +1250,7 @@ jobs:
         continue-on-error: true
       - name: "Summarize Report Portal"
         if: github.ref_name == 'master'
-        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v6.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/reportportal-summarize@v7.0.0
         id: rp-summarize
         with:
           tests-outcome: ${{ steps.run-tests.outcome }}
@@ -1292,9 +1292,9 @@ jobs:
       !contains(github.event.head_commit.message, '[force]')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: |

--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -34,12 +34,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v6.1.0
         with:
           username: ${{ env.GIT_USERNAME }}
           email: ${{ env.GIT_EMAIL }}
@@ -63,12 +63,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v1.35.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v1.35.2      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.35.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v6.1.0
         with:
           username: ${{ env.GIT_USERNAME }}
           email: ${{ env.GIT_EMAIL }}

--- a/.github/workflows/master_release.yml
+++ b/.github/workflows/master_release.yml
@@ -34,12 +34,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v7.0.0
         with:
           username: ${{ env.GIT_USERNAME }}
           email: ${{ env.GIT_EMAIL }}
@@ -63,12 +63,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v6.1.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v6.1.0      
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v7.0.0      
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v7.0.0
         with:
           username: ${{ env.GIT_USERNAME }}
           email: ${{ env.GIT_EMAIL }}


### PR DESCRIPTION
- Migrate from **Node16** to **Node20**.
- Bump `actions/upload-artifact` and `actions/download-artifact` from v3 to v4.
- Additionally: upgrading the version to the latest for other actions from the **alfresco-build-tools**.