### PR TITLE
[PRODSEC-9804] Updated Surf-Webscripts version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency.jackson.version>2.17.2</dependency.jackson.version>
         <dependency.cxf.version>4.0.5</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0-jakarta-1</dependency.opencmis.version>
-        <dependency.webscripts.version>9.4</dependency.webscripts.version>
+        <dependency.webscripts.version>9.5</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.79</dependency.bouncycastle.version>
         <dependency.mockito-core.version>5.14.1</dependency.mockito-core.version>
         <dependency.assertj.version>3.26.3</dependency.assertj.version>


### PR DESCRIPTION
This update migrates the project core from surf-webscripts 9.4 to 9.5 aiming to leverage the new features, security patches and performance improvements. While ensuring capability and optimization of the alfresco-community-repo repository.