### PR TITLE
MNT-24641 Avoid duplicate key error on content upload

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
@@ -435,6 +435,8 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             // Cache it
             if (cache != null)
             {
+                VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
+                cache.put(new CacheRegionValueKey(cacheRegion, valueKey), entityPair.getFirst());
                 cache.put(
                         new CacheRegionKey(cacheRegion, entityPair.getFirst()),
                         (entityPair.getSecond() == null ? VALUE_NULL : entityPair.getSecond()));
@@ -562,6 +564,39 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
                 (value == null ? VALUE_NULL : value));
         // Done
         return updateCount;
+    }
+
+    /**
+     * Find the entity associated with the given value if its cached
+     *
+     * @param value
+     *            The entity value (<tt>null</tt> is not allowed)
+     * @return Returns the key-value pair (existing or <tt>null</tt>)
+     */
+    @SuppressWarnings("unchecked")
+    public Pair<K, V> getCachedEntityByValue(V value)
+    {
+        if (cache == null || value == null)
+        {
+            return null;
+        }
+
+        VK valueKey = entityLookup.getValueKey(value);
+        if (valueKey == null)
+        {
+            return null;
+        }
+
+        // Retrieve the cached value
+        CacheRegionValueKey valueCacheKey = new CacheRegionValueKey(cacheRegion, valueKey);
+        K key = (K) cache.get(valueCacheKey);
+
+        if (key != null && !key.equals(VALUE_NOT_FOUND))
+        {
+            return getByKey(key);
+        }
+
+        return null;
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
@@ -21,37 +21,33 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
- * #L%
+ * #L% 
  */
 package org.alfresco.repo.cache.lookup;
 
 import java.io.Serializable;
 import java.sql.Savepoint;
 
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.extensions.surf.util.ParameterCheck;
+
 import org.alfresco.repo.cache.SimpleCache;
 import org.alfresco.repo.domain.control.ControlDAO;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.util.Pair;
-import org.springframework.dao.ConcurrencyFailureException;
-import org.springframework.extensions.surf.util.ParameterCheck;
 
 /**
- * A cache for two-way lookups of database entities.  These are characterized by having a unique
- * key (perhaps a database ID) and a separate unique key that identifies the object.  If no cache
- * is given, then all calls are passed through to the backing DAO.
+ * A cache for two-way lookups of database entities. These are characterized by having a unique key (perhaps a database ID) and a separate unique key that identifies the object. If no cache is given, then all calls are passed through to the backing DAO.
  * <p>
- * The keys must have good <code>equals</code> and <code>hashCode</code> implementations and
- * must respect the case-sensitivity of the use-case.
+ * The keys must have good <code>equals</code> and <code>hashCode</code> implementations and must respect the case-sensitivity of the use-case.
  * <p>
- * All keys will be unique to the given cache region, allowing the cache to be shared
- * between instances of this class.
+ * All keys will be unique to the given cache region, allowing the cache to be shared between instances of this class.
  * <p>
  * Generics:
  * <ul>
- *   <li>K:  The database unique identifier.</li>
- *   <li>V:  The value stored against K.</li>
- *   <li>VK: The a value-derived key that will be used as a cache key when caching K for lookups by V.
- *           This can be the value itself if it is itself a good key.</li>
+ * <li>K: The database unique identifier.</li>
+ * <li>V: The value stored against K.</li>
+ * <li>VK: The a value-derived key that will be used as a cache key when caching K for lookups by V. This can be the value itself if it is itself a good key.</li>
  * </ul>
  * 
  * @author Derek Hulley
@@ -65,105 +61,95 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
     public static interface EntityLookupCallbackDAO<K1 extends Serializable, V1 extends Object, VK1 extends Serializable>
     {
         /**
-         * Resolve the given value into a unique value key that can be used to find the entity's ID.
-         * A return value should be small and efficient; don't return a value if this is not possible.
+         * Resolve the given value into a unique value key that can be used to find the entity's ID. A return value should be small and efficient; don't return a value if this is not possible.
          * <p/>
-         * Implementations will often return the value itself, provided that the value is both
-         * serializable and has a good <code>equals</code> and <code>hashCode</code>.
+         * Implementations will often return the value itself, provided that the value is both serializable and has a good <code>equals</code> and <code>hashCode</code>.
          * <p/>
-         * Were no adequate key can be generated for the value, then <tt>null</tt> can be returned.
-         * In this case, the {@link #findByValue(Object) findByValue} method might not even do a search
-         * and just return <tt>null</tt> itself  i.e. if it is difficult to look the value up in storage
-         * then it is probably difficult to generate a cache key from it, too..  In this scenario, the
-         * cache will be purely for key-based lookups 
+         * Were no adequate key can be generated for the value, then <tt>null</tt> can be returned. In this case, the {@link #findByValue(Object) findByValue} method might not even do a search and just return <tt>null</tt> itself i.e. if it is difficult to look the value up in storage then it is probably difficult to generate a cache key from it, too.. In this scenario, the cache will be purely for key-based lookups
          * 
-         * @param value         the full value being keyed (never <tt>null</tt>)
-         * @return              Returns the business key representing the entity, or <tt>null</tt>
-         *                      if an economical key cannot be generated.
+         * @param value
+         *            the full value being keyed (never <tt>null</tt>)
+         * @return Returns the business key representing the entity, or <tt>null</tt> if an economical key cannot be generated.
          */
         VK1 getValueKey(V1 value);
-        
+
         /**
          * Find an entity for a given key.
          * 
-         * @param key           the key (ID) used to identify the entity (never <tt>null</tt>)
-         * @return              Return the entity or <tt>null</tt> if no entity is exists for the ID
+         * @param key
+         *            the key (ID) used to identify the entity (never <tt>null</tt>)
+         * @return Return the entity or <tt>null</tt> if no entity is exists for the ID
          */
         Pair<K1, V1> findByKey(K1 key);
-        
+
         /**
-         * Find and entity using the given value key.  The <code>equals</code> and <code>hashCode</code>
-         * methods of the value object should respect case-sensitivity in the same way that this
-         * lookup treats case-sensitivity i.e. if the <code>equals</code> method is <b>case-sensitive</b>
-         * then this method should look the entity up using a <b>case-sensitive</b> search.
+         * Find and entity using the given value key. The <code>equals</code> and <code>hashCode</code> methods of the value object should respect case-sensitivity in the same way that this lookup treats case-sensitivity i.e. if the <code>equals</code> method is <b>case-sensitive</b> then this method should look the entity up using a <b>case-sensitive</b> search.
          * <p/>
-         * Since this is a cache backed by some sort of database, <tt>null</tt> values are allowed by the
-         * cache.  The implementation of this method can throw an exception if <tt>null</tt> is not
-         * appropriate for the use-case.
+         * Since this is a cache backed by some sort of database, <tt>null</tt> values are allowed by the cache. The implementation of this method can throw an exception if <tt>null</tt> is not appropriate for the use-case.
          * <p/>
-         * If the search is impossible or expensive, this method should just return <tt>null</tt>.  This
-         * would usually be the case if the {@link #getValueKey(Object) getValueKey} method also returned
-         * <tt>null</tt> i.e. if it is difficult to look the value up in storage then it is probably
-         * difficult to generate a cache key from it, too.
+         * If the search is impossible or expensive, this method should just return <tt>null</tt>. This would usually be the case if the {@link #getValueKey(Object) getValueKey} method also returned <tt>null</tt> i.e. if it is difficult to look the value up in storage then it is probably difficult to generate a cache key from it, too.
          * 
-         * @param value         the value (business object) used to identify the entity (<tt>null</tt> allowed).
-         * @return              Return the entity or <tt>null</tt> if no entity matches the given value
+         * @param value
+         *            the value (business object) used to identify the entity (<tt>null</tt> allowed).
+         * @return Return the entity or <tt>null</tt> if no entity matches the given value
          */
         Pair<K1, V1> findByValue(V1 value);
-        
+
         /**
-         * Create an entity using the given values.  It is valid to assume that the entity does not exist
-         * within the current transaction at least.
+         * Create an entity using the given values. It is valid to assume that the entity does not exist within the current transaction at least.
          * <p/>
-         * Since persistence mechanisms often allow <tt>null</tt> values, these can be expected here.  The
-         * implementation  must throw an exception if <tt>null</tt> is not allowed for the specific use-case.
+         * Since persistence mechanisms often allow <tt>null</tt> values, these can be expected here. The implementation must throw an exception if <tt>null</tt> is not allowed for the specific use-case.
          * 
-         * @param value         the value (business object) used to identify the entity (<tt>null</tt> allowed).
-         * @return              Return the newly-created entity ID-value pair
+         * @param value
+         *            the value (business object) used to identify the entity (<tt>null</tt> allowed).
+         * @return Return the newly-created entity ID-value pair
          */
         Pair<K1, V1> createValue(V1 value);
-        
+
         /**
          * Update the entity identified by the given key.
          * <p/>
-         * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation
-         * or not.
+         * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation or not.
          * 
-         * @param key           the existing key (ID) used to identify the entity (never <tt>null</tt>)
-         * @param value         the new value
-         * @return              Returns the row update count.
-         * @throws UnsupportedOperationException if entity updates are not supported
+         * @param key
+         *            the existing key (ID) used to identify the entity (never <tt>null</tt>)
+         * @param value
+         *            the new value
+         * @return Returns the row update count.
+         * @throws UnsupportedOperationException
+         *             if entity updates are not supported
          */
         int updateValue(K1 key, V1 value);
-        
+
         /**
          * Delete an entity for the given key.
          * <p/>
-         * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation
-         * or not.
-         *  
-         * @param key           the key (ID) used to identify the entity (never <tt>null</tt>)
-         * @return              Returns the row deletion count.
-         * @throws UnsupportedOperationException if entity deletion is not supported
+         * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation or not.
+         * 
+         * @param key
+         *            the key (ID) used to identify the entity (never <tt>null</tt>)
+         * @return Returns the row deletion count.
+         * @throws UnsupportedOperationException
+         *             if entity deletion is not supported
          */
         int deleteByKey(K1 key);
-        
+
         /**
          * Delete an entity for the given value.
          * <p/>
-         * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation
-         * or not.
+         * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation or not.
          * 
-         * @param value         the value (business object) used to identify the enitity (<tt>null</tt> allowed)
-         * @return              Returns the row deletion count.
-         * @throws UnsupportedOperationException if entity deletion is not supported
+         * @param value
+         *            the value (business object) used to identify the enitity (<tt>null</tt> allowed)
+         * @return Returns the row deletion count.
+         * @throws UnsupportedOperationException
+         *             if entity deletion is not supported
          */
         int deleteByValue(V1 value);
     }
