### PR TITLE
[APPS-3152] fix for mnt-24137

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/AuditImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/AuditImpl.java
@@ -913,7 +913,7 @@ public class AuditImpl implements Audit
         final String applicationName = auditApplication.getKey().substring(1);
 
         AuditQueryParameters parameters = new AuditQueryParameters();
-        parameters.setApplicationName(applicationName);
+        parameters.setApplicationName(auditApplication.getName());
         parameters.setFromTime(propertyWalker.getFromTime());
         parameters.setToTime(propertyWalker.getToTime());
         parameters.setFromId(propertyWalker.getFromId());

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/AuditImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/AuditImpl.java
@@ -910,10 +910,10 @@ public class AuditImpl implements Audit
 
     public int getAuditEntriesCountByAppAndProperties(AuditService.AuditApplication auditApplication, AuditEntryQueryWalker propertyWalker)
     {
-        final String applicationName = auditApplication.getKey().substring(1);
+        final String applicationName = auditApplication.getName();
 
         AuditQueryParameters parameters = new AuditQueryParameters();
-        parameters.setApplicationName(auditApplication.getName());
+        parameters.setApplicationName(applicationName);
         parameters.setFromTime(propertyWalker.getFromTime());
         parameters.setToTime(propertyWalker.getToTime());
         parameters.setFromId(propertyWalker.getFromId());


### PR DESCRIPTION
https://hyland.atlassian.net/browse/APPS-3129

This issue is happening when appNamePair shortvalue is generated with stringlowercase irrespective of caseSensitive flag, but as per the scenario the appName in audit application is differed by case (Upper vs Lower). 

When its try to get appNamePair for appName its not matching value and its returning null from convertFromRestAuditQueryParameters(parameters) in getAuditEntriesCountByAppAndProperties method in AuditDAOImpl class.

So instead of getting auditEntries by the appKey we are now getting auditEntries by appName it will resolve the issue. Same approch already was there in getAuditEntry method in AuditImpl class.

Tested Scenarios:

1. name="TESTPermissionAudit" key="testpermissionaudit"
2. name="testpermissionaudit" key="testpermissionaudit"
3. name="testpermissionaudit" key="test"
4. name="test" key="testpermissionaudit"

We can’t use same AppName or AppKey for multiple applications which is already validated. 
If we use same AppName or AppKey for multiple applications we are getting exception like org.alfresco.repo.audit.model.AuditModelException: 11200000 Audit application key 'testpermissionaudit' is used by: AuditApplication[ name=TESTPermissionaudit, id=3, disabledPathsId=4]