### PR TITLE
MNT-24441 Transaction Retries From A Behavior Can Fail During REST API Calls

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
@@ -228,7 +228,7 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
 
     protected void resetRequest(WebScriptRequest req)
     {
-        if (req != null && req instanceof BufferedRequest)
+        if (req instanceof BufferedRequest)
         {
             BufferedRequest bufferedRequest = (BufferedRequest) req;
             bufferedRequest.reset();

--- a/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/webscripts/AbstractResourceWebScript.java
@@ -100,6 +100,7 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
             final Map<String, String> templateVars = req.getServiceMatch().getTemplateVars();
             final ResourceWithMetadata resource = locator.locateResource(api,templateVars, httpMethod);
             final boolean isReadOnly = HttpMethod.GET==httpMethod;
+            final Params params = paramsExtractor.extractParams(resource.getMetaData(), req);
 
             // MNT-20308 - allow write transactions for authentication api
             RetryingTransactionHelper transHelper = getTransactionHelper(resource.getMetaData().getApi().getName());
@@ -110,22 +111,7 @@ public abstract class AbstractResourceWebScript extends ApiWebScript implements 
                 @Override
                 public Object execute() throws Throwable
                 {
-                    try
-                    {
-                        final Params params = paramsExtractor.extractParams(resource.getMetaData(), req);
-                        return AbstractResourceWebScript.this.execute(resource, params, res, isReadOnly);
-                    }
-                    catch (Exception e)
-                    {
-                        if (req instanceof BufferedRequest)
-                        {
-                            // Reset the request in case of a transaction retry
-                            ((BufferedRequest) req).reset();
-                        }
-
-                        // re-throw original exception for retry
-                        throw e;
-                    }
+                    return AbstractResourceWebScript.this.execute(resource, params, res, isReadOnly);
                 }
             };
 


### PR DESCRIPTION
* Upon execution error, since there is another retry in transaction inside it can be retried without throwing an error and entering the catch
* Reset the buffered request at the beginning of the transaction so in case of a retry in can be read.