### PR TITLE
[MNT-24282] Obtain site manager authority as system and keep site manager permissions when inheritance flag is disabled

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -2798,12 +2798,9 @@ public class NodesImpl implements Nodes
         {
             try
             {
-                if (nodePerms.getIsInheritanceEnabled() != null && !nodePerms.getIsInheritanceEnabled())
+                if (nodePerms.getIsInheritanceEnabled() != null && !nodePerms.getIsInheritanceEnabled() && siteManagerAuthority != null)
                 {
-                    if (siteManagerAuthority != null)
-                    {
-                        permissionService.setPermission(nodeRef, siteManagerAuthority, SiteModel.SITE_MANAGER, true);
-                    }
+                    permissionService.setPermission(nodeRef, siteManagerAuthority, SiteModel.SITE_MANAGER, true);
                 }
             }
             catch (Exception e)

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -2519,7 +2519,10 @@ public class NodesImpl implements Nodes
                     boolean isSiteManagerAuthority = siteManagerAuthority != null && siteManagerAuthority.equals(accessPerm.getAuthority());
                     if (!isInheritanceEnabled && isSiteManagerAuthority)
                     {
-                        logger.debug("Site manager permissions will be kept since inheritance flag is disabled: " + nodeRef.getId());
+                        if (logger.isDebugEnabled())
+                        {
+                            logger.debug("Site manager permissions will be kept since inheritance flag is disabled: " + nodeRef.getId());
+                        }
                         continue;
                     }
                     permissionService.deletePermission(nodeRef, accessPerm.getAuthority(), accessPerm.getPermission());

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -6369,7 +6369,7 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
      * Tests if site manager permissions are kept after inheritance flag is disabled
      */
     @Test
-    public void testSiteManagerPermission() throws Exception
+    public void testSiteManagerPermission_MNT23379() throws Exception
     {
         // Change to User1 context
         setRequestContext(user1);
@@ -6395,6 +6395,10 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         Node nodeUpdate = new Node();
         NodePermissions nodePerms = new NodePermissions();
         nodePerms.setIsInheritanceEnabled(false);
+        NodePermission permission = new NodePermission("GROUP_site_" + site1Id + "_SiteConsumer", SiteRole.SiteConsumer.toString(), AccessStatus.ALLOWED.toString());
+        List<NodePermission> locallySet = new ArrayList<>();
+        locallySet.add(permission);
+        nodePerms.setLocallySet(locallySet);
         nodeUpdate.setPermissions(nodePerms);
         put(URL_NODES, content1_Id, toJsonAsStringNonNull(nodeUpdate), null, 200);
 

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/NodeApiTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -6521,12 +6522,12 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
         delete(URL_NODES, folderId, 204);
     }
 
-    private void disableSiteNodeInheritanceAsShare(String siteId, String nodeId) throws Exception
+    private void disableSiteNodeInheritanceAsShare(String siteId, String nodeId) throws IOException
     {
         setSiteNodeInheritance(siteId, nodeId, false, true);
     }
 
-    private void setSiteNodeInheritance(String siteId, String nodeId, boolean inheritanceFlag, boolean addSiteManager) throws Exception
+    private void setSiteNodeInheritance(String siteId, String nodeId, boolean inheritanceFlag, boolean addSiteManager) throws IOException
     {
         Node node = new Node();
         NodePermissions perms = new NodePermissions();
@@ -6537,7 +6538,11 @@ public class NodeApiTest extends AbstractSingleNetworkSiteTest
             perms.setLocallySet(locallySet);
         }
         node.setPermissions(perms);
-        put(URL_NODES, nodeId, toJsonAsStringNonNull(node), null, 200);
+        try {
+            put(URL_NODES, nodeId, toJsonAsStringNonNull(node), null, 200);
+        } catch (Exception e) {
+            throw new IOException("Failed to update permissions: " + e.getMessage(), e);
+        }
     }
 }
 


### PR DESCRIPTION
- Obtain site manager authority as system user
- Set site manager permissions as the authenticated user
- Prevent site manager permissions from being removed if inheritance flag is disabled (as it happens in Share)