-    
+
     /**
-     * Adaptor for implementations that support immutable entities.  The update and delete operations
-     * throw {@link UnsupportedOperationException}.
+     * Adaptor for implementations that support immutable entities. The update and delete operations throw {@link UnsupportedOperationException}.
      * 
      * @author Derek Hulley
      * @since 3.2
@@ -174,7 +160,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         /**
          * This implementation never finds a value and is backed by {@link #getValueKey(Object)} returning nothing.
          * 
-         * @return          Returns <tt>null</tt> always
+         * @return Returns <tt>null</tt> always
          */
         public Pair<K2, V2> findByValue(V2 value)
         {
@@ -184,7 +170,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         /**
          * This implementation does not find by value and is backed by {@link #findByValue(Object)} returning nothing.
          * 
-         * @return          Returns <tt>null</tt> always
+         * @return Returns <tt>null</tt> always
          */
         public VK2 getValueKey(V2 value)
         {
@@ -194,7 +180,8 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         /**
          * Disallows the operation.
          * 
-         * @throws UnsupportedOperationException        always
+         * @throws UnsupportedOperationException
+         *             always
          */
         public int updateValue(K2 key, V2 value)
         {
@@ -204,24 +191,26 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         /**
          * Disallows the operation.
          * 
-         * @throws UnsupportedOperationException        always
+         * @throws UnsupportedOperationException
+         *             always
          */
         public int deleteByKey(K2 key)
         {
             throw new UnsupportedOperationException("Entity deletion by key is not supported");
         }
-        
+
         /**
          * Disallows the operation.
          * 
-         * @throws UnsupportedOperationException        always
+         * @throws UnsupportedOperationException
+         *             always
          */
         public int deleteByValue(V2 value)
         {
             throw new UnsupportedOperationException("Entity deletion by value is not supported");
         }
     }
-    
+
     /**
      * A valid <code>null</code> value i.e. a value that has been <u>persisted</u> as null.
      */
@@ -234,46 +223,49 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
      * The cache region that will be used (see {@link CacheRegionKey}) in all the cache keys
      */
     private static final String CACHE_REGION_DEFAULT = "DEFAULT";
-    
+
     private final SimpleCache<Serializable, Object> cache;
     private final EntityLookupCallbackDAO<K, V, VK> entityLookup;
     private final String cacheRegion;
 
     /**
-     * Construct the lookup cache <b>without any cache</b>.  All calls are passed directly to the
-     * underlying DAO entity lookup.
+     * Construct the lookup cache <b>without any cache</b>. All calls are passed directly to the underlying DAO entity lookup.
      * 
-     * @param entityLookup          the instance that is able to find and persist entities
+     * @param entityLookup
+     *            the instance that is able to find and persist entities
      */
     public EntityLookupCache(EntityLookupCallbackDAO<K, V, VK> entityLookup)
     {
         this(null, CACHE_REGION_DEFAULT, entityLookup);
     }
-    
+
     /**
      * Construct the lookup cache, using the {@link #CACHE_REGION_DEFAULT default cache region}.
      * 
-     * @param cache                 the cache that will back the two-way lookups
-     * @param entityLookup          the instance that is able to find and persist entities
+     * @param cache
+     *            the cache that will back the two-way lookups
+     * @param entityLookup
+     *            the instance that is able to find and persist entities
      */
     @SuppressWarnings("rawtypes")
     public EntityLookupCache(SimpleCache cache, EntityLookupCallbackDAO<K, V, VK> entityLookup)
     {
         this(cache, CACHE_REGION_DEFAULT, entityLookup);
     }
-    
+
     /**
      * Construct the lookup cache, using the given cache region.
      * <p>
-     * All keys will be unique to the given cache region, allowing the cache to be shared
-     * between instances of this class.
+     * All keys will be unique to the given cache region, allowing the cache to be shared between instances of this class.
      * 
-     * @param cache                 the cache that will back the two-way lookups; <tt>null</tt> to have no backing
-     *                              in a cache.
-     * @param cacheRegion           the region within the cache to use.
-     * @param entityLookup          the instance that is able to find and persist entities
+     * @param cache
+     *            the cache that will back the two-way lookups; <tt>null</tt> to have no backing in a cache.
+     * @param cacheRegion
+     *            the region within the cache to use.
+     * @param entityLookup
+     *            the instance that is able to find and persist entities
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public EntityLookupCache(SimpleCache cache, String cacheRegion, EntityLookupCallbackDAO<K, V, VK> entityLookup)
     {
         ParameterCheck.mandatory("cacheRegion", cacheRegion);
@@ -282,17 +274,15 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         this.cacheRegion = cacheRegion;
         this.entityLookup = entityLookup;
     }
-    
+
     /**
-     * Find the entity associated with the given key.
-     * The {@link EntityLookupCallbackDAO#findByKey(Serializable) entity callback} will be used if necessary.
+     * Find the entity associated with the given key. The {@link EntityLookupCallbackDAO#findByKey(Serializable) entity callback} will be used if necessary.
      * <p/>
-     * It is up to the client code to decide if a <tt>null</tt> return value indicates a concurrency violation
-     * or not; the former would normally result in a concurrency-related exception such as
-     * {@link ConcurrencyFailureException}.
+     * It is up to the client code to decide if a <tt>null</tt> return value indicates a concurrency violation or not; the former would normally result in a concurrency-related exception such as {@link ConcurrencyFailureException}.
      * 
-     * @param key                   The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
-     * @return                      Returns the key-value pair or <tt>null</tt> if the key doesn't reference an entity
+     * @param key
+     *            The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
+     * @return Returns the key-value pair or <tt>null</tt> if the key doesn't reference an entity
      */
     @SuppressWarnings("unchecked")
     public Pair<K, V> getByKey(K key)
@@ -306,7 +296,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return entityLookup.findByKey(key);
         }
-        
+
         CacheRegionKey keyCacheKey = new CacheRegionKey(cacheRegion, key);
         // Look in the cache
         V value = (V) cache.get(keyCacheKey);
@@ -337,7 +327,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             value = entityPair.getSecond();
             // Get the value key
-            VK valueKey = (value == null) ? (VK)VALUE_NULL : entityLookup.getValueKey(value);
+            VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
             // Check if the value has a good key
             if (valueKey != null)
             {
@@ -352,17 +342,15 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         // Done
         return entityPair;
     }
-    
+
     /**
-     * Find the entity associated with the given value.
-     * The {@link EntityLookupCallbackDAO#findByValue(Object) entity callback} will be used if no entry exists in the cache.
+     * Find the entity associated with the given value. The {@link EntityLookupCallbackDAO#findByValue(Object) entity callback} will be used if no entry exists in the cache.
      * <p/>
-     * It is up to the client code to decide if a <tt>null</tt> return value indicates a concurrency violation
-     * or not; the former would normally result in a concurrency-related exception such as
-     * {@link ConcurrencyFailureException}.
+     * It is up to the client code to decide if a <tt>null</tt> return value indicates a concurrency violation or not; the former would normally result in a concurrency-related exception such as {@link ConcurrencyFailureException}.
      * 
-     * @param value                 The entity value, which may be valid or invalid (<tt>null</tt> is allowed)
-     * @return                      Returns the key-value pair or <tt>null</tt> if the value doesn't reference an entity
+     * @param value
+     *            The entity value, which may be valid or invalid (<tt>null</tt> is allowed)
+     * @return Returns the key-value pair or <tt>null</tt> if the value doesn't reference an entity
      */
     @SuppressWarnings("unchecked")
     public Pair<K, V> getByValue(V value)
@@ -372,17 +360,17 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return entityLookup.findByValue(value);
         }
