### PR TITLE
ACS-9074 Bump log4j to 2.24.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
         <dependency.xercesImpl.version>2.12.2</dependency.xercesImpl.version>
         <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
-        <dependency.log4j.version>2.23.1</dependency.log4j.version>
+        <dependency.log4j.version>2.24.2</dependency.log4j.version>
         <dependency.groovy.version>3.0.23</dependency.groovy.version>
         <dependency.tika.version>2.9.2</dependency.tika.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>

--- a/repository/src/main/java/org/alfresco/repo/admin/Log4JHierarchyInit.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/Log4JHierarchyInit.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-
 import java.util.Properties;
 
 import org.apache.commons.logging.Log;
@@ -49,21 +48,21 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 
 /**
- * Initialises Log4j's HierarchyDynamicMBean (refer to core-services-context.xml) and any overriding log4.properties files.
- * The actual implementation uses introspection to avoid any hard-coded references to Log4J classes.  If Log4J is
- * not present, this class will do nothing.
+ * Initialises Log4j's HierarchyDynamicMBean (refer to core-services-context.xml) and any overriding log4.properties files. The actual implementation uses introspection to avoid any hard-coded references to Log4J classes. If Log4J is not present, this class will do nothing.
  * <p>
- * Alfresco modules can provide their own log4j2.properties file, which augments/overrides the global log4j2.properties
- * within the Alfresco webapp. Within the module's source tree, suppose you create:
+ * Alfresco modules can provide their own log4j2.properties file, which augments/overrides the global log4j2.properties within the Alfresco webapp. Within the module's source tree, suppose you create:
+ * 
  * <pre>
  *      config/alfresco/module/{module.id}/log4j2.properties
  * </pre>
+ * 
  * At deployment time, this log4j2.properties file will be placed in:
+ * 
  * <pre>
  *      WEB-INF/classes/alfresco/module/{module.id}/log4j2.properties
  * </pre>
- * Where {module.id} is whatever value is set within the AMP's module.properties file. For details, see: <a
- * href='http://wiki.alfresco.com/wiki/Developing_an_Alfresco_Module'>Developing an Alfresco Module</a>
+ * 
+ * Where {module.id} is whatever value is set within the AMP's module.properties file. For details, see: <a href='http://wiki.alfresco.com/wiki/Developing_an_Alfresco_Module'>Developing an Alfresco Module</a>
  * <p>
  * For example, if {module.id} is "org.alfresco.module.someModule", then within your source code you'll have:
  *
@@ -72,6 +71,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  * </pre>
  * <p>
  * This would be deployed to:
+ * 
  * <pre>
  * WEB - INF / classes / alfresco / module / org.alfresco.module.someModule / log4j2.properties
  * </pre>
@@ -82,6 +82,11 @@ public class Log4JHierarchyInit implements ApplicationContextAware
     private final List<String> extraLog4jUrls;
     private ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 
+    static
+    {
+        System.setProperty("log4j2.disableJmx", "false");
+    }
+
     public Log4JHierarchyInit()
     {
         extraLog4jUrls = new ArrayList<>();
@@ -90,8 +95,7 @@ public class Log4JHierarchyInit implements ApplicationContextAware
     /**
      * Loads a set of augmenting/overriding log4j2.properties files from locations specified via an array of Spring URLS.
      * <p>
-     * This function supports Spring's syntax for retrieving multiple class path resources with the same name,
-     * via the "classpath&#042;:" prefix. For details, see: {@link PathMatchingResourcePatternResolver}.
+     * This function supports Spring's syntax for retrieving multiple class path resources with the same name, via the "classpath&#042;:" prefix. For details, see: {@link PathMatchingResourcePatternResolver}.
      */
     public void setExtraLog4jUrls(List<String> urls)
     {

--- a/repository/src/main/java/org/alfresco/repo/admin/Log4JHierarchyInit.java
+++ b/repository/src/main/java/org/alfresco/repo/admin/Log4JHierarchyInit.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2022 Alfresco Software Limited
+ * Copyright (C) 2005 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of


### PR DESCRIPTION
JMX support has been disabled by default in `Log4j 24.0.0` version (See: [Release notes](https://logging.apache.org/log4j/2.x/release-notes.html#_jmx_changes))
Added `log4j2.disableJmx=false` system property in `Log4JHierarchyInit` to enable JMX support.

alfresco-enterprise-repo PR: https://github.com/Alfresco/alfresco-enterprise-repo/pull/2282