### PR TITLE
[fix/MNT-23559-FixForRecordsManagementSearch] Fix for limited 500 items in RecordManagement Search

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/search/RecordsManagementSearchServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/search/RecordsManagementSearchServiceImpl.java
@@ -27,9 +27,16 @@
 
 package org.alfresco.module.org_alfresco_module_rm.search;
 
+import static org.alfresco.module.org_alfresco_module_rm.model.RecordsManagementModel.ASPECT_SAVED_SEARCH;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.extensions.surf.util.I18NUtil;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.model.ContentModel;
@@ -54,12 +61,6 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.util.ISO9075;
 import org.alfresco.util.Pair;
 import org.alfresco.util.ParameterCheck;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.springframework.extensions.surf.util.I18NUtil;
-
-import static org.alfresco.module.org_alfresco_module_rm.model.RecordsManagementModel.ASPECT_SAVED_SEARCH;
 
 /**
  * Records management search service implementation
@@ -79,11 +80,11 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
     /** Search service */
     private SearchService searchService;
 
-	/** Site service */
-	private SiteService siteService;
+    /** Site service */
+    private SiteService siteService;
 
-	/** Namespace service */
-	private NamespaceService namespaceService;
+    /** Namespace service */
+    private NamespaceService namespaceService;
 
     /**
      * Node service
@@ -91,47 +92,52 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
     private NodeService nodeService;
 
     /** List of report details */
-	private List<ReportDetails> reports = new ArrayList<>(13);
+    private List<ReportDetails> reports = new ArrayList<>(13);
 
     /**
      * Records Search Parameters
      */
     private RecordsManagementSearchParameters recordsManagementSearchParameters;
 
-	/**
-	 * @param fileFolderService    file folder service
-	 */
-	public void setFileFolderService(FileFolderService fileFolderService)
+    /**
+     * @param fileFolderService
+     *            file folder service
+     */
+    public void setFileFolderService(FileFolderService fileFolderService)
     {
         this.fileFolderService = fileFolderService;
     }
 
-	/**
-	 * @param searchService    search service
-	 */
-	public void setSearchService(SearchService searchService)
+    /**
+     * @param searchService
+     *            search service
+     */
+    public void setSearchService(SearchService searchService)
     {
         this.searchService = searchService;
     }
 
-	/**
-	 * @param siteService  site service
-	 */
-	public void setSiteService(SiteService siteService)
+    /**
+     * @param siteService
+     *            site service
+     */
+    public void setSiteService(SiteService siteService)
     {
         this.siteService = siteService;
     }
 