-        
+
         // Get the value key.
         // The cast to (VK) is counter-intuitive, but works because they're all just Serializable
         // It's nasty, but hidden from the cache client code.
-        VK valueKey = (value == null) ? (VK)VALUE_NULL : entityLookup.getValueKey(value);
+        VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
         // Check if the value has a good key
         if (valueKey == null)
         {
             return entityLookup.findByValue(value);
         }
-        
+
         // Look in the cache
         CacheRegionValueKey valueCacheKey = new CacheRegionValueKey(cacheRegion, valueKey);
         K key = (K) cache.get(valueCacheKey);
@@ -420,19 +408,18 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         // Done
         return entityPair;
     }
-    
+
     /**
      * Attempt to create the entity and, failing that, look it up.<br/>
-     * This method takes the opposite approach to {@link #getOrCreateByValue(Object)}, which assumes the entity's
-     * existence: in this case the entity is assumed to NOT exist.
-     * The {@link EntityLookupCallbackDAO#createValue(Object)} and {@link EntityLookupCallbackDAO#findByValue(Object)}
-     * will be used if necessary.<br/>
+     * This method takes the opposite approach to {@link #getOrCreateByValue(Object)}, which assumes the entity's existence: in this case the entity is assumed to NOT exist. The {@link EntityLookupCallbackDAO#createValue(Object)} and {@link EntityLookupCallbackDAO#findByValue(Object)} will be used if necessary.<br/>
      * <p/>
      * Use this method when the data involved is seldom reused.
      * 
-     * @param value                 The entity value (<tt>null</tt> is allowed)
-     * @param controlDAO            an essential DAO required in order to ensure a transactionally-safe attempt at data creation
-     * @return                      Returns the key-value pair (new or existing and never <tt>null</tt>)
+     * @param value
+     *            The entity value (<tt>null</tt> is allowed)
+     * @param controlDAO
+     *            an essential DAO required in order to ensure a transactionally-safe attempt at data creation
+     * @return Returns the key-value pair (new or existing and never <tt>null</tt>)
      */
     public Pair<K, V> createOrGetByValue(V value, ControlDAO controlDAO)
     {
@@ -462,14 +449,13 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             return getOrCreateByValue(value);
         }
     }
-    
+
     /**
-     * Find the entity associated with the given value and create it if it doesn't exist.
-     * The {@link EntityLookupCallbackDAO#findByValue(Object)} and {@link EntityLookupCallbackDAO#createValue(Object)}
-     * will be used if necessary.
+     * Find the entity associated with the given value and create it if it doesn't exist. The {@link EntityLookupCallbackDAO#findByValue(Object)} and {@link EntityLookupCallbackDAO#createValue(Object)} will be used if necessary.
      * 
-     * @param value                 The entity value (<tt>null</tt> is allowed)
-     * @return                      Returns the key-value pair (new or existing and never <tt>null</tt>)
+     * @param value
+     *            The entity value (<tt>null</tt> is allowed)
+     * @return Returns the key-value pair (new or existing and never <tt>null</tt>)
      */
     @SuppressWarnings("unchecked")
     public Pair<K, V> getOrCreateByValue(V value)
@@ -484,11 +470,11 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             }
             return entityPair;
         }
-        
+
         // Get the value key
         // The cast to (VK) is counter-intuitive, but works because they're all just Serializable.
         // It's nasty, but hidden from the cache client code.
-        VK valueKey = (value == null) ? (VK)VALUE_NULL : entityLookup.getValueKey(value);
+        VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
         // Check if the value has a good key
         if (valueKey == null)
         {
@@ -503,7 +489,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             }
             return entityPair;
         }
-        
+
         // Look in the cache
         CacheRegionValueKey valueCacheKey = new CacheRegionValueKey(cacheRegion, valueKey);
         K key = (K) cache.get(valueCacheKey);
@@ -528,19 +514,17 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         // Done
         return entityPair;
     }
