### PR TITLE
[MNT-24590] Bump surf webscripts to 9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency.jackson.version>2.15.2</dependency.jackson.version>
         <dependency.cxf.version>4.0.5</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0-jakarta-1</dependency.opencmis.version>
-        <dependency.webscripts.version>9.0</dependency.webscripts.version>
+        <dependency.webscripts.version>9.3</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.78.1</dependency.bouncycastle.version>
         <dependency.mockito-core.version>5.12.0</dependency.mockito-core.version>
         <dependency.assertj.version>3.26.3</dependency.assertj.version>


### PR DESCRIPTION
* [MNT-24590] Bump spring-webscripts to 9.3

(cherry picked from commit d17c11b8ad7150e7008dba5cf4e4df6ec6836752)

[MNT-24590]: https://hyland.atlassian.net/browse/MNT-24590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