-	/**
-	 * @param namespaceService namespace service
-	 */
-	public void setNamespaceService(NamespaceService namespaceService)
+    /**
+     * @param namespaceService
+     *            namespace service
+     */
+    public void setNamespaceService(NamespaceService namespaceService)
     {
         this.namespaceService = namespaceService;
     }
 
     /**
-     * @param nodeService Node service
+     * @param nodeService
+     *            Node service
      */
     public void setNodeService(NodeService nodeService)
     {
@@ -139,62 +145,62 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
     }
 
     /**
-	 * @param reportsJSON
-	 */
-	public void setReportsJSON(String reportsJSON)
+     * @param reportsJSON
+     */
+    public void setReportsJSON(String reportsJSON)
     {
-	    try
-	    {
-    	   JSONArray jsonArray = new JSONArray(reportsJSON);
-           for (int i=0; i < jsonArray.length(); i++)
-           {
-               JSONObject report = jsonArray.getJSONObject(i);
+        try
+        {
+            JSONArray jsonArray = new JSONArray(reportsJSON);
+            for (int i = 0; i < jsonArray.length(); i++)
+            {
+                JSONObject report = jsonArray.getJSONObject(i);
 
-               // Get the name
-               if (!report.has(SavedSearchDetails.NAME))
-               {
-                   throw new AlfrescoRuntimeException("Unable to load report details because name has not been specified. \n" + reportsJSON);
-               }
-               String name = report.getString(SavedSearchDetails.NAME);
-               String translatedName = I18NUtil.getMessage(name);
-               if (translatedName != null)
-               {
-                   name = translatedName;
-               }
+                // Get the name
+                if (!report.has(SavedSearchDetails.NAME))
+                {
+                    throw new AlfrescoRuntimeException("Unable to load report details because name has not been specified. \n" + reportsJSON);
+                }
+                String name = report.getString(SavedSearchDetails.NAME);
+                String translatedName = I18NUtil.getMessage(name);
+                if (translatedName != null)
+                {
+                    name = translatedName;
+                }
 
-               // Get the query
-               if (!report.has(SavedSearchDetails.SEARCH))
-               {
-                   throw new AlfrescoRuntimeException("Unable to load report details because search has not been specified for report " + name + ". \n" + reportsJSON);
-               }
-               String query = report.getString(SavedSearchDetails.SEARCH);
+                // Get the query
+                if (!report.has(SavedSearchDetails.SEARCH))
+                {
+                    throw new AlfrescoRuntimeException("Unable to load report details because search has not been specified for report " + name + ". \n" + reportsJSON);
+                }
+                String query = report.getString(SavedSearchDetails.SEARCH);
 
-               // Get the description
-               String description = "";
-               if (report.has(SavedSearchDetails.DESCRIPTION))
-               {
-                   description = report.getString(SavedSearchDetails.DESCRIPTION);
-                   String translatedDescription = I18NUtil.getMessage(description);
-                   if (translatedDescription != null)
-                   {
-                       description = translatedDescription;
-                   }
-               }
+                // Get the description
+                String description = "";
+                if (report.has(SavedSearchDetails.DESCRIPTION))
+                {
+                    description = report.getString(SavedSearchDetails.DESCRIPTION);
+                    String translatedDescription = I18NUtil.getMessage(description);
+                    if (translatedDescription != null)
+                    {
+                        description = translatedDescription;
+                    }
+                }
 
-               if (report.has("searchparams"))
-               {
-                   recordsManagementSearchParameters = RecordsManagementSearchParameters.createFromJSON(report.getJSONObject("searchparams"), namespaceService);
-               }
+                if (report.has("searchparams"))
+                {
+                    recordsManagementSearchParameters = RecordsManagementSearchParameters.createFromJSON(report.getJSONObject("searchparams"), namespaceService);
+                }
 
-               // Create the report details and add to list
-               ReportDetails reportDetails = new ReportDetails(name, description, query, recordsManagementSearchParameters);
-               reports.add(reportDetails);
-           }
-	    }
-	    catch (JSONException exception)
-	    {
-	        throw new AlfrescoRuntimeException("Unable to load report details.\n" + reportsJSON, exception);
-	    }
+                // Create the report details and add to list
+                ReportDetails reportDetails = new ReportDetails(name, description, query, recordsManagementSearchParameters);
+                reports.add(reportDetails);
+            }
+        }
+        catch (JSONException exception)
+        {
+            throw new AlfrescoRuntimeException("Unable to load report details.\n" + reportsJSON, exception);
+        }
     }
 
     /**
@@ -207,31 +213,35 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
         this.recordsManagementSearchParameters = recordsManagementSearchParameters;
     }
 
-	/**
-	 * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#search(java.lang.String, java.lang.String, org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchParameters)
-	 */
+    /**
+     * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#search(java.lang.String, java.lang.String, org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchParameters)
+     */
     @Override
     public List<Pair<NodeRef, NodeRef>> search(String siteId, String query, RecordsManagementSearchParameters rmSearchParameters)
     {
         // build the full RM query
         StringBuilder fullQuery = new StringBuilder(1024);
         fullQuery.append("PATH:\"")
-                 .append(SITES_SPACE_QNAME_PATH)
-                 .append("cm:").append(ISO9075.encode(siteId)).append("/cm:documentLibrary//*\"")
-                 .append(" AND (")
-                 .append(buildQueryString(query, rmSearchParameters))
-                 .append(")");
+                .append(SITES_SPACE_QNAME_PATH)
+                .append("cm:").append(ISO9075.encode(siteId)).append("/cm:documentLibrary//*\"")
+                .append(" AND (")
+                .append(buildQueryString(query, rmSearchParameters))
+                .append(")");
 
         // create the search parameters
         SearchParameters searchParameters = new SearchParameters();
         searchParameters.setQuery(fullQuery.toString());
         searchParameters.setLanguage(SearchService.LANGUAGE_FTS_ALFRESCO);
         searchParameters.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
-        searchParameters.setMaxItems(recordsManagementSearchParameters.getMaxItems());
+        int maxItems = rmSearchParameters.getMaxItems();
+        if (maxItems > 0)
+        {
+            searchParameters.setMaxItems(maxItems);
+        }
         searchParameters.setNamespace(RecordsManagementModel.RM_URI);
 
         // set sort
-        for(SortItem entry : rmSearchParameters.getSortOrder())
+        for (SortItem entry : rmSearchParameters.getSortOrder())
         {
             searchParameters.addSort(entry.property.toPrefixString(namespaceService), entry.assc);
         }
@@ -244,12 +254,12 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
 
         // execute query
         ResultSet resultSet = searchService.query(searchParameters);
-        
+
         // process results
         List<Pair<NodeRef, NodeRef>> result = new ArrayList<>(resultSet.length());
         for (ChildAssociationRef childAssoc : resultSet.getChildAssocRefs())
         {
-        	result.add(new Pair<>(childAssoc.getParentRef(), childAssoc.getChildRef()));
+            result.add(new Pair<>(childAssoc.getParentRef(), childAssoc.getChildRef()));
         }
 
         // return results
@@ -263,98 +273,98 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
      * @param types
      * @return
      */
-    /*package*/ String buildQueryString(String queryTerm, RecordsManagementSearchParameters searchParameters)
+    /* package */ String buildQueryString(String queryTerm, RecordsManagementSearchParameters searchParameters)
     {
-       StringBuilder aspectQuery = new StringBuilder();
-       if (searchParameters.isIncludeRecords())
-       {
-           appendAspect(aspectQuery, "rma:record");
-           if (!searchParameters.isIncludeUndeclaredRecords())
-           {
-               appendAspect(aspectQuery, "rma:declaredRecord");
-           }
-           if (searchParameters.isIncludeVitalRecords())
-           {
-               appendAspect(aspectQuery, "rma:vitalRecord");
-           }
-       }
+        StringBuilder aspectQuery = new StringBuilder();
+        if (searchParameters.isIncludeRecords())
+        {
+            appendAspect(aspectQuery, "rma:record");
+            if (!searchParameters.isIncludeUndeclaredRecords())
+            {
+                appendAspect(aspectQuery, "rma:declaredRecord");
+            }
+            if (searchParameters.isIncludeVitalRecords())
+            {
+                appendAspect(aspectQuery, "rma:vitalRecord");
+            }
+        }
 
-       StringBuilder typeQuery = new StringBuilder();
-       if (searchParameters.isIncludeRecordFolders())
-       {
-           appendType(typeQuery, "rma:recordFolder");
-       }
-       List<QName> includedContainerTypes = searchParameters.getIncludedContainerTypes();
-       if (includedContainerTypes != null && includedContainerTypes.size() != 0)
-       {
-           for (QName includedContainerType : includedContainerTypes)
-           {
-               appendType(typeQuery, includedContainerType.toPrefixString(namespaceService));
-           }
-       }
+        StringBuilder typeQuery = new StringBuilder();
+        if (searchParameters.isIncludeRecordFolders())
+        {
+            appendType(typeQuery, "rma:recordFolder");
+        }
+        List<QName> includedContainerTypes = searchParameters.getIncludedContainerTypes();
+        if (includedContainerTypes != null && includedContainerTypes.size() != 0)
+        {
+            for (QName includedContainerType : includedContainerTypes)
+            {
+                appendType(typeQuery, includedContainerType.toPrefixString(namespaceService));
+            }
+        }
 
-       StringBuilder query = new StringBuilder();
-       if (queryTerm == null || queryTerm.length() == 0)
-       {
-           // Default to search for everything
-           query.append("ISNODE:T");
-       }
-       else
-       {
-           if (isComplexQueryTerm(queryTerm))
-           {
-               query.append(queryTerm);
-           }
-           else
-           {
-               query.append("keywords:\"" + queryTerm + "\"");
-           }
-       }
+        StringBuilder query = new StringBuilder();
+        if (queryTerm == null || queryTerm.length() == 0)
+        {
+            // Default to search for everything
+            query.append("ISNODE:T");
+        }
+        else
+        {
+            if (isComplexQueryTerm(queryTerm))
+            {
+                query.append(queryTerm);
+            }
+            else
+            {
+                query.append("keywords:\"" + queryTerm + "\"");
+            }
+        }
 
-       StringBuilder fullQuery = new StringBuilder(1024);
-       if (aspectQuery.length() != 0 || typeQuery.length() != 0)
-       {
-           if (aspectQuery.length() != 0 && typeQuery.length() != 0)
-           {
-               fullQuery.append("(");
-           }
+        StringBuilder fullQuery = new StringBuilder(1024);
+        if (aspectQuery.length() != 0 || typeQuery.length() != 0)
+        {
+            if (aspectQuery.length() != 0 && typeQuery.length() != 0)
+            {
+                fullQuery.append("(");
+            }
 
-           if (aspectQuery.length() != 0)
-           {
-               fullQuery.append("(").append(aspectQuery).append(") ");
-           }
+            if (aspectQuery.length() != 0)
+            {
+                fullQuery.append("(").append(aspectQuery).append(") ");
+            }
 
-           if (typeQuery.length() != 0)
-           {
-               fullQuery.append("(").append(typeQuery).append(")");
-           }
+            if (typeQuery.length() != 0)
+            {
+                fullQuery.append("(").append(typeQuery).append(")");
+            }
 
-           if (aspectQuery.length() != 0 && typeQuery.length() != 0)
-           {
-               fullQuery.append(")");
-           }
-       }
+            if (aspectQuery.length() != 0 && typeQuery.length() != 0)
+            {
+                fullQuery.append(")");
+            }
+        }
 
-       if (searchParameters.isIncludeFrozen())
-       {
-           appendAspect(fullQuery, "rma:frozen");
-       }
-       else
-       {
-           appendNotAspect(fullQuery, "rma:frozen");
-       }
-       if (searchParameters.isIncludeCutoff())
-       {
-           appendAspect(fullQuery, "rma:cutOff");
-       }
+        if (searchParameters.isIncludeFrozen())
+        {
+            appendAspect(fullQuery, "rma:frozen");
+        }
+        else
+        {
+            appendNotAspect(fullQuery, "rma:frozen");
+        }
+        if (searchParameters.isIncludeCutoff())
+        {
+            appendAspect(fullQuery, "rma:cutOff");
+        }
 
-       if (fullQuery.length() != 0)
-       {
-           fullQuery.append(" AND ");
-       }
-       fullQuery.append(query).append(" AND NOT ASPECT:\"rma:versionedRecord\"");
+        if (fullQuery.length() != 0)
+        {
+            fullQuery.append(" AND ");
+        }
+        fullQuery.append(query).append(" AND NOT ASPECT:\"rma:versionedRecord\"");
 
-       return fullQuery.toString();
+        return fullQuery.toString();
     }
 
     private boolean isComplexQueryTerm(String query)
@@ -440,8 +450,11 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
 
     /**
      * Add the search details to the list.
-     * @param searches      list of search details
-     * @param searchNode    search node
+     * 
+     * @param searches
+     *            list of search details
+     * @param searchNode
+     *            search node
      */
     private void addSearchDetailsToList(List<SavedSearchDetails> searches, NodeRef searchNode)
     {
@@ -482,38 +495,37 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
     /**
      * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#saveSearch(String, String, String, String, RecordsManagementSearchParameters, boolean)
      */
-	@Override
-	public SavedSearchDetails saveSearch(String siteId, String name, String description, String query, RecordsManagementSearchParameters searchParameters, boolean isPublic)
-	{
-	    // Check for mandatory parameters
-	    ParameterCheck.mandatory("siteId", siteId);
-	    ParameterCheck.mandatory("name", name);
-	    ParameterCheck.mandatory("query", query);
-	    ParameterCheck.mandatory("searchParameters", searchParameters);
+    @Override
+    public SavedSearchDetails saveSearch(String siteId, String name, String description, String query, RecordsManagementSearchParameters searchParameters, boolean isPublic)
+    {
+        // Check for mandatory parameters
+        ParameterCheck.mandatory("siteId", siteId);
+        ParameterCheck.mandatory("name", name);
+        ParameterCheck.mandatory("query", query);
+        ParameterCheck.mandatory("searchParameters", searchParameters);
 
         // Create saved search details
         SavedSearchDetails savedSearchDetails = new SavedSearchDetails(siteId, name, description, query, searchParameters, isPublic, false, namespaceService, this);
 
         // Save search details
         return saveSearch(savedSearchDetails);
-	}
+    }
 
-	/**
-	 * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#saveSearch(org.alfresco.module.org_alfresco_module_rm.search.SavedSearchDetails)
-	 */
-	@Override
-	public SavedSearchDetails saveSearch(final SavedSearchDetails savedSearchDetails)
+    /**
+     * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#saveSearch(org.alfresco.module.org_alfresco_module_rm.search.SavedSearchDetails)
+     */
+    @Override
+    public SavedSearchDetails saveSearch(final SavedSearchDetails savedSearchDetails)
     {
-	    // Check for mandatory parameters
-	    ParameterCheck.mandatory("savedSearchDetails", savedSearchDetails);
+        // Check for mandatory parameters
+        ParameterCheck.mandatory("savedSearchDetails", savedSearchDetails);
 
-	    // Get the root saved search container
-	    final String siteId = savedSearchDetails.getSiteId();
-	    NodeRef container = siteService.getContainer(siteId, SEARCH_CONTAINER);
+        // Get the root saved search container
+        final String siteId = savedSearchDetails.getSiteId();
+        NodeRef container = siteService.getContainer(siteId, SEARCH_CONTAINER);
         if (container == null)
         {
-            container = AuthenticationUtil.runAs(new RunAsWork<NodeRef>()
-            {
+            container = AuthenticationUtil.runAs(new RunAsWork<NodeRef>() {
                 @Override
                 public NodeRef doWork()
                 {
@@ -530,8 +542,7 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
             if (userContainer == null)
             {
                 final NodeRef parentContainer = container;
-                userContainer = AuthenticationUtil.runAs(new RunAsWork<NodeRef>()
-                {
+                userContainer = AuthenticationUtil.runAs(new RunAsWork<NodeRef>() {
                     @Override
                     public NodeRef doWork()
                     {
@@ -547,8 +558,7 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
         if (searchNode == null)
         {
             final NodeRef searchContainer = container;
-            searchNode = AuthenticationUtil.runAs(new RunAsWork<NodeRef>()
-            {
+            searchNode = AuthenticationUtil.runAs(new RunAsWork<NodeRef>() {
                 @Override
                 public NodeRef doWork()
                 {
@@ -559,8 +569,7 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
         nodeService.addAspect(searchNode, ASPECT_SAVED_SEARCH, null);
         // Write the JSON content to search node
         final NodeRef writableSearchNode = searchNode;
-        AuthenticationUtil.runAs(new RunAsWork<Void>()
-        {
+        AuthenticationUtil.runAs(new RunAsWork<Void>() {
             @Override
             public Void doWork()
             {
@@ -576,27 +585,27 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
         return savedSearchDetails;
     }
 
-	/**
-	 * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#deleteSavedSearch(java.lang.String, java.lang.String)
-	 */
-	@Override
-	public void deleteSavedSearch(String siteId, String name)
-	{
-	    // Check parameters
-	    ParameterCheck.mandatory("siteId", siteId);
-	    ParameterCheck.mandatory("name", name);
+    /**
+     * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#deleteSavedSearch(java.lang.String, java.lang.String)
+     */
+    @Override
+    public void deleteSavedSearch(String siteId, String name)
+    {
+        // Check parameters
+        ParameterCheck.mandatory("siteId", siteId);
+        ParameterCheck.mandatory("name", name);
 
-	    // Get the search node for the saved query
+        // Get the search node for the saved query
         NodeRef searchNode = getSearchNodeRef(siteId, name);
         if (searchNode != null && fileFolderService.exists(searchNode))
         {
             fileFolderService.delete(searchNode);
         }
-	}
+    }
 
-	/**
-	 * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#deleteSavedSearch(org.alfresco.module.org_alfresco_module_rm.search.SavedSearchDetails)
-	 */
+    /**
+     * @see org.alfresco.module.org_alfresco_module_rm.search.RecordsManagementSearchService#deleteSavedSearch(org.alfresco.module.org_alfresco_module_rm.search.SavedSearchDetails)
+     */
     @Override
     public void deleteSavedSearch(SavedSearchDetails savedSearchDetails)
     {
@@ -609,9 +618,12 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
 
     /**
      * Get the saved search node reference.
-     * @param siteId    site id
-     * @param name      search name
-     * @return {@link NodeRef}  search node reference
+     * 
+     * @param siteId
+     *            site id
+     * @param name
+     *            search name
+     * @return {@link NodeRef} search node reference
      */
     private NodeRef getSearchNodeRef(String siteId, String name)
     {
@@ -649,15 +661,15 @@ public class RecordsManagementSearchServiceImpl implements RecordsManagementSear
         {
             // Create saved search details
             SavedSearchDetails savedSearchDetails = new SavedSearchDetails(
-                                                            siteId,
-                                                            report.getName(),
-                                                            report.getDescription(),
-                                                            report.getSearch(),
-                                                            report.getSearchParameters(),
-                                                            true,
-                                                            true,
-                                                            namespaceService,
-                                                            this);
+                    siteId,
+                    report.getName(),
+                    report.getDescription(),
+                    report.getSearch(),
+                    report.getSearchParameters(),
+                    true,
+                    true,
+                    namespaceService,
+                    this);
 
             // Save search details
             saveSearch(savedSearchDetails);


### PR DESCRIPTION
https://hyland.atlassian.net/browse/MNT-23559

**[Concern]** When performing a records search on the RM site, the number of results returned is limited to a maximum of 500 items.

**[Solution]** As per the implementation, it retrieves a static value from the property file, which is why it is restricted to 500 items. However, upon reviewing the code, I noticed that the same method is being called from RMSearchGet, where we have the privilege to set a custom maximum number of items. Therefore, instead of using the default value from the property file, we are now setting the value from the caller method's arguments.