-    
+
     /**
-     * Update the entity associated with the given key.
-     * The {@link EntityLookupCallbackDAO#updateValue(Serializable, Object)} callback
-     * will be used if necessary.
+     * Update the entity associated with the given key. The {@link EntityLookupCallbackDAO#updateValue(Serializable, Object)} callback will be used if necessary.
      * <p/>
-     * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation
-     * or not; usually the former will generate {@link ConcurrencyFailureException} or something recognised
-     * by the {@link RetryingTransactionHelper#RETRY_EXCEPTIONS RetryingTransactionHelper}.
+     * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation or not; usually the former will generate {@link ConcurrencyFailureException} or something recognised by the {@link RetryingTransactionHelper#RETRY_EXCEPTIONS RetryingTransactionHelper}.
      * 
-     * @param key                   The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
-     * @param value                 The new entity value (may be <tt>null</tt>)
-     * @return                      Returns the row update count.
+     * @param key
+     *            The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
+     * @param value
+     *            The new entity value (may be <tt>null</tt>)
+     * @return Returns the row update count.
      */
     @SuppressWarnings("unchecked")
     public int updateValue(K key, V value)
@@ -550,11 +534,11 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return entityLookup.updateValue(key, value);
         }
-        
+
         // Remove entries for the key (bidirectional removal removes the old value as well)
         // but leave the key as it will get updated
         removeByKey(key, false);
-        
+
         // Do the update
         int updateCount = entityLookup.updateValue(key, value);
         if (updateCount == 0)
@@ -562,9 +546,9 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             // Nothing was done
             return updateCount;
         }
-        
+
         // Get the value key.
-        VK valueKey = (value == null) ? (VK)VALUE_NULL : entityLookup.getValueKey(value);
+        VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
         // Check if the value has a good key
         if (valueKey != null)
         {
@@ -579,12 +563,13 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         // Done
         return updateCount;
     }
-    
+
     /**
      * Cache-only operation: Get the key for a given value key (note: not 'value' but 'value key').
      * 
-     * @param valueKey                 The entity value key, which must be valid (<tt>null</tt> not allowed)
-     * @return                      The entity key (may be <tt>null</tt>)
+     * @param valueKey
+     *            The entity value key, which must be valid (<tt>null</tt> not allowed)
+     * @return The entity key (may be <tt>null</tt>)
      */
     @SuppressWarnings("unchecked")
     public K getKey(VK valueKey)
@@ -599,12 +584,13 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         }
         return key;
     }
-    
+
     /**
      * Cache-only operation: Get the value for a given key
      * 
-     * @param key                   The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
-     * @return                      The entity value (may be <tt>null</tt>)
+     * @param key
+     *            The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
+     * @return The entity value (may be <tt>null</tt>)
      */
     @SuppressWarnings("unchecked")
     public V getValue(K key)
@@ -630,12 +616,14 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             return value;
         }
     }
-    
+
     /**
      * Cache-only operation: Update the cache's value
      * 
-     * @param key                   The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
-     * @param value                 The new entity value (may be <tt>null</tt>)
+     * @param key
+     *            The entity key, which may be valid or invalid (<tt>null</tt> not allowed)
+     * @param value
+     *            The new entity value (may be <tt>null</tt>)
      */
     @SuppressWarnings("unchecked")
     public void setValue(K key, V value)
@@ -645,13 +633,13 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return;
         }
-        
+
         // Remove entries for the key (bidirectional removal removes the old value as well)
         // but leave the key as it will get updated
         removeByKey(key, false);
-        
+
         // Get the value key.
-        VK valueKey = (value == null) ? (VK)VALUE_NULL : entityLookup.getValueKey(value);
+        VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
         // Check if the value has a good key
         if (valueKey != null)
         {
@@ -665,17 +653,15 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
                 (value == null ? VALUE_NULL : value));
         // Done
     }
-    
+
     /**
-     * Delete the entity associated with the given key.
-     * The {@link EntityLookupCallbackDAO#deleteByKey(Serializable)} callback will be used if necessary.
+     * Delete the entity associated with the given key. The {@link EntityLookupCallbackDAO#deleteByKey(Serializable)} callback will be used if necessary.
      * <p/>
-     * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation
-     * or not; usually the former will generate {@link ConcurrencyFailureException} or something recognised
-     * by the {@link RetryingTransactionHelper#RETRY_EXCEPTIONS RetryingTransactionHelper}.
+     * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation or not; usually the former will generate {@link ConcurrencyFailureException} or something recognised by the {@link RetryingTransactionHelper#RETRY_EXCEPTIONS RetryingTransactionHelper}.
      * 
-     * @param key                   the entity key, which may be valid or invalid (<tt>null</tt> not allowed)
-     * @return                      Returns the row deletion count
+     * @param key
+     *            the entity key, which may be valid or invalid (<tt>null</tt> not allowed)
+     * @return Returns the row deletion count
      */
     public int deleteByKey(K key)
     {
@@ -684,24 +670,22 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return entityLookup.deleteByKey(key);
         }
-        
+
         // Remove entries for the key (bidirectional removal removes the old value as well)
         removeByKey(key);
-        
+
         // Do the delete
         return entityLookup.deleteByKey(key);
     }
-    
+
     /**
-     * Delete the entity having the given value..
-     * The {@link EntityLookupCallbackDAO#deleteByValue(Object)} callback will be used if necessary.
+     * Delete the entity having the given value.. The {@link EntityLookupCallbackDAO#deleteByValue(Object)} callback will be used if necessary.
      * <p/>
-     * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation
-     * or not; usually the former will generate {@link ConcurrencyFailureException} or something recognised
-     * by the {@link RetryingTransactionHelper#RETRY_EXCEPTIONS RetryingTransactionHelper}.
+     * It is up to the client code to decide if a <tt>0</tt> return value indicates a concurrency violation or not; usually the former will generate {@link ConcurrencyFailureException} or something recognised by the {@link RetryingTransactionHelper#RETRY_EXCEPTIONS RetryingTransactionHelper}.
      * 
-     * @param value                   the entity value, which may be valid or invalid (<tt>null</tt> allowed)
-     * @return                      Returns the row deletion count
+     * @param value
+     *            the entity value, which may be valid or invalid (<tt>null</tt> allowed)
+     * @return Returns the row deletion count
      */
     public int deleteByValue(V value)
     {
@@ -710,14 +694,14 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return entityLookup.deleteByValue(value);
         }
-        
+
         // Remove entries for the value
         removeByValue(value);
-        
+
         // Do the delete
         return entityLookup.deleteByValue(value);
     }
-    
+
     /**
      * Cache-only operation: Remove all cache values associated with the given key.
      */
@@ -728,14 +712,15 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return;
         }
-        
+
         removeByKey(key, true);
     }
-    
+
     /**
      * Cache-only operation: Remove all cache values associated with the given key.
      * 
-     * @param removeKey             <tt>true</tt> to remove the given key's entry
+     * @param removeKey
+     *            <tt>true</tt> to remove the given key's entry
      */
     @SuppressWarnings("unchecked")
     private void removeByKey(K key, boolean removeKey)
@@ -757,11 +742,12 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             cache.remove(keyCacheKey);
         }
     }
-    
+
     /**
      * Cache-only operation: Remove all cache values associated with the given value
      * 
-     * @param value                 The entity value (<tt>null</tt> is allowed)
+     * @param value
+     *            The entity value (<tt>null</tt> is allowed)
      */
     @SuppressWarnings("unchecked")
     public void removeByValue(V value)
@@ -771,12 +757,12 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             return;
         }
-        
+
         // Get the value key
-        VK valueKey = (value == null) ? (VK)VALUE_NULL : entityLookup.getValueKey(value);
+        VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
         if (valueKey == null)
         {
-            // No key generated for the value.  There is nothing that can be done.
+            // No key generated for the value. There is nothing that can be done.
             return;
         }
         // Look in the cache
