### PR TITLE
Add precommit for secret scanning, formatting and license header checking.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v7.0.0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: changed-files
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v6.1.0
+        with:
+          write-list-to-env: true
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v6.1.0
       - name: "Init"
         run: bash ./scripts/ci/init.sh
       - name: "Prepare maven cache and check compilation"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+  - repo: local
+    hooks:
+      - id: check-format-and-headers
+        name: Check format and headers and fix if necessary
+        entry: ./scripts/hooks/check-format-and-headers.sh
+        language: script
+        files: ".*.java"
+        pass_filenames: false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1864 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github/workflows/ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "3eaefff58bb411413fcbd76dc410d392529627e7",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "21b46dc06a4681d07e88157fec3a477484fd314b",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    ".github/workflows/master_release.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/master_release.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      }
+    ],
+    "amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/base/TestData.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/base/TestData.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 57,
+        "is_secret": false
+      }
+    ],
+    "amps/ags/rm-automation/rm-automation-community-rest-api/src/test/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-automation/rm-automation-community-rest-api/src/test/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-automation/rm-automation-community-rest-api/src/test/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      }
+    ],
+    "amps/ags/rm-community/rm-community-repo/docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-community/rm-community-repo/docker-compose.yml",
+        "hashed_secret": "953bf453cebf3913edbe172ec292c4ff81d27415",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-community/rm-community-repo/docker-compose.yml",
+        "hashed_secret": "22b56e39272fd3bcd467c8e902c9dae5490b2277",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-community/rm-community-repo/docker-compose.yml",
+        "hashed_secret": "d1ebbc78705ad98aa2c8fb357d2e30c8f001673a",
+        "is_verified": false,
+        "line_number": 74
+      }
+    ],
+    "amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/capability/RMPermissionModel.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/capability/RMPermissionModel.java",
+        "hashed_secret": "b1f53ef1d62bcc8dc4701e495a7472b380c45afc",
+        "is_verified": false,
+        "line_number": 121,
+        "is_secret": false
+      }
+    ],
+    "amps/ags/rm-community/rm-community-repo/src/test/properties/local/alfresco-global.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "amps/ags/rm-community/rm-community-repo/src/test/properties/local/alfresco-global.properties",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "core/src/main/java/org/alfresco/encryption/AlfrescoKeyStore.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/main/java/org/alfresco/encryption/AlfrescoKeyStore.java",
+        "hashed_secret": "a718763bca0f328b0e7ce2a98d9e79fc271bf827",
+        "is_verified": false,
+        "line_number": 35,
+        "is_secret": false
+      }
+    ],
+    "core/src/main/java/org/alfresco/httpclient/HttpClientFactory.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/main/java/org/alfresco/httpclient/HttpClientFactory.java",
+        "hashed_secret": "5d3c708390e5f51413e414393d4ad2a6d0e59a45",
+        "is_verified": false,
+        "line_number": 126,
+        "is_secret": false
+      }
+    ],
+    "core/src/test/resources/keystore-tests/empty-alias-metadata.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/empty-alias-metadata.properties",
+        "hashed_secret": "99a3024c77ef51c031038ab2c696f85e93ca9e62",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "core/src/test/resources/keystore-tests/ks1-metadata.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/ks1-metadata.properties",
+        "hashed_secret": "99a3024c77ef51c031038ab2c696f85e93ca9e62",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/ks1-metadata.properties",
+        "hashed_secret": "41315a3765e4803f355d0582fed38a3a510d9692",
+        "is_verified": false,
+        "line_number": 3,
+        "is_secret": false
+      }
+    ],
+    "core/src/test/resources/keystore-tests/wrong-alias-metadata.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/wrong-alias-metadata.properties",
+        "hashed_secret": "99a3024c77ef51c031038ab2c696f85e93ca9e62",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/wrong-alias-metadata.properties",
+        "hashed_secret": "41315a3765e4803f355d0582fed38a3a510d9692",
+        "is_verified": false,
+        "line_number": 3,
+        "is_secret": false
+      }
+    ],
+    "core/src/test/resources/keystore-tests/wrong-key-password-metadata.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/wrong-key-password-metadata.properties",
+        "hashed_secret": "99a3024c77ef51c031038ab2c696f85e93ca9e62",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/wrong-key-password-metadata.properties",
+        "hashed_secret": "8d4170611a0278170def15c9a7c6b16706cd23ea",
+        "is_verified": false,
+        "line_number": 3,
+        "is_secret": false
+      }
+    ],
+    "core/src/test/resources/keystore-tests/wrong-keystore-password-metadata.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/wrong-keystore-password-metadata.properties",
+        "hashed_secret": "6809ffccad03b80fa1fbc32c17e7e054805ec30b",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "core/src/test/resources/keystore-tests/wrong-keystore-password-metadata.properties",
+        "hashed_secret": "41315a3765e4803f355d0582fed38a3a510d9692",
+        "is_verified": false,
+        "line_number": 3,
+        "is_secret": false
+      }
+    ],
+    "packaging/distribution/src/main/resources/keystore/metadata-keystore/keystore-passwords.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/distribution/src/main/resources/keystore/metadata-keystore/keystore-passwords.properties",
+        "hashed_secret": "f039ca7aa02b913940a6a97f01251f257178068f",
+        "is_verified": false,
+        "line_number": 6,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/distribution/src/main/resources/keystore/metadata-keystore/keystore-passwords.properties",
+        "hashed_secret": "22ccad749b70baa70011eaab411efa0c4128ee86",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/environment/docker-compose-minimal+transforms.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/environment/docker-compose-minimal+transforms.yml",
+        "hashed_secret": "9e3d103f7aa5f4f778cf752087dfceeba15d4fef",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/environment/docker-compose-minimal+transforms.yml",
+        "hashed_secret": "92cda941553ea9ba9b39716c79a46b08a740613c",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/environment/docker-compose-minimal+transforms.yml",
+        "hashed_secret": "d1ebbc78705ad98aa2c8fb357d2e30c8f001673a",
+        "is_verified": false,
+        "line_number": 76
+      }
+    ],
+    "packaging/tests/environment/docker-compose-minimal.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/environment/docker-compose-minimal.yml",
+        "hashed_secret": "9e3d103f7aa5f4f778cf752087dfceeba15d4fef",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/environment/docker-compose-minimal.yml",
+        "hashed_secret": "92cda941553ea9ba9b39716c79a46b08a740613c",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/environment/docker-compose-minimal.yml",
+        "hashed_secret": "d1ebbc78705ad98aa2c8fb357d2e30c8f001673a",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "packaging/tests/tas-cmis/src/main/java/org/alfresco/cmis/AuthParameterProviderFactory.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "packaging/tests/tas-cmis/src/main/java/org/alfresco/cmis/AuthParameterProviderFactory.java",
+        "hashed_secret": "a28cecdb5056cf30135809b921e38a84deb6c345",
+        "is_verified": false,
+        "line_number": 102,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "packaging/tests/tas-cmis/src/main/java/org/alfresco/cmis/AuthParameterProviderFactory.java",
+        "hashed_secret": "5e39d8e2991ef9705998de26b33f11be0f3cdcde",
+        "is_verified": false,
+        "line_number": 103,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-cmis/src/main/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-cmis/src/main/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-cmis/src/main/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 76,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-cmis/src/test/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-cmis/src/test/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-cmis/src/test/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 84,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-email/src/test/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-email/src/test/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-email/src/test/resources/default.properties",
+        "hashed_secret": "43b7ed74f99cf021109506832a48aa75435b817d",
+        "is_verified": false,
+        "line_number": 35,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-email/src/test/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 97,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-integration/src/test/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-integration/src/test/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-integration/src/test/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 118,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/core/RestAisAuthentication.java": [
+      {
+        "type": "JSON Web Token",
+        "filename": "packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/core/RestAisAuthentication.java",
+        "hashed_secret": "a28cecdb5056cf30135809b921e38a84deb6c345",
+        "is_verified": false,
+        "line_number": 79,
+        "is_secret": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/core/RestAisAuthentication.java",
+        "hashed_secret": "5e39d8e2991ef9705998de26b33f11be0f3cdcde",
+        "is_verified": false,
+        "line_number": 80,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestSitePersonMembershipRequestModelsCollection.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestSitePersonMembershipRequestModelsCollection.java",
+        "hashed_secret": "8b30a14989d7b8093ac29462fe29423d836625b4",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-restapi/src/main/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-restapi/src/main/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-restapi/src/main/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-restapi/src/test/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-restapi/src/test/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-restapi/src/test/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      }
+    ],
+    "packaging/tests/tas-webdav/src/test/resources/default.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-webdav/src/test/resources/default.properties",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/tests/tas-webdav/src/test/resources/default.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 73,
+        "is_secret": false
+      }
+    ],
+    "packaging/war/src/main/webapp/META-INF/context.xml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "packaging/war/src/main/webapp/META-INF/context.xml",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "packaging/war/src/main/webapp/scripts/yui-3.3.0-dependencies.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "packaging/war/src/main/webapp/scripts/yui-3.3.0-dependencies.js",
+        "hashed_secret": "c53c35a5b0f18b4e9061b386eeacc58e3dfcd24b",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/main/java/org/alfresco/repo/web/scripts/tenant/AbstractTenantAdminWebScript.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/main/java/org/alfresco/repo/web/scripts/tenant/AbstractTenantAdminWebScript.java",
+        "hashed_secret": "889d2688743fdce6115117a5ba7dbc5f33e0ce03",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java",
+        "hashed_secret": "43d52295ed5cb7e2b772f2b8be9695ddde971c49",
+        "is_verified": false,
+        "line_number": 62,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java",
+        "hashed_secret": "1bd5147ff91b8b1220d2f1ffde850ebabbc5ec8c",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/main/resources/alfresco/subsystems/Authentication/kerberos/kerberos-filter.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/main/resources/alfresco/subsystems/Authentication/kerberos/kerberos-filter.properties",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/person/people.post.json.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/person/people.post.json.js",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/repo/remoteticket/RemoteAlfrescoTicketServiceTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/repo/remoteticket/RemoteAlfrescoTicketServiceTest.java",
+        "hashed_secret": "a926a50b320cea0d6c008a04322627400fe33f55",
+        "is_verified": false,
+        "line_number": 74,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/repo/web/scripts/node/NodeWebScripTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/repo/web/scripts/node/NodeWebScripTest.java",
+        "hashed_secret": "a926a50b320cea0d6c008a04322627400fe33f55",
+        "is_verified": false,
+        "line_number": 95,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/repo/web/scripts/servlet/RemoteAuthenticatorFactoryAdminConsoleAccessTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/repo/web/scripts/servlet/RemoteAuthenticatorFactoryAdminConsoleAccessTest.java",
+        "hashed_secret": "4ffa743f28fc949c19e65ab045d7906d0609a2c2",
+        "is_verified": false,
+        "line_number": 264,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/repo/web/scripts/solr/SOLRAuthenticationFilterTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/repo/web/scripts/solr/SOLRAuthenticationFilterTest.java",
+        "hashed_secret": "76ed0a056aa77060de25754586440cff390791d0",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/repo/webdav/LockMethodTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/repo/webdav/LockMethodTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 109,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/repo/webdav/UnlockMethodTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/repo/webdav/UnlockMethodTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 106,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/AbstractBaseApiTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/AbstractBaseApiTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 120,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/RepoService.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/RepoService.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 418,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/TestCMIS.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestCMIS.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 182,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/TestPeople.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestPeople.java",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 592,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestPeople.java",
+        "hashed_secret": "53dad674827218e94c8fe9c1984c8dd9db512a17",
+        "is_verified": false,
+        "line_number": 728,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestPeople.java",
+        "hashed_secret": "be66cf01c56d963de61462f37a43df2305367216",
+        "is_verified": false,
+        "line_number": 1429,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestPeople.java",
+        "hashed_secret": "283d47a9338ed1100b5fe2a5aff2d1f7c799bfd0",
+        "is_verified": false,
+        "line_number": 1430,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestPeople.java",
+        "hashed_secret": "425a715491af2bbec1eef2def6fa8d79c3050401",
+        "is_verified": false,
+        "line_number": 1452,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/TestRemovePermissions.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/TestRemovePermissions.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 57,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/client/AuthenticatedHttp.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/client/AuthenticatedHttp.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 54,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/rest/api/tests/client/UserData.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/rest/api/tests/client/UserData.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 42,
+        "is_secret": false
+      }
+    ],
+    "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java",
+        "hashed_secret": "43d52295ed5cb7e2b772f2b8be9695ddde971c49",
+        "is_verified": false,
+        "line_number": 50,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java",
+        "hashed_secret": "1bd5147ff91b8b1220d2f1ffde850ebabbc5ec8c",
+        "is_verified": false,
+        "line_number": 51,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java",
+        "hashed_secret": "5d3c708390e5f51413e414393d4ad2a6d0e59a45",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 53,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java",
+        "hashed_secret": "3324f82c5b370b84973c54f8ab9a582328146694",
+        "is_verified": false,
+        "line_number": 56,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "remote-api/src/test/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilterTest.java",
+        "hashed_secret": "02bc8dee91680edf3de772b31247d23a45b3bf5a",
+        "is_verified": false,
+        "line_number": 57,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/heartbeat/jobs/LockingJob.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/heartbeat/jobs/LockingJob.java",
+        "hashed_secret": "b003370e1497c5003e21f1ec5da89e3d2d819506",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/heartbeat/jobs/LockingJob.java",
+        "hashed_secret": "fc99e6a90240c45f46ed33a4d96a3dbecef41c60",
+        "is_verified": false,
+        "line_number": 61,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/heartbeat/jobs/NonLockingJob.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/heartbeat/jobs/NonLockingJob.java",
+        "hashed_secret": "b003370e1497c5003e21f1ec5da89e3d2d819506",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/admin/patch/impl/AdminUserPatch.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/main/java/org/alfresco/repo/admin/patch/impl/AdminUserPatch.java",
+        "hashed_secret": "87a754b00f7ee047d496808125d6259104e9382a",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/invitation/WorkflowModelNominatedInvitation.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/repo/invitation/WorkflowModelNominatedInvitation.java",
+        "hashed_secret": "59ca42c026e181a60e4bf26c980a65b4ef457e16",
+        "is_verified": false,
+        "line_number": 90,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorServiceImpl.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorServiceImpl.java",
+        "hashed_secret": "a172ffc990129fe6f68b50f6037c54a1894ee3fd",
+        "is_verified": false,
+        "line_number": 204,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/repo/remoteconnector/RemoteConnectorServiceImpl.java",
+        "hashed_secret": "a172ffc990129fe6f68b50f6037c54a1894ee3fd",
+        "is_verified": false,
+        "line_number": 204,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/security/authentication/ResetPasswordServiceImpl.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/repo/security/authentication/ResetPasswordServiceImpl.java",
+        "hashed_secret": "e25df0eeed8d8eb4e198c3464c7bf747bc26eff8",
+        "is_verified": false,
+        "line_number": 92,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/security/authentication/SimpleAcceptOrRejectAllAuthenticationComponentImpl.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/main/java/org/alfresco/repo/security/authentication/SimpleAcceptOrRejectAllAuthenticationComponentImpl.java",
+        "hashed_secret": "304de25a3d73b68ad408ca3843356b5cf67f6f14",
+        "is_verified": false,
+        "line_number": 93,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/transfer/TransferServiceImpl2.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/repo/transfer/TransferServiceImpl2.java",
+        "hashed_secret": "9ae9f2be7702b726809545808a8a9ba2e5a38410",
+        "is_verified": false,
+        "line_number": 130,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/java/org/alfresco/repo/workflow/WorkflowModelResetPassword.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/repo/workflow/WorkflowModelResetPassword.java",
+        "hashed_secret": "65e636b62dec4469612f16d52ff6df67f9da39e5",
+        "is_verified": false,
+        "line_number": 47,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/java/org/alfresco/repo/workflow/WorkflowModelResetPassword.java",
+        "hashed_secret": "4562cd9b8a9ece1f797784a2256a0812778680e1",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/content-service.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/content-service.properties",
+        "hashed_secret": "4737a3ab81d198fe7e81e91ce484ace21e13fdf4",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages.properties",
+        "hashed_secret": "5c4bc97ee5d0ac344829dbcef02d7302feb098a8",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_cs.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_cs.properties",
+        "hashed_secret": "3840ac3163c4ae3c44592e153e8aa9c005eb4976",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_da.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_da.properties",
+        "hashed_secret": "7795d909f846130a4b0ca2ceb11a45595a926dd7",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_de.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_de.properties",
+        "hashed_secret": "6ac2476e6b3264476c266b8b62e58463876eec93",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_es.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_es.properties",
+        "hashed_secret": "95c4a994da53f9d8c72f0090abd7dd4ee27e6a97",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_fi.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_fi.properties",
+        "hashed_secret": "92651e851d1a520088933d6b71c6706fc9b7fffe",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_fr.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_fr.properties",
+        "hashed_secret": "bb642b8d5071dbbf3779269cba14e721dc262bf7",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_it.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_it.properties",
+        "hashed_secret": "add35a788b003ae03ac5d8295f85ba295bc72ffd",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_nb.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_nb.properties",
+        "hashed_secret": "eb7fbdaf36ad281fde77f529f34af1d978f1bffe",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_nl.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_nl.properties",
+        "hashed_secret": "b64c2b68f7d1657c41a91ebf1fcf3fc31b05f6bd",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_pl.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_pl.properties",
+        "hashed_secret": "9d2c0d9b6442c31608b506bc56d6bd3fb7e6b7f6",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/reset-password-messages_pt_BR.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/reset-password-messages_pt_BR.properties",
+        "hashed_secret": "c46c3f680d905635a6921b359958008cb01a88ca",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service.properties",
+        "hashed_secret": "a945c7b85d492603ff45bc8b5ffebb3f93e801f8",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_cs.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_cs.properties",
+        "hashed_secret": "9f7107d692855f31ac45258147f51061f58912fd",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_da.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_da.properties",
+        "hashed_secret": "1908bd06e765ab2a7eccb65eb75e969b6b1cd7d0",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_de.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_de.properties",
+        "hashed_secret": "6532379d6c1e79379b9cf6525931289f989277b0",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_es.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_es.properties",
+        "hashed_secret": "af1daa244f81315fd558c04acef3abcc7d2a2f33",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_fi.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_fi.properties",
+        "hashed_secret": "a09629af4a7dc396527e2564da7ab83432c2442c",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_fr.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_fr.properties",
+        "hashed_secret": "5a540b7894111df6f7e4415f7f268cb3f1021d6f",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_it.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_it.properties",
+        "hashed_secret": "a337872fcdd32797bce4edfff734dc46cfc43ff9",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_nb.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_nb.properties",
+        "hashed_secret": "12a34c67bcf44c9ab1468b2f8ee7829a2df4568a",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_nl.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_nl.properties",
+        "hashed_secret": "e3bbf7fadd78a31531a446935bc03b73211c9fd0",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_pl.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_pl.properties",
+        "hashed_secret": "9618b3812f9d4b1adbdcd428b79bf2e8049f4cfd",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_pt_BR.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_pt_BR.properties",
+        "hashed_secret": "6eda6f1f1c71323a31fa2320efa8007d3265b0d4",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/messages/transfer-service_sv.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/messages/transfer-service_sv.properties",
+        "hashed_secret": "edcb85415622decdad5e58098a287f24478eb0db",
+        "is_verified": false,
+        "line_number": 48,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/repository.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/repository.properties",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 245,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/repository.properties",
+        "hashed_secret": "1459a56410378e4d3ab470eff570e5eae1742762",
+        "is_verified": false,
+        "line_number": 312,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/repository.properties",
+        "hashed_secret": "84551ae5442affc9f1a2d3b4c86ae8b24860149d",
+        "is_verified": false,
+        "line_number": 767,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/alfresco/subsystems/Authentication/ldap/ldap-authentication.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/alfresco/subsystems/Authentication/ldap/ldap-authentication.properties",
+        "hashed_secret": "ca9d2dd42543cea510c0b9c2bce22272f4fb264a",
+        "is_verified": false,
+        "line_number": 187,
+        "is_secret": false
+      }
+    ],
+    "repository/src/main/resources/org/alfresco/encryption/keystore-parameters.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/main/resources/org/alfresco/encryption/keystore-parameters.properties",
+        "hashed_secret": "f039ca7aa02b913940a6a97f01251f257178068f",
+        "is_verified": false,
+        "line_number": 1,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/filesys/FTPServerTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/filesys/FTPServerTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 82,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/filesys/FTPServerTest.java",
+        "hashed_secret": "c464af817287343305cbd6493c593885695df531",
+        "is_verified": false,
+        "line_number": 86,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/filesys/FTPServerTest.java",
+        "hashed_secret": "8ad8572a0b3fc4cb3afc1baaebc97a2cae58eb8c",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/filesys/FTPServerTest.java",
+        "hashed_secret": "915692b4d7465b0084354173d552ac90145dc315",
+        "is_verified": false,
+        "line_number": 88,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/filesys/repo/ContentDiskDriverTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "repository/src/test/java/org/alfresco/filesys/repo/ContentDiskDriverTest.java",
+        "hashed_secret": "8c85434f6f339a24b808810bd95629d0f5856355",
+        "is_verified": false,
+        "line_number": 1281,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/opencmis/CMISTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/opencmis/CMISTest.java",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 4134,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/coci/CheckOutCheckInServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/coci/CheckOutCheckInServiceImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 140,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/i18n/MessageServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/i18n/MessageServiceImplTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 102,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/imap/ImapMessageTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/imap/ImapMessageTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 118,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/imap/ImapServiceImplCacheTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/imap/ImapServiceImplCacheTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 68,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/imap/ImapServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/imap/ImapServiceImplTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 116,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/imap/LoadTester.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/imap/LoadTester.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 80,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/imap/RemoteLoadTester.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/imap/RemoteLoadTester.java",
+        "hashed_secret": "678721c0433c8cf5c9069a0e70784cf1839e866b",
+        "is_verified": false,
+        "line_number": 58,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/invitation/site/InviteSenderTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/invitation/site/InviteSenderTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 109,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/lock/LockBehaviourImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/lock/LockBehaviourImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 112,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/lock/LockServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/lock/LockServiceImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 109,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java",
+        "hashed_secret": "9f1bf21429a1074c37c6017bb76c3e3132bab061",
+        "is_verified": false,
+        "line_number": 65,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java",
+        "hashed_secret": "209b9067f058a1c526cd5db7057f52ed1bbd6583",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/management/JmxDumpUtilTest.java",
+        "hashed_secret": "1af7165c744122c81be672d0deb9f04c02117c42",
+        "is_verified": false,
+        "line_number": 75,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/model/filefolder/FileFolderServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/model/filefolder/FileFolderServiceImplTest.java",
+        "hashed_secret": "9e10e28cb9c3e381c13d13fa97dd97148982cdaa",
+        "is_verified": false,
+        "line_number": 595,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/notification/NotificationServiceImplSystemTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/notification/NotificationServiceImplSystemTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 74,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/oauth1/OAuth1CredentialsStoreServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/test/java/org/alfresco/repo/oauth1/OAuth1CredentialsStoreServiceTest.java",
+        "hashed_secret": "c60646de4c4893cf860a12ecb7ba4f5317b1a1d0",
+        "is_verified": false,
+        "line_number": 61,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/oauth1/OAuth1CredentialsStoreServiceTest.java",
+        "hashed_secret": "c60646de4c4893cf860a12ecb7ba4f5317b1a1d0",
+        "is_verified": false,
+        "line_number": 61,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/oauth1/OAuth1CredentialsStoreServiceTest.java",
+        "hashed_secret": "ad8a621976e9a19cc78af501a84638a04fca9b83",
+        "is_verified": false,
+        "line_number": 65,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/oauth2/OAuth2CredentialsStoreServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/test/java/org/alfresco/repo/oauth2/OAuth2CredentialsStoreServiceTest.java",
+        "hashed_secret": "c60646de4c4893cf860a12ecb7ba4f5317b1a1d0",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/rendition2/AbstractRenditionIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/rendition2/AbstractRenditionIntegrationTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 127,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/replication/ReplicationServiceIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/replication/ReplicationServiceIntegrationTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 1328,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/AuthenticationServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/AuthenticationServiceImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 68,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/AuthenticationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/AuthenticationTest.java",
+        "hashed_secret": "607e729c2f77c4e821e68e26b4c1f5a4398624e9",
+        "is_verified": false,
+        "line_number": 2129,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/AuthorizationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/AuthorizationTest.java",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 37,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/CompositePasswordEncoderTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/CompositePasswordEncoderTest.java",
+        "hashed_secret": "4360136f24381dcec1d35d79fbf7dac4b54dfe97",
+        "is_verified": false,
+        "line_number": 301,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceFacadeFactoryBeanTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/identityservice/IdentityServiceFacadeFactoryBeanTest.java",
+        "hashed_secret": "c4b66dbe168ad1d2b19119494a0da063801bc3bb",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/identityservice/LazyInstantiatingIdentityServiceFacadeUnitTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/identityservice/LazyInstantiatingIdentityServiceFacadeUnitTest.java",
+        "hashed_secret": "12e59296b0d17c1ceb345a7adca98574c835ba24",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/security/authentication/identityservice/SpringBasedIdentityServiceFacadeUnitTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/security/authentication/identityservice/SpringBasedIdentityServiceFacadeUnitTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/tenant/MultiTNodeServiceInterceptorTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/tenant/MultiTNodeServiceInterceptorTest.java",
+        "hashed_secret": "a63d4b132a9a1d3430f9ae507825f572449e0d17",
+        "is_verified": false,
+        "line_number": 51,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/transfer/HttpClientTransmitterImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/HttpClientTransmitterImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 75,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceCallbackTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceCallbackTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 664,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 203,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceImplTest.java",
+        "hashed_secret": "ad782ecdac770fc6eb9a62e44f90873fb97fb26b",
+        "is_verified": false,
+        "line_number": 513,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceImplTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 3687,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceToBeRefactoredTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceToBeRefactoredTest.java",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 2682,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/TransferServiceToBeRefactoredTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 3772,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/transfer/manifest/ManifestIntegrationTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/manifest/ManifestIntegrationTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 115,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/transfer/manifest/TransferManifestTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/transfer/manifest/TransferManifestTest.java",
+        "hashed_secret": "5395ebfd174b0a5617e6f409dfbb3e064e3fdf0a",
+        "is_verified": false,
+        "line_number": 127,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/version/BaseVersionStoreTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/version/BaseVersionStoreTest.java",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 149,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/version/NodeServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/version/NodeServiceImplTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 86,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/repo/version/VersionServiceImplTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/repo/version/VersionServiceImplTest.java",
+        "hashed_secret": "dee17075a8c96d9c57c15d56b1f64e5abc1caf0b",
+        "is_verified": false,
+        "line_number": 122,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/util/test/junitrules/AlfrescoTenant.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/util/test/junitrules/AlfrescoTenant.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 67,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/java/org/alfresco/util/test/testusers/TestUserComponentImpl.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/java/org/alfresco/util/test/testusers/TestUserComponentImpl.java",
+        "hashed_secret": "f73e110427648014568f7144031a6d48060eab0a",
+        "is_verified": false,
+        "line_number": 55,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/alfresco-global.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/resources/alfresco-global.properties",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/alfresco/keystore-tests/encryption-test-context.xml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/resources/alfresco/keystore-tests/encryption-test-context.xml",
+        "hashed_secret": "99a3024c77ef51c031038ab2c696f85e93ca9e62",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/resources/alfresco/keystore-tests/encryption-test-context.xml",
+        "hashed_secret": "316d20a7e5744b8542e2a4b14b0a38084150c8ae",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/alfresco/keystore/keystore-passwords.properties": [
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/resources/alfresco/keystore/keystore-passwords.properties",
+        "hashed_secret": "f039ca7aa02b913940a6a97f01251f257178068f",
+        "is_verified": false,
+        "line_number": 6,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "repository/src/test/resources/alfresco/keystore/keystore-passwords.properties",
+        "hashed_secret": "22ccad749b70baa70011eaab411efa0c4128ee86",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/bulkimport/folder1/folder1.1/quick.vdx": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/test/resources/bulkimport/folder1/folder1.1/quick.vdx",
+        "hashed_secret": "37c332070388a4797ccf1fa64f7029a193ce0371",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/imap/test-tnef-message.eml": [
+      {
+        "type": "AWS Access Key",
+        "filename": "repository/src/test/resources/imap/test-tnef-message.eml",
+        "hashed_secret": "b3a5ad926ea30683aa0628700e681923b79a0537",
+        "is_verified": false,
+        "line_number": 159,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/quick/quick.vdx": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "repository/src/test/resources/quick/quick.vdx",
+        "hashed_secret": "37c332070388a4797ccf1fa64f7029a193ce0371",
+        "is_verified": false,
+        "line_number": 2,
+        "is_secret": false
+      }
+    ],
+    "repository/src/test/resources/realms/alfresco-realm.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "repository/src/test/resources/realms/alfresco-realm.json",
+        "hashed_secret": "3fd30b50f0bc29e976e17546c5d52d39fac358ee",
+        "is_verified": false,
+        "line_number": 1792,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "repository/src/test/resources/realms/alfresco-realm.json",
+        "hashed_secret": "8f45a0ff50a62e6f42d8b968dd5a59c4e8b973aa",
+        "is_verified": false,
+        "line_number": 1843,
+        "is_secret": false
+      }
+    ],
+    "scripts/ci/docker-compose/docker-compose.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/ci/docker-compose/docker-compose.yaml",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/ci/docker-compose/docker-compose.yaml",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 43,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2024-10-07T13:24:33Z"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,53 @@ Thanks for your interest in contributing to this project!
 
 The following is a set of guidelines for contributing to this library. Most of them will make the life of the reviewer easier and therefore decrease the time required for the patch be included in the next version.
 
