### PR TITLE
Use normalised user name in re-hashing password via txn listener

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/security/authentication/AuthenticationComponentImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/AuthenticationComponentImpl.java
@@ -131,7 +131,7 @@ public class AuthenticationComponentImpl extends AbstractAuthenticationComponent
                                             if (hashIndicator.size() > 1 || !passwordEncoder.lastEncodingIsPreferred(hashIndicator))
                                             {
                                                 // add transaction listener to re-hash the users password
-                                                HashPasswordTransactionListener txListener = new HashPasswordTransactionListener(userName, password);
+                                                HashPasswordTransactionListener txListener = new HashPasswordTransactionListener(finalUserName, password);
                                                 txListener.setTransactionService(getTransactionService());
                                                 txListener.setAuthenticationDao(authenticationDao);
                                                 AlfrescoTransactionSupport.bindListener(txListener);


### PR DESCRIPTION
This PR resolves #2503 by using the correctly normalised user name to trigger the password re-hashing via a transaction listener.