@@ -790,7 +776,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         }
         cache.remove(valueCacheKey);
     }
-    
+
     /**
      * Cache-only operation: Remove all cache entries
      * <p/>

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
@@ -21,7 +21,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
- * #L%
+ * #L% 
  */
 package org.alfresco.repo.domain.contentdata;
 
@@ -30,6 +30,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import org.alfresco.repo.cache.SimpleCache;
 import org.alfresco.repo.cache.lookup.EntityLookupCache;
@@ -45,19 +50,13 @@ import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.util.EqualsHelper;
 import org.alfresco.util.Pair;
 import org.alfresco.util.transaction.TransactionListenerAdapter;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.springframework.dao.ConcurrencyFailureException;
-import org.springframework.dao.DataIntegrityViolationException;
 
 /**
  * Abstract implementation for ContentData DAO.
  * <p>
- * This provides basic services such as caching, but defers to the underlying implementation
- * for CRUD operations.
+ * This provides basic services such as caching, but defers to the underlying implementation for CRUD operations.
  * <p>
- * The DAO deals in {@link ContentData} instances.  The cache is primarily present to decode
- * IDs into <code>ContentData</code> instances.
+ * The DAO deals in {@link ContentData} instances. The cache is primarily present to decode IDs into <code>ContentData</code> instances.
  * 
  * @author Derek Hulley
  * @author sglover
@@ -74,7 +73,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     private static final String KEY_PRE_COMMIT_CONTENT_URL_DELETIONS = "AbstractContentDataDAOImpl.PreCommitContentUrlDeletions";
 
     private static Log logger = LogFactory.getLog(AbstractContentDataDAOImpl.class);
-    
+
     private final ContentDataCallbackDAO contentDataCallbackDAO;
     private final ContentUrlCallbackDAO contentUrlCallbackDAO;
     protected ControlDAO controlDAO;
@@ -127,7 +126,8 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     /**
      * Set this property to enable eager cleanup of orphaned content.
      * 
-     * @param contentStoreCleaner       an eager cleaner (may be <tt>null</tt>)
+     * @param contentStoreCleaner
+     *            an eager cleaner (may be <tt>null</tt>)
      */
     public void setContentStoreCleaner(EagerContentStoreCleaner contentStoreCleaner)
     {
@@ -135,7 +135,8 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     }
 
     /**
-     * @param contentDataCache              the cache of IDs to ContentData and vice versa
+     * @param contentDataCache
+     *            the cache of IDs to ContentData and vice versa
      */
     public void setContentDataCache(SimpleCache<Long, ContentData> contentDataCache)
     {
@@ -154,8 +155,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     }
 
     /**
-     * A <b>content_url</b> entity was dereferenced.  This makes no assumptions about the
-     * current references - dereference deletion is handled in the commit phase.
+     * A <b>content_url</b> entity was dereferenced. This makes no assumptions about the current references - dereference deletion is handled in the commit phase.
      */
     protected void registerDereferencedContentUrl(String contentUrl)
     {
@@ -205,7 +205,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             throw new IllegalArgumentException("Cannot look up ContentData by null ID.");
         }
         Pair<Long, ContentUrlEntity> pair = contentUrlCache.getByValue(contentUrl);
-        if(pair != null)
+        if (pair != null)
         {
             result = contentUrlCache.updateValue(pair.getFirst(), contentUrl);
         }
@@ -246,7 +246,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         for (ContentDataEntity entity : getContentDataEntitiesForNodes(nodeIds))
         {
             contentDataCache.setValue(entity.getId(), makeContentData(entity));
-        }        
+        }
     }
 
     @Override
@@ -325,7 +325,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             ContentDataEntity contentDataEntity = getContentDataEntity(key);
             if (contentDataEntity == null)
             {
-                return 0;           // The client (outer-level code) will decide if this is an error
+                return 0; // The client (outer-level code) will decide if this is an error
             }
             return updateContentDataEntity(contentDataEntity, value);
         }
@@ -343,7 +343,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     private class ContentUrlCallbackDAO extends EntityLookupCallbackDAOAdaptor<Long, ContentUrlEntity, String>
     {
         /**
-         * @return                  Returns the Node's NodeRef
+         * @return Returns the Node's NodeRef
          */
         @Override
         public String getValueKey(ContentUrlEntity value)
@@ -393,7 +393,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             ContentUrlEntity contentUrlEntity = getContentUrlEntity(id);
             if (contentUrlEntity == null)
             {
-                return 0;           // The client (outer-level code) will decide if this is an error
+                return 0; // The client (outer-level code) will decide if this is an error
             }
             return updateContentUrlEntity(contentUrlEntity, value);
         }
@@ -413,7 +413,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         // Decode content URL
         Long contentUrlId = contentDataEntity.getContentUrlId();
         String contentUrl = null;
-        if(contentUrlId != null)
+        if (contentUrlId != null)
         {
             Pair<Long, ContentUrlEntity> entityPair = contentUrlCache.getByKey(contentUrlId);
             if (entityPair == null)
@@ -495,13 +495,13 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         {
             localeId = localeDAO.getOrCreateLocalePair(locale).getFirst();
         }
-        
+
         // Create ContentDataEntity
         ContentDataEntity contentDataEntity = createContentDataEntity(contentUrlId, mimetypeId, encodingId, localeId);
         // Done
         return contentDataEntity;
     }
-    
+
     /**
      * Translates the {@link ContentData} into persistable values using the helper DAOs
      */
@@ -510,7 +510,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         // Resolve the content URL
         Long oldContentUrlId = contentDataEntity.getContentUrlId();
         ContentUrlEntity contentUrlEntity = null;
