### PR TITLE
ACS 9185 implement rest api for reauthorizing a single user

### DIFF
--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestAuthCodeModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestAuthCodeModel.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * alfresco-tas-restapi
+ * %%
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.alfresco.utility.model.TestModel;
+
+/**
+ * Authorization code implementation
+ */
+public class RestAuthCodeModel extends TestModel
+{
+    @JsonProperty
+    private String authorizationCode;
+
+    public String getAuthorizationCode()
+    {
+        return authorizationCode;
+    }
+
+    public void setAuthorizationCode(String authorizationCode)
+    {
+        this.authorizationCode = authorizationCode;
+    }
+}

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestAuthKeyModel.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/model/RestAuthKeyModel.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * alfresco-tas-restapi
+ * %%
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.alfresco.utility.model.TestModel;
+
+/**
+ * Authorization key implementation
+ */
+public class RestAuthKeyModel extends TestModel
+{
+    @JsonProperty(required = true)
+    private String authorizationKey;
+
+    public String getAuthorizationKey()
+    {
+        return authorizationKey;
+    }
+
+    public void setAuthorizationKey(String authorizationKey)
+    {
+        this.authorizationKey = authorizationKey;
+    }
+}

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/People.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/People.java
@@ -454,7 +454,7 @@ public class People extends ModelRequest<People>
     public void reauthorizeUser(RestAuthKeyModel authKey)
     {
         var request = RestRequest.requestWithBody(HttpMethod.POST, authKey.toJson(), "people/{personId}/reauthorize", this.person.getUsername());
-        restWrapper.process(request);
+        restWrapper.processEmptyModel(request);
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/People.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/People.java
@@ -42,6 +42,7 @@ import org.alfresco.rest.core.RestWrapper;
 import org.alfresco.rest.exception.EmptyJsonResponseException;
 import org.alfresco.rest.exception.JsonToModelConversionException;
 import org.alfresco.rest.model.RestActivityModelsCollection;
+import org.alfresco.rest.model.RestAuthKeyModel;
 import org.alfresco.rest.model.RestFavoriteSiteModel;
 import org.alfresco.rest.model.RestGroupsModelsCollection;
 import org.alfresco.rest.model.RestNetworkModel;
@@ -444,6 +445,15 @@ public class People extends ModelRequest<People>
     {
         RestRequest request = RestRequest.simpleRequest(HttpMethod.POST, "people/{personId}/deauthorize", this.person.getUsername(), restWrapper.getParameters());
         restWrapper.processEmptyModel(request);
+    }
+
+    /**
+     * Reauthorizes a user.
+     */
+    public void reauthorizeUser(RestAuthKeyModel authKey)
+    {
+        var request = RestRequest.requestWithBody(HttpMethod.POST, authKey.toJson(), "people/{personId}/reauthorize", this.person.getUsername());
+        restWrapper.process(request);
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/People.java
+++ b/packaging/tests/tas-restapi/src/main/java/org/alfresco/rest/requests/People.java
@@ -42,6 +42,7 @@ import org.alfresco.rest.core.RestWrapper;
 import org.alfresco.rest.exception.EmptyJsonResponseException;
 import org.alfresco.rest.exception.JsonToModelConversionException;
 import org.alfresco.rest.model.RestActivityModelsCollection;
+import org.alfresco.rest.model.RestAuthCodeModel;
 import org.alfresco.rest.model.RestAuthKeyModel;
 import org.alfresco.rest.model.RestFavoriteSiteModel;
 import org.alfresco.rest.model.RestGroupsModelsCollection;
@@ -454,6 +455,22 @@ public class People extends ModelRequest<People>
     {
         var request = RestRequest.requestWithBody(HttpMethod.POST, authKey.toJson(), "people/{personId}/reauthorize", this.person.getUsername());
         restWrapper.process(request);
+    }
+
+    /**
+     * Get the reauthorization code.
+     */
+    public RestAuthCodeModel getReauthorizationCode()
+    {
+        var request = RestRequest.simpleRequest(HttpMethod.POST, "people/{personId}/reauthorization-code", this.person.getUsername());
+        try
+        {
+            return restWrapper.processModel(RestAuthCodeModel.class, request);
+        }
+        catch (JsonToModelConversionException | EmptyJsonResponseException e)
+        {
+            return null;
+        }
     }
 
     /**

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/people/deauthorization/community/ReauthorizeSanityTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/people/deauthorization/community/ReauthorizeSanityTests.java
@@ -46,4 +46,20 @@ public class ReauthorizeSanityTests extends RestTest
         // then
         restClient.assertStatusCodeIs(HttpStatus.NOT_IMPLEMENTED);
     }
+
+    @Test(groups = {TestGroup.REST_API, TestGroup.PEOPLE, TestGroup.SANITY})
+    @TestRail(section = {TestGroup.REST_API, TestGroup.PEOPLE}, executionType = ExecutionType.SANITY,
+            description = "Check if the reauthorization code is not implemented in Community Edition")
+    public void reauthorizationCodeIsNotImplementedInCommunityEdition()
+    {
+        // when admin invokes API
+        restClient.authenticateUser(adminUser).withCoreAPI().usingUser(userModel).getReauthorizationCode();
+        // then
+        restClient.assertStatusCodeIs(HttpStatus.NOT_IMPLEMENTED);
+
+        // when user invokes API
+        restClient.authenticateUser(userModel).withCoreAPI().usingUser(userModel).getReauthorizationCode();
+        // then
+        restClient.assertStatusCodeIs(HttpStatus.NOT_IMPLEMENTED);
+    }
 }

--- a/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/people/deauthorization/community/ReauthorizeSanityTests.java
+++ b/packaging/tests/tas-restapi/src/test/java/org/alfresco/rest/people/deauthorization/community/ReauthorizeSanityTests.java
@@ -1,0 +1,49 @@
+package org.alfresco.rest.people.deauthorization.community;
+
+import org.springframework.http.HttpStatus;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.alfresco.rest.RestTest;
+import org.alfresco.rest.model.RestAuthKeyModel;
+import org.alfresco.utility.model.TestGroup;
+import org.alfresco.utility.model.UserModel;
+import org.alfresco.utility.testrail.ExecutionType;
+import org.alfresco.utility.testrail.annotation.TestRail;
+
+/**
+ * Verifies API behavior in community edition. Should be excluded in enterprise edition.
+ */
+@Test
+public class ReauthorizeSanityTests extends RestTest
+{
+    private UserModel userModel;
+    private UserModel adminUser;
+
+    @BeforeClass(alwaysRun = true)
+    public void dataPreparation()
+    {
+        adminUser = dataUser.getAdminUser();
+        userModel = dataUser.createRandomTestUser();
+    }
+
+    @Test(groups = {TestGroup.REST_API, TestGroup.PEOPLE, TestGroup.SANITY})
+    @TestRail(section = {TestGroup.REST_API, TestGroup.PEOPLE}, executionType = ExecutionType.SANITY,
+            description = "Check if reauthorization is not implemented in Community Edition")
+    public void reauthorizationIsNotImplementedInCommunityEdition()
+    {
+        // given
+        var key = new RestAuthKeyModel();
+        key.setAuthorizationKey("am9obnRlc3RAMTIzNDU=");
+
+        // when admin invokes API
+        restClient.authenticateUser(adminUser).withCoreAPI().usingUser(userModel).reauthorizeUser(key);
+        // then
+        restClient.assertStatusCodeIs(HttpStatus.NOT_IMPLEMENTED);
+
+        // when user invokes API
+        restClient.authenticateUser(userModel).withCoreAPI().usingUser(userModel).reauthorizeUser(key);
+        // then
+        restClient.assertStatusCodeIs(HttpStatus.NOT_IMPLEMENTED);
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/AuthCode.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/AuthCode.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.api.model;
+
+/**
+ * An object representing user authorization code.
+ */
+public class AuthCode
+{
+    private String authorizationCode;
+
+    public AuthCode()
+    {}
+
+    public AuthCode(String authorizationCode)
+    {
+        this.authorizationCode = authorizationCode;
+    }
+
+    public String getAuthorizationCode()
+    {
+        return authorizationCode;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AuthCode[" +
+                "authorizationCode='" + authorizationCode + '\'' +
+                ']';
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/AuthCode.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/AuthCode.java
@@ -28,28 +28,5 @@ package org.alfresco.rest.api.model;
 /**
  * An object representing user authorization code.
  */
-public class AuthCode
-{
-    private String authorizationCode;
-
-    public AuthCode()
-    {}
-
-    public AuthCode(String authorizationCode)
-    {
-        this.authorizationCode = authorizationCode;
-    }
-
-    public String getAuthorizationCode()
-    {
-        return authorizationCode;
-    }
-
-    @Override
-    public String toString()
-    {
-        return "AuthCode[" +
-                "authorizationCode='" + authorizationCode + '\'' +
-                ']';
-    }
-}
+public record AuthCode(String authorizationCode)
+{}

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/AuthKey.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/AuthKey.java
@@ -4,54 +4,40 @@
  * %%
  * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
 package org.alfresco.rest.api.model;
 
-import org.apache.commons.lang3.StringUtils;
+import static org.apache.commons.lang3.StringUtils.length;
 
 /**
  * An object representing user authorization key request body.
  */
-public class AuthKey
+public record AuthKey(String authorizationKey)
 {
-    private String authorizationKey;
-
-    public AuthKey()
-    {}
-
-    public AuthKey(String authorizationKey)
-    {
-        this.authorizationKey = authorizationKey;
-    }
-
-    public String getAuthorizationKey()
-    {
-        return authorizationKey;
-    }
-
     @Override
     public String toString()
     {
+        // for security reasons the key content should be never logged
         return "AuthKey[" +
-                "authorizationKeyLength='" + StringUtils.length(authorizationKey) + '\'' +
+                "authorizationKeyLength=" + length(authorizationKey) +
                 ']';
     }
 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/AuthKey.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/AuthKey.java
@@ -1,0 +1,57 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software. 
+ * If the software was purchased under a paid Alfresco license, the terms of 
+ * the paid license agreement will prevail.  Otherwise, the software is 
+ * provided under the following open source license terms:
+ * 
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.rest.api.model;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * An object representing user authorization key request body.
+ */
+public class AuthKey
+{
+    private String authorizationKey;
+
+    public AuthKey()
+    {}
+
+    public AuthKey(String authorizationKey)
+    {
+        this.authorizationKey = authorizationKey;
+    }
+
+    public String getAuthorizationKey()
+    {
+        return authorizationKey;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AuthKey[" +
+                "authorizationKeyLength='" + StringUtils.length(authorizationKey) + '\'' +
+                ']';
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/rest/api/people/PeopleEntityResource.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/people/PeopleEntityResource.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.rest.api.People;
+import org.alfresco.rest.api.model.AuthCode;
 import org.alfresco.rest.api.model.AuthKey;
 import org.alfresco.rest.api.model.Client;
 import org.alfresco.rest.api.model.PasswordReset;
@@ -245,6 +246,19 @@ public class PeopleEntityResource implements EntityResourceAction.ReadById<Perso
     public void deauthorizeUser(String personId, Void body, Parameters parameters, WithResponse withResponse)
     {
         // functionality is not implemented in community edition
+    }
+
+    /**
+     * Get the authorization code.
+     *
+     * Not supported in community edition.
+     */
+    @Operation("reauthorization-code")
+    @WebApiDescription(title = "Get the reauthorization code", description = "Get the reauthorization code", successStatus = HttpServletResponse.SC_NOT_IMPLEMENTED)
+    public AuthCode getReauthorizationCode(String personId, Void body, Parameters parameters, WithResponse withResponse)
+    {
+        // functionality is not implemented in community edition
+        return null;
     }
 
     /**

--- a/remote-api/src/main/java/org/alfresco/rest/api/people/PeopleEntityResource.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/people/PeopleEntityResource.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.rest.api.People;
+import org.alfresco.rest.api.model.AuthKey;
 import org.alfresco.rest.api.model.Client;
 import org.alfresco.rest.api.model.PasswordReset;
 import org.alfresco.rest.api.model.Person;
@@ -242,6 +243,18 @@ public class PeopleEntityResource implements EntityResourceAction.ReadById<Perso
     @Operation("deauthorize")
     @WebApiDescription(title = "De-authorize user", description = "Performs user de-authorization", successStatus = HttpServletResponse.SC_NOT_IMPLEMENTED)
     public void deauthorizeUser(String personId, Void body, Parameters parameters, WithResponse withResponse)
+    {
+        // functionality is not implemented in community edition
+    }
+
+    /**
+     * Reauthorize user.
+     *
+     * Not supported in community edition.
+     */
+    @Operation("reauthorize")
+    @WebApiDescription(title = "Reauthorize user", description = "Performs user reauthorization", successStatus = HttpServletResponse.SC_NOT_IMPLEMENTED)
+    public void reauthorizeUser(String personId, AuthKey authKey, Parameters parameters, WithResponse withResponse)
     {
         // functionality is not implemented in community edition
     }


### PR DESCRIPTION
Implementation according to https://github.com/Alfresco/rest-api-explorer/pull/222

In community edition endpoins return `HTTP 501 Not implemented`