### PR TITLE
[APPS-3154] fix for number of file field in response

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
@@ -2,7 +2,8 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2024 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
+ *
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
@@ -63,7 +63,6 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
     private TransactionService transactionService;
     private ThreadPoolExecutor threadPoolExecutor;
     private int defaultItems;
-    private int totalFiles;
 
     public void setSearchService(SearchService searchService)
     {
@@ -99,11 +98,6 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
     public void setDefaultItems(int defaultItems)
     {
         this.defaultItems = defaultItems;
-    }
-
-    public int getTotalFiles()
-    {
-        return totalFiles;
     }
 
     @Override
@@ -197,7 +191,7 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
             }
             Date calculationDate = new Date(System.currentTimeMillis());
             NodeSizeDetails nodeSizeDetails = new NodeSizeDetails(nodeRef.getId(), totalSizeFromFacet, calculationDate,
-                    getTotalFiles(),
+                    (int) results.getNumberFound(),
                     STATUS.COMPLETED, jobId);
             return nodeSizeDetails;
         }
@@ -220,8 +214,7 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
             }
             searchParameters.addFacetQuery(FACET_QUERY);
             FieldFacet fieldFacet = new FieldFacet(FIELD_FACET);
-            totalFiles = (int) resultsWithoutFacet.getNumberFound();
-            fieldFacet.setLimitOrNull(totalFiles);
+            fieldFacet.setLimitOrNull((int) resultsWithoutFacet.getNumberFound());
             searchParameters.addFieldFacet(fieldFacet);
             resultsWithoutFacet.close();
             return searchService.query(searchParameters);

--- a/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
@@ -63,6 +63,7 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
     private TransactionService transactionService;
     private ThreadPoolExecutor threadPoolExecutor;
     private int defaultItems;
+    private int totalFiles;
 
     public void setSearchService(SearchService searchService)
     {
@@ -98,6 +99,11 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
     public void setDefaultItems(int defaultItems)
     {
         this.defaultItems = defaultItems;
+    }
+
+    public int getTotalFiles()
+    {
+        return totalFiles;
     }
 
     @Override
@@ -191,8 +197,7 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
             }
             Date calculationDate = new Date(System.currentTimeMillis());
             NodeSizeDetails nodeSizeDetails = new NodeSizeDetails(nodeRef.getId(), totalSizeFromFacet, calculationDate,
-                    results.getNodeRefs()
-                            .size(),
+                                                                  getTotalFiles(),
                     STATUS.COMPLETED, jobId);
             return nodeSizeDetails;
         }
@@ -215,7 +220,8 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
             }
             searchParameters.addFacetQuery(FACET_QUERY);
             FieldFacet fieldFacet = new FieldFacet(FIELD_FACET);
-            fieldFacet.setLimitOrNull((int) resultsWithoutFacet.getNumberFound());
+            totalFiles = (int) resultsWithoutFacet.getNumberFound();
+            fieldFacet.setLimitOrNull(totalFiles);
             searchParameters.addFieldFacet(fieldFacet);
             resultsWithoutFacet.close();
             return searchService.query(searchParameters);

--- a/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
@@ -191,8 +191,8 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
             }
             Date calculationDate = new Date(System.currentTimeMillis());
             NodeSizeDetails nodeSizeDetails = new NodeSizeDetails(nodeRef.getId(), totalSizeFromFacet, calculationDate,
-                    (int) results.getNumberFound(),
-                    STATUS.COMPLETED, jobId);
+                    (int) results.getNumberFound(), STATUS.COMPLETED,
+                    jobId);
             return nodeSizeDetails;
         }
         catch (Exception e)
@@ -395,5 +395,4 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
         }
 
     }
-
 }

--- a/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/sizedetails/NodeSizeDetailsServiceImpl.java
@@ -197,7 +197,7 @@ public class NodeSizeDetailsServiceImpl implements NodeSizeDetailsService, Initi
             }
             Date calculationDate = new Date(System.currentTimeMillis());
             NodeSizeDetails nodeSizeDetails = new NodeSizeDetails(nodeRef.getId(), totalSizeFromFacet, calculationDate,
-                                                                  getTotalFiles(),
+                    getTotalFiles(),
                     STATUS.COMPLETED, jobId);
             return nodeSizeDetails;
         }


### PR DESCRIPTION
https://hyland.atlassian.net/browse/APPS-3154
Here in this ticket, The "numberOfFiles" field in the GET/size-details response does not return accurate data for values exceeding 500.
The root cause appears to be the default limit of 500 in the search parameter when executing size-details for more than 500 files.
To address this issue, I made some changes by taking the value from the "NumberFound" field in the result entity, and it is now working correctly.