### PR TITLE
Fix typo in status.setCode() method in category update script

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/category/category.put.json.js
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/category/category.put.json.js
@@ -28,7 +28,7 @@ function main()
    var name = json.get(PROP_NAME);       
    if (name == null || name.length === 0)
    {
-      tatus.setCode(status.STATUS_BAD_REQUEST, "Could not update category, because 'name' parameter is missing from json request.");
+      status.setCode(status.STATUS_BAD_REQUEST, "Could not update category, because 'name' parameter is missing from json request.");
       return;
    }
    


### PR DESCRIPTION
### Summary
This PR fixes a typo in the category update script where `status.setCode()` was mistakenly written as `tatus.setCode()`.

### Changes
- Corrected the typo from `tatus.setCode` to `status.setCode` in the script responsible for updating category names.

### Impact
This fix ensures that proper error handling is in place when the 'name' parameter is missing from the JSON request. The corrected `status.setCode()` method will now function as intended, returning the appropriate status code and message.

### Testing
- Reviewed the code to ensure there are no other instances of similar typos.
- Basic functionality was manually tested to confirm that the script handles missing 'name' parameters correctly after the fix.

### Related Issues
N/A

### Notes
No additional dependencies or changes outside of this typo correction are introduced in this PR.