-Because this project forms a part of Alfresco Content Services, the guidelines are hosted in the [Alfresco Social Community](http://community.alfresco.com/community/ecm) where they can be referenced from multiple projects.
+The project uses [pre-commit](https://pre-commit.com/) to format code (with [Spotless](https://github.com/diffplug/spotless)), validate license headers and check for secrets (with [detect-secrets](https://github.com/Yelp/detect-secrets)). To install the pre-commit hooks then first install pre-commit and then run:
+```shell
+pre-commit install
+```
+When you make a commit then these hooks will run and check the modified files. If it makes changes then you can review them and then `git commit` again to accept the changes.
 
-Read an [overview on how this project is goverened](https://community.alfresco.com/docs/DOC-6385-project-overview-repository).
+#### Code Quality
+This project uses `spotless` that enforces `alfresco-formatter.xml` to ensure code quality.
+
+To check code-style violations you can use:
+```bash
+mvn spotless:check
+```
+To reformat files you can use:
+```bash
+mvn spotless:apply
+```
+
+#### Secret Detection
+
+We are using [detect-secrets](https://github.com/Yelp/detect-secrets) to try to avoid accidentally publishing secret keys.
+If you have pre-commit installed then this should run automatically when making a commit. Usually there should be no issues,
+but if it finds a potential issue (e.g. a high entropy string) then you will see the following:
+
+```shell
+Detect secrets...........................................................Failed
+- hook id: detect-secrets
+- exit code: 1
+
+ERROR: Potential secrets about to be committed to git repo!
+
+Secret Type: Secret Keyword
+Location:    test.txt:1
+```
+
+If this is a false positive and you actually want to commit the string then run these two commands:
+
+```shell
+detect-secrets scan --baseline .secrets.baseline
+detect-secrets audit .secrets.baseline
+```
+
+This will update the baseline file to include your new code and then allow you to review the detected secret and mark it as a false positive.
+Once you are finished then you can add `.secrets.baseline` to the staged changes and you should be able to create a commit.
+
+
+Because this project forms a part of Alfresco Content Services, the guidelines are hosted in the [Alfresco Social Community](https://hub.alfresco.com/t5/alfresco-content-services-ecm/ct-p/ECM-software) where they can be referenced from multiple projects.
 
 You can report an issue in the ALF project of the [Alfresco issue tracker](http://issues.alfresco.com).
 

--- a/alfresco-formatter.xml
+++ b/alfresco-formatter.xml
@@ -1,0 +1,401 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="23">
+    <profile kind="CodeFormatterProfile" name="Spotless" version="23">
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_switch_case_arrow_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_permitted_types" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_annotations" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_permitted_types_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_record_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.javadoc_do_not_separate_block_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_record_components" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_arrow" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="999"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_constructor" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_selector_in_method_invocation_on_expression_first_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_switch_case_with_arrow_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_switch_case_with_colon" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_record_components" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_switch_case_with_arrow" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_permitted_types" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="next_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="999"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    </profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,9 @@
 
         <alfresco.maven-plugin.version>2.2.0</alfresco.maven-plugin.version>
         <license-maven-plugin.version>2.0.1.alfresco-2</license-maven-plugin.version>
+        <spotless-plugin.version>2.43.0</spotless-plugin.version>
+        <!-- Do not match any files by default, but this can be overridden from the command line. -->
+        <spotless-include-list>NO_AUTOMATED_FORMATTING</spotless-include-list>
 
         <dependency.postgresql.version>42.5.2</dependency.postgresql.version>
         <dependency.mysql.version>8.0.30</dependency.mysql.version>
@@ -1021,12 +1024,36 @@
                         <skipDeploy>true</skipDeploy>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${spotless-plugin.version}</version>
+                    <configuration>
+                        <java>
+                            <includes>
+                                ${spotless-include-list}
+                            </includes>
+                            <eclipse>
+                                <file>alfresco-formatter.xml</file>
+                            </eclipse>
+                            <importOrder>
+                                <order>\#java|\#javax|\#jakarta,\#,\#org.alfresco,java|javax|jakarta,,org.alfresco</order>
+                            </importOrder>
+                            <removeUnusedImports />
+                            <formatAnnotations />
+                        </java>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/scripts/hooks/check-format-and-headers.sh
+++ b/scripts/hooks/check-format-and-headers.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set +x
+
+if [[ -z ${GITHUB_MODIFIED_FILES} ]]
+then
+  modified_files=$(git diff --cached --name-only --diff-filter=ACMR)
+else
+  modified_files=${GITHUB_MODIFIED_FILES}
+fi
+
+include_list=""
+for file in ${modified_files}
+do
+  include_list="${include_list},${file}"
+done
+include_list=${include_list:1}
+
+mvn spotless:apply validate -DlicenseUpdateHeaders=true -Pags,all-tas-tests -Dspotless-include-list="${include_list}" > /dev/null || true
+
+set -x


### PR DESCRIPTION
* Add precommit for secret scanning, formatting and license header checking.

* Turn off bash debug logging.

* Skip precommit checks that apply to all files.

There are too many violations to run against all files.

(cherry picked from commit b00e11cb6fe312558439cfc8565cf4b8d1e7dca6)