### PR TITLE
Fix/MNT-24571-Site Membership API

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -25,14 +25,14 @@
  */
 package org.alfresco.repo.site;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
 import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.query.CannedQuerySortDetails;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.alfresco.util.Pair;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Conveys information for a member of a site.

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2024 Alfresco Software Limited
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -76,13 +76,8 @@ public class SiteMembership extends AbstractSiteMembership
             throw new java.lang.IllegalArgumentException(
                     "FirstName required building site membership of " + siteInfo.getShortName());
         }
-        if (lastName == null)
-        {
-            throw new java.lang.IllegalArgumentException(
-                    "LastName required building site membership of " + siteInfo.getShortName());
-        }
         this.firstName = firstName;
-        this.lastName = lastName;
+        this.lastName = Optional.ofNullable(lastName).orElse("");
         this.isMemberOfGroup = isMemberOfGroup;
     }
 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -29,10 +29,10 @@ import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.query.CannedQuerySortDetails;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.alfresco.util.Pair;
-import org.apache.commons.lang.StringUtils;
+
 import java.util.Comparator;
 import java.util.List;
-
+import java.util.Optional;
 
 /**
  * Conveys information for a member of a site.
@@ -78,8 +78,7 @@ public class SiteMembership extends AbstractSiteMembership
                     "FirstName required building site membership of " + siteInfo.getShortName());
         }
         this.firstName = firstName;
-       // this.lastName =  Optional.of(lastName).orElse("");
-        this.lastName= StringUtils.isBlank(lastName) ? StringUtils.EMPTY : lastName;
+        this.lastName = Optional.ofNullable(lastName).orElse("");
         this.isMemberOfGroup = isMemberOfGroup;
     }
 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -29,9 +29,9 @@ import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.query.CannedQuerySortDetails;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.alfresco.util.Pair;
-import org.apache.commons.lang.StringUtils;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -78,8 +78,7 @@ public class SiteMembership extends AbstractSiteMembership
                     "FirstName required building site membership of " + siteInfo.getShortName());
         }
         this.firstName = firstName;
-       // this.lastName =  Optional.of(lastName).orElse("");
-        this.lastName= StringUtils.isBlank(lastName) ? StringUtils.EMPTY : lastName;
+        this.lastName =  Optional.of(lastName).orElse("");
         this.isMemberOfGroup = isMemberOfGroup;
     }
 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2014 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -29,10 +29,10 @@ import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.query.CannedQuerySortDetails;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.alfresco.util.Pair;
-
+import org.apache.commons.lang.StringUtils;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
+
 
 /**
  * Conveys information for a member of a site.
@@ -78,7 +78,8 @@ public class SiteMembership extends AbstractSiteMembership
                     "FirstName required building site membership of " + siteInfo.getShortName());
         }
         this.firstName = firstName;
-        this.lastName = Optional.ofNullable(lastName).orElse("");
+       // this.lastName =  Optional.of(lastName).orElse("");
+        this.lastName= StringUtils.isBlank(lastName) ? StringUtils.EMPTY : lastName;
         this.isMemberOfGroup = isMemberOfGroup;
     }
 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -32,6 +32,7 @@ import org.alfresco.util.Pair;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Conveys information for a member of a site.

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -29,10 +29,10 @@ import org.alfresco.api.AlfrescoPublicApi;
 import org.alfresco.query.CannedQuerySortDetails;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.alfresco.util.Pair;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-
 
 /**
  * Conveys information for a member of a site.
@@ -159,7 +159,6 @@ public class SiteMembership extends AbstractSiteMembership
                 + ", firstName=" + firstName + ", lastName=" + lastName + ", role=" + role +
                 ", isMemberOfGroup = " + isMemberOfGroup + "]";
     }
-
 
     static int compareTo(List<Pair<? extends Object, CannedQuerySortDetails.SortOrder>> sortPairs, SiteMembership o1, SiteMembership o2)
     {

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -78,7 +78,7 @@ public class SiteMembership extends AbstractSiteMembership
                     "FirstName required building site membership of " + siteInfo.getShortName());
         }
         this.firstName = firstName;
-        this.lastName = Optional.of(lastName).orElse("");
+        this.lastName = Optional.ofNullable(lastName).orElse("");
         this.isMemberOfGroup = isMemberOfGroup;
     }
 

--- a/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteMembership.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2014 Alfresco Software Limited
+ * Copyright (C) 2005 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 
@@ -53,7 +53,7 @@ public class SiteMembership extends AbstractSiteMembership
     public SiteMembership(SiteInfo siteInfo, String id, String firstName, String lastName,
             String role)
     {
-        super(siteInfo,id, role);
+        super(siteInfo, id, role);
         if (firstName == null)
         {
             throw new java.lang.IllegalArgumentException(
@@ -78,7 +78,7 @@ public class SiteMembership extends AbstractSiteMembership
                     "FirstName required building site membership of " + siteInfo.getShortName());
         }
         this.firstName = firstName;
-        this.lastName =  Optional.of(lastName).orElse("");
+        this.lastName = Optional.of(lastName).orElse("");
         this.isMemberOfGroup = isMemberOfGroup;
     }
 


### PR DESCRIPTION
The Site Membership API fails when the last name is null. This fix addresses the issue to ensure that the API can handle cases where the last name field is missing or null without throwing an error.