### PR TITLE
Revert "Bump dependency.log4j.version from 2.23.1 to 2.24.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
         <dependency.xercesImpl.version>2.12.2</dependency.xercesImpl.version>
         <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
-        <dependency.log4j.version>2.24.2</dependency.log4j.version>
+        <dependency.log4j.version>2.23.1</dependency.log4j.version>
         <dependency.groovy.version>3.0.23</dependency.groovy.version>
         <dependency.tika.version>2.9.2</dependency.tika.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>


### PR DESCRIPTION
It makes enterprise-repository tests fail. See more https://hyland.atlassian.net/browse/ACS-9074