### PR TITLE
Restrict site permission cleaner to site groups

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/site/SitesPermissionCleaner.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SitesPermissionCleaner.java
@@ -131,11 +131,11 @@ public class SitesPermissionCleaner
                 String authority = entry.getAuthority();
 
                 String thisSiteGroupPrefix = siteServiceImpl.getSiteGroup(containingSite.getShortName(), true);
+                String anySiteGroupPrefix = thisSiteGroupPrefix.substring(0, thisSiteGroupPrefix.lastIndexOf(containingSite.getShortName()));
 
                 // If it's a group site permission for a site other than the current site
-                if (authority.startsWith(PermissionService.GROUP_PREFIX) &&
-                        // And it's not GROUP_EVERYONE
-                        !authority.startsWith(PermissionService.ALL_AUTHORITIES) && !authority.startsWith(thisSiteGroupPrefix) &&
+                if (authority.startsWith(anySiteGroupPrefix) &&
+                        !authority.startsWith(thisSiteGroupPrefix) &&
                         //  And if the current user has permissions to do it
                         publicServiceAccessService.hasAccess("PermissionService", "clearPermission", targetNode, authority) == AccessStatus.ALLOWED)
                 {


### PR DESCRIPTION
This PR resolves #2444 by restricting the clearing of permissions to only handle site group name patterns, instead of any group name patterns, which before was not doing what the operation claimed it would be doing.