-        if(oldContentUrlId != null)
+        if (oldContentUrlId != null)
         {
             Pair<Long, ContentUrlEntity> entityPair = contentUrlCache.getByKey(oldContentUrlId);
             if (entityPair == null)
@@ -526,12 +526,12 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         {
             if (oldContentUrl != null)
             {
-                // We have a changed value.  The old content URL has been dereferenced.
+                // We have a changed value. The old content URL has been dereferenced.
                 registerDereferencedContentUrl(oldContentUrl);
             }
             if (newContentUrl != null)
             {
-                if(contentUrlEntity == null)
+                if (contentUrlEntity == null)
                 {
                     contentUrlEntity = new ContentUrlEntity();
                     contentUrlEntity.setContentUrl(newContentUrl);
@@ -595,7 +595,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         boolean success = true;
 
         ContentUrlEntity existing = getContentUrl(contentUrlId);
-        if(existing != null)
+        if (existing != null)
         {
             ContentUrlEntity entity = ContentUrlEntity.setContentUrlKey(existing, contentUrlKey);
             updateContentUrl(entity);
@@ -638,36 +638,40 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     }
 
     /**
-     * @param contentUrl    the content URL to create or search for
+     * @param contentUrl
+     *            the content URL to create or search for
      */
     protected abstract ContentUrlEntity createContentUrlEntity(String contentUrl, long size, ContentUrlKeyEntity contentUrlKey);
 
     /**
-     * @param id            the ID of the <b>content url</b> entity
-     * @return              Return the entity or <tt>null</tt> if it doesn't exist
+     * @param id
+     *            the ID of the <b>content url</b> entity
+     * @return Return the entity or <tt>null</tt> if it doesn't exist
      */
     protected abstract ContentUrlEntity getContentUrlEntity(Long id);
 
     protected abstract ContentUrlEntity getContentUrlEntity(String contentUrl);
 
-    
     /**
-     * @param contentUrl    the URL of the <b>content url</b> entity
-     * @return              Return the entity or <tt>null</tt> if it doesn't exist or is still
-     *                      referenced by a <b>content_data</b> entity
+     * @param contentUrl
+     *            the URL of the <b>content url</b> entity
+     * @return Return the entity or <tt>null</tt> if it doesn't exist or is still referenced by a <b>content_data</b> entity
      */
     protected abstract ContentUrlEntity getContentUrlEntityUnreferenced(String contentUrl);
-    
+
     /**
      * Update a content URL with the given orphan time
      * 
-     * @param id            the unique ID of the entity 
-     * @param orphanTime    the time (ms since epoch) that the entity was orphaned
-     * @param oldOrphanTime the orphan time we expect to update for optimistic locking (may be <tt>null</tt>)
-     * @return              Returns the number of rows updated
+     * @param id
+     *            the unique ID of the entity
+     * @param orphanTime
+     *            the time (ms since epoch) that the entity was orphaned
+     * @param oldOrphanTime
+     *            the orphan time we expect to update for optimistic locking (may be <tt>null</tt>)
+     * @return Returns the number of rows updated
      */
     protected abstract int updateContentUrlOrphanTime(Long id, Long orphanTime, Long oldOrphanTime);
-    
+
     /**
      * Create the row for the <b>alf_content_data</b>
      */
@@ -676,35 +680,39 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             Long mimetypeId,
             Long encodingId,
             Long localeId);
-    
+
     /**
-     * @param id            the entity ID
-     * @return              Returns the entity or <tt>null</tt> if it doesn't exist
+     * @param id
+     *            the entity ID
+     * @return Returns the entity or <tt>null</tt> if it doesn't exist
      */
     protected abstract ContentDataEntity getContentDataEntity(Long id);
 
     /**
-     * @param nodeIds       the node ID
-     * @return              Returns the associated entities or <tt>null</tt> if none exist
+     * @param nodeIds
+     *            the node ID
+     * @return Returns the associated entities or <tt>null</tt> if none exist
      */
-    protected abstract List<ContentDataEntity> getContentDataEntitiesForNodes(Set<Long> nodeIds);    
+    protected abstract List<ContentDataEntity> getContentDataEntitiesForNodes(Set<Long> nodeIds);
 
     /**
      * Update an existing <b>alf_content_data</b> entity
      * 
-     * @param entity        the existing entity that will be updated
-     * @return              Returns the number of rows updated (should be 1)
+     * @param entity
+     *            the existing entity that will be updated
+     * @return Returns the number of rows updated (should be 1)
      */
     protected abstract int updateContentDataEntity(ContentDataEntity entity);
 
     /**
      * Delete the entity with the given ID
      * 
-     * @return              Returns the number of rows deleted
+     * @return Returns the number of rows deleted
      */
     protected abstract int deleteContentDataEntity(Long id);
 
     protected abstract int deleteContentUrlEntity(long id);
+
     protected abstract int updateContentUrlEntity(ContentUrlEntity existing, ContentUrlEntity entity);
 
     /**
@@ -738,7 +746,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
                 {
                     // We mark the URL as orphaned.
                     // The content binary is not scheduled for immediate removal so just mark the
-                    // row's orphan time.  Concurrently, it is possible for multiple references
+                    // row's orphan time. Concurrently, it is possible for multiple references
                     // to be made WHILE the orphan time is set, but we handle that separately.
                     Long contentUrlId = contentUrlEntity.getId();
                     Long oldOrphanTime = contentUrlEntity.getOrphanTime();

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
@@ -470,7 +470,15 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             ContentUrlEntity contentUrlEntity = new ContentUrlEntity();
             contentUrlEntity.setContentUrl(contentUrl);
             contentUrlEntity.setSize(size);
-            Pair<Long, ContentUrlEntity> pair = contentUrlCache.createOrGetByValue(contentUrlEntity, controlDAO);
+
+            // Attempt to get the data from cache
+            Pair<Long, ContentUrlEntity> pair = contentUrlCache.getCachedEntityByValue(contentUrlEntity);
+
+            if (pair == null)
+            {
+                pair = contentUrlCache.createOrGetByValue(contentUrlEntity, controlDAO);
+            }
+
             contentUrlId = pair.getFirst();
         }
 

--- a/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
+++ b/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
@@ -193,7 +193,8 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
-        assertEquals(1, cache.getKeys().size());
+        // We cache both by value and by key, so we should have 2 entries
+        assertEquals(2, cache.getKeys().size());
 
         Pair<Long, Object> entityPairOneCheck = entityLookupCacheA.createOrGetByValue(valueOne, controlDAO);
         assertNotNull(entityPairOneCheck);
@@ -262,6 +263,29 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         entityLookupCacheA.clear();
         assertEquals(valueOne.val, database.get(id)); // Must still be in database
         assertEquals(0, cache.getKeys().size()); // ... but cache must be empty
+    }
+
+    public void testGetCachedValue() throws Exception
+    {
+        // Create a new value
+        TestValue valueCached = new TestValue(getName() + "-CACHED");
+        Pair<Long, Object> entityPairOne = entityLookupCacheA.createOrGetByValue(valueCached, controlDAO);
+        assertNotNull(entityPairOne);
+        Long id = entityPairOne.getFirst();
+        // We cache both by value and by key, so we should have 2 entries
+        assertEquals(2, cache.getKeys().size());
+
+        // Check the cache for the previously created value
+        Pair<Long, Object> entityPairCacheCheck = entityLookupCacheA.getCachedEntityByValue(valueCached);
+        assertNotNull(entityPairCacheCheck);
+        assertEquals(id, entityPairCacheCheck.getFirst());
+
+        // Clear the cache and attempt to retrieve it again
+        entityLookupCacheA.clear();
+        entityPairCacheCheck = entityLookupCacheA.getCachedEntityByValue(valueCached);
+
+        // Since we are only retrieving from cache, the value should not be found
+        assertNull(entityPairCacheCheck);
     }
 
     /**

--- a/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
+++ b/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
@@ -21,7 +21,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
- * #L%
+ * #L% 
  */
 package org.alfresco.repo.cache.lookup;
 
@@ -31,6 +31,8 @@ import java.util.TreeMap;
 
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
+import org.mockito.Mockito;
+import org.springframework.dao.DuplicateKeyException;
 
 import org.alfresco.repo.cache.MemoryCache;
 import org.alfresco.repo.cache.SimpleCache;
@@ -38,15 +40,11 @@ import org.alfresco.repo.cache.lookup.EntityLookupCache.EntityLookupCallbackDAO;
 import org.alfresco.repo.domain.control.ControlDAO;
 import org.alfresco.util.EqualsHelper;
 import org.alfresco.util.Pair;
-import org.mockito.Mockito;
-import org.springframework.dao.DuplicateKeyException;
 
 /**
- * A cache for two-way lookups of database entities.  These are characterized by having a unique
- * key (perhaps a database ID) and a separate unique key that identifies the object.
+ * A cache for two-way lookups of database entities. These are characterized by having a unique key (perhaps a database ID) and a separate unique key that identifies the object.
  * <p>
- * The keys must have good <code>equals</code> and </code>hashCode</code> implementations and
- * must respect the case-sensitivity of the use-case.
+ * The keys must have good <code>equals</code> and </code>hashCode</code> implementations and must respect the case-sensitivity of the use-case.
  * 
  * @author Derek Hulley
  * @since 3.2
@@ -66,11 +64,11 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         entityLookupCacheA = new EntityLookupCache<Long, Object, String>(cache, "A", this);
         entityLookupCacheB = new EntityLookupCache<Long, Object, String>(cache, "B", this);
         database = new TreeMap<Long, String>();
-        
+
         controlDAO = Mockito.mock(ControlDAO.class);
         Mockito.when(controlDAO.createSavepoint(Mockito.anyString())).thenReturn(Mockito.mock(Savepoint.class));
     }
-    
+
     public void testLookupsUsingIncorrectValue() throws Exception
     {
         try
@@ -83,53 +81,53 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
             // Expected
         }
     }
-    
+
     public void testLookupAgainstEmpty() throws Exception
     {
         TestValue value = new TestValue("AAA");
         Pair<Long, Object> entityPair = entityLookupCacheA.getByValue(value);
         assertNull(entityPair);
         assertTrue(database.isEmpty());
-        
+
         // Now do lookup or create
         entityPair = entityLookupCacheA.getOrCreateByValue(value);
         assertNotNull("Expected a value to be found", entityPair);
         Long entityId = entityPair.getFirst();
         assertTrue("Database ID should have been created", database.containsKey(entityId));
         assertEquals("Database value incorrect", value.val, database.get(entityId));
-        
+
         // Do lookup or create again
         entityPair = entityLookupCacheA.getOrCreateByValue(value);
         assertNotNull("Expected a value to be found", entityPair);
         assertEquals("Expected same entity ID", entityId, entityPair.getFirst());
-        
+
         // Look it up using the value
         entityPair = entityLookupCacheA.getByValue(value);
         assertNotNull("Lookup after create should work", entityPair);
-        
+
         // Look it up using the ID
         entityPair = entityLookupCacheA.getByKey(entityId);
         assertNotNull("Lookup by key should work after create", entityPair);
         assertTrue("Looked-up type incorrect", entityPair.getSecond() instanceof TestValue);
         assertEquals("Looked-up type value incorrect", value, entityPair.getSecond());
     }
-    
+
     public void testLookupAgainstExisting() throws Exception
     {
         // Put some values in the "database"
         createValue(new TestValue("AAA"));
         createValue(new TestValue("BBB"));
         createValue(new TestValue("CCC"));
-        
+
         // Look up by value
         Pair<Long, Object> entityPair = entityLookupCacheA.getByValue(new TestValue("AAA"));
         assertNotNull("Expected value to be found", entityPair);
         assertEquals("ID is incorrect", Long.valueOf(1), entityPair.getFirst());
-        
+
         // Look up by ID
         entityPair = entityLookupCacheA.getByKey(Long.valueOf(2));
         assertNotNull("Expected value to be found", entityPair);
-        
+
         // Do lookup or create
         entityPair = entityLookupCacheA.getByValue(new TestValue("CCC"));
         assertNotNull("Expected value to be found", entityPair);
@@ -143,14 +141,14 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertNotNull(entityPairAAA);
         assertEquals("AAA", database.get(entityPairAAA.getFirst()));
         assertEquals(2, cache.getKeys().size());
-        
+
         TestValue valueBBB = new TestValue("BBB");
         Pair<Long, Object> entityPairBBB = entityLookupCacheB.getOrCreateByValue(valueBBB);
         assertNotNull(entityPairBBB);
         assertEquals("BBB", database.get(entityPairBBB.getFirst()));
         assertEquals(4, cache.getKeys().size());
-        
-        // Now cross-check against the caches and make sure that the cache 
+
+        // Now cross-check against the caches and make sure that the cache
         entityPairBBB = entityLookupCacheA.getByValue(valueBBB);
         assertEquals(6, cache.getKeys().size());
         entityPairBBB = entityLookupCacheB.getByValue(valueAAA);
@@ -165,7 +163,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertTrue(database.containsKey(entityPairNull.getFirst()));
         assertNull(database.get(entityPairNull.getFirst()));
         assertEquals(2, cache.getKeys().size());
-        
+
         // Look it up again
         Pair<Long, Object> entityPairCheck = entityLookupCacheA.getOrCreateByValue(valueNull);
         assertNotNull(entityPairNull);
@@ -173,7 +171,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertNull(database.get(entityPairNull.getFirst()));
         assertEquals(entityPairNull, entityPairCheck);
     }
-    
+
     public void testGetOrCreate() throws Exception
     {
         TestValue valueOne = new TestValue(getName() + "-ONE");
@@ -182,12 +180,12 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
         assertEquals(2, cache.getKeys().size());
-        
+
         Pair<Long, Object> entityPairOneCheck = entityLookupCacheA.getOrCreateByValue(valueOne);
         assertNotNull(entityPairOneCheck);
         assertEquals(id, entityPairOneCheck.getFirst());
     }
-    
+
     public void testCreateOrGet() throws Exception
     {
         TestValue valueOne = new TestValue(getName() + "-ONE");
@@ -196,12 +194,12 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
         assertEquals(1, cache.getKeys().size());
-        
+
         Pair<Long, Object> entityPairOneCheck = entityLookupCacheA.createOrGetByValue(valueOne, controlDAO);
         assertNotNull(entityPairOneCheck);
         assertEquals(id, entityPairOneCheck.getFirst());
     }
-    
+
     public void testUpdate() throws Exception
     {
         TestValue valueOne = new TestValue(getName() + "-ONE");
@@ -211,14 +209,14 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
         assertEquals(2, cache.getKeys().size());
-        
+
         // Update
         int updateCount = entityLookupCacheA.updateValue(id, valueTwo);
         assertEquals("Update count was incorrect.", 1, updateCount);
         assertEquals(valueTwo.val, database.get(id));
         assertEquals(2, cache.getKeys().size());
     }
-    
+
     public void testDeleteByKey() throws Exception
     {
         TestValue valueOne = new TestValue(getName() + "-ONE");
@@ -227,14 +225,14 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
         assertEquals(2, cache.getKeys().size());
-        
+
         // Delete
         int deleteCount = entityLookupCacheA.deleteByKey(id);
         assertEquals("Delete count was incorrect.", 1, deleteCount);
         assertNull(database.get(id));
         assertEquals(0, cache.getKeys().size());
     }
-    
+
     public void testDeleteByValue() throws Exception
     {
         TestValue valueOne = new TestValue(getName() + "-ONE");
@@ -243,14 +241,14 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
         assertEquals(2, cache.getKeys().size());
-        
+
         // Delete
         int deleteCount = entityLookupCacheA.deleteByValue(valueOne);
         assertEquals("Delete count was incorrect.", 1, deleteCount);
         assertNull(database.get(id));
         assertEquals(0, cache.getKeys().size());
     }
-    
+
     public void testClear() throws Exception
     {
         TestValue valueOne = new TestValue(getName() + "-ONE");
@@ -259,11 +257,11 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Long id = entityPairOne.getFirst();
         assertEquals(valueOne.val, database.get(id));
         assertEquals(2, cache.getKeys().size());
-        
+
         // Clear it
         entityLookupCacheA.clear();
-        assertEquals(valueOne.val, database.get(id));               // Must still be in database
-        assertEquals(0, cache.getKeys().size());                    // ... but cache must be empty
+        assertEquals(valueOne.val, database.get(id)); // Must still be in database
+        assertEquals(0, cache.getKeys().size()); // ... but cache must be empty
     }
 
     /**
@@ -272,10 +270,12 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     private static class TestValue
     {
         private final String val;
+
         private TestValue(String val)
         {
             this.val = val;
         }
+
         @Override
         public boolean equals(Object obj)
         {
@@ -283,21 +283,22 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
             {
                 return false;
             }
-            return val.equals( ((TestValue)obj).val );
+            return val.equals(((TestValue) obj).val);
         }
+
         @Override
         public int hashCode()
         {
             return val.hashCode();
         }
-        
+
     }
-    
+
     public String getValueKey(Object value)
     {
         assertNotNull(value);
         assertTrue(value instanceof TestValue);
-        String dbValue = ((TestValue)value).val;
+        String dbValue = ((TestValue) value).val;
         return dbValue;
     }
 
@@ -318,7 +319,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     public Pair<Long, Object> findByValue(Object value)
     {
         assertTrue(value == null || value instanceof TestValue);
-        String dbValue = (value == null) ? null : ((TestValue)value).val;
+        String dbValue = (value == null) ? null : ((TestValue) value).val;
 
         for (Map.Entry<Long, String> entry : database.entrySet())
         {
@@ -336,14 +337,14 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     public Pair<Long, Object> createValue(Object value)
     {
         assertTrue(value == null || value instanceof TestValue);
-        String dbValue = (value == null) ? null : ((TestValue)value).val;
-        
+        String dbValue = (value == null) ? null : ((TestValue) value).val;
+
         // Kick out any duplicate values
         if (database.containsValue(dbValue))
         {
             throw new DuplicateKeyException("Value is duplicated: " + value);
         }
-        
+
         // Get the last key
         Long lastKey = database.isEmpty() ? null : database.lastKey();
         Long newKey = null;
@@ -363,7 +364,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     {
         assertNotNull(key);
         assertTrue(value == null || value instanceof TestValue);
-        
+
         // Find it
         Pair<Long, Object> entityPair = findByKey(key);
         if (entityPair == null)
@@ -372,7 +373,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         }
         else
         {
-            database.put(key, ((TestValue)value).val);
+            database.put(key, ((TestValue) value).val);
             return 1;
         }
     }
@@ -380,7 +381,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     public int deleteByKey(Long key)
     {
         assertNotNull(key);
-        
+
         if (database.containsKey(key))
         {
             database.remove(key);
@@ -395,7 +396,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     public int deleteByValue(Object value)
     {
         assertTrue(value == null || value instanceof TestValue);
-        
+
         // Find it
         Pair<Long, Object> entityPair = findByValue(value);
         if (entityPair == null)

--- a/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
+++ b/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
@@ -25,12 +25,15 @@
  */
 package org.alfresco.repo.cache.lookup;
 
+import static org.junit.Assert.*;
+
 import java.sql.Savepoint;
 import java.util.Map;
 import java.util.TreeMap;
 
 import junit.framework.AssertionFailedError;
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.dao.DuplicateKeyException;
 
@@ -49,7 +52,7 @@ import org.alfresco.util.Pair;
  * @author Derek Hulley
  * @since 3.2
  */
-public class EntityLookupCacheTest extends TestCase implements EntityLookupCallbackDAO<Long, Object, String>
+public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Object, String>
 {
     SimpleCache<Long, Object> cache;
     private EntityLookupCache<Long, Object, String> entityLookupCacheA;
@@ -57,7 +60,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
     private TreeMap<Long, String> database;
     private ControlDAO controlDAO;
 
-    @Override
+    @Before
     protected void setUp() throws Exception
     {
         cache = new MemoryCache<Long, Object>();
@@ -69,6 +72,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         Mockito.when(controlDAO.createSavepoint(Mockito.anyString())).thenReturn(Mockito.mock(Savepoint.class));
     }
 
+    @Test
     public void testLookupsUsingIncorrectValue() throws Exception
     {
         try
@@ -82,6 +86,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         }
     }
 
+    @Test
     public void testLookupAgainstEmpty() throws Exception
     {
         TestValue value = new TestValue("AAA");
@@ -112,6 +117,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals("Looked-up type value incorrect", value, entityPair.getSecond());
     }
 
+    @Test
     public void testLookupAgainstExisting() throws Exception
     {
         // Put some values in the "database"
@@ -134,6 +140,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals("ID is incorrect", Long.valueOf(3), entityPair.getFirst());
     }
 
+    @Test
     public void testRegions() throws Exception
     {
         TestValue valueAAA = new TestValue("AAA");
@@ -155,6 +162,7 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(8, cache.getKeys().size());
     }
 
+    @Test
     public void testNullLookups() throws Exception
     {
         TestValue valueNull = null;
@@ -172,9 +180,10 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(entityPairNull, entityPairCheck);
     }
 
+    @Test
     public void testGetOrCreate() throws Exception
     {
-        TestValue valueOne = new TestValue(getName() + "-ONE");
+        TestValue valueOne = new TestValue(getClass().getName() + "-ONE");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.getOrCreateByValue(valueOne);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
@@ -186,9 +195,10 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(id, entityPairOneCheck.getFirst());
     }
 
+    @Test
     public void testCreateOrGet() throws Exception
     {
-        TestValue valueOne = new TestValue(getName() + "-ONE");
+        TestValue valueOne = new TestValue(getClass().getName() + "-ONE");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.createOrGetByValue(valueOne, controlDAO);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
@@ -201,10 +211,11 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(id, entityPairOneCheck.getFirst());
     }
 
+    @Test
     public void testUpdate() throws Exception
     {
-        TestValue valueOne = new TestValue(getName() + "-ONE");
-        TestValue valueTwo = new TestValue(getName() + "-TWO");
+        TestValue valueOne = new TestValue(getClass().getName() + "-ONE");
+        TestValue valueTwo = new TestValue(getClass().getName() + "-TWO");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.getOrCreateByValue(valueOne);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
@@ -218,9 +229,10 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(2, cache.getKeys().size());
     }
 
+    @Test
     public void testDeleteByKey() throws Exception
     {
-        TestValue valueOne = new TestValue(getName() + "-ONE");
+        TestValue valueOne = new TestValue(getClass().getName() + "-ONE");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.getOrCreateByValue(valueOne);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
@@ -234,9 +246,10 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(0, cache.getKeys().size());
     }
 
+    @Test
     public void testDeleteByValue() throws Exception
     {
-        TestValue valueOne = new TestValue(getName() + "-ONE");
+        TestValue valueOne = new TestValue(getClass().getName() + "-ONE");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.getOrCreateByValue(valueOne);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
@@ -250,9 +263,10 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(0, cache.getKeys().size());
     }
 
+    @Test
     public void testClear() throws Exception
     {
-        TestValue valueOne = new TestValue(getName() + "-ONE");
+        TestValue valueOne = new TestValue(getClass().getName() + "-ONE");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.getOrCreateByValue(valueOne);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();
@@ -265,10 +279,11 @@ public class EntityLookupCacheTest extends TestCase implements EntityLookupCallb
         assertEquals(0, cache.getKeys().size()); // ... but cache must be empty
     }
 
+    @Test
     public void testGetCachedValue() throws Exception
     {
         // Create a new value
-        TestValue valueCached = new TestValue(getName() + "-CACHED");
+        TestValue valueCached = new TestValue(getClass().getName() + "-CACHED");
         Pair<Long, Object> entityPairOne = entityLookupCacheA.createOrGetByValue(valueCached, controlDAO);
         assertNotNull(entityPairOne);
         Long id = entityPairOne.getFirst();


### PR DESCRIPTION
* On createOrGetByValue in EntityLookupCache, also cache by value
* Created getCachedEntityByValue that attempt to retrieve the value only from cache
* On attempt to create content URL, first check cache before attempting to create in the database avoiding a duplicate key error