### PR TITLE
ACS-9199 Bump subethasmtp version to 7.1.3

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1377,7 +1377,7 @@
         "filename": "repository/src/test/java/org/alfresco/repo/imap/ImapMessageTest.java",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 116,
         "is_secret": false
       }
     ],
@@ -1868,5 +1868,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-11T13:28:51Z"
+  "generated_at": "2025-02-18T15:50:35Z"
 }

--- a/amps/ags/rm-community/rm-community-repo/pom.xml
+++ b/amps/ags/rm-community/rm-community-repo/pom.xml
@@ -566,7 +566,6 @@
                            </build>
                         </image>
                      </images>
-                      <verbose>true</verbose>
                   </configuration>
                   <executions>
                      <execution>

--- a/amps/ags/rm-community/rm-community-repo/pom.xml
+++ b/amps/ags/rm-community/rm-community-repo/pom.xml
@@ -64,10 +64,6 @@
          <artifactId>jakarta.servlet-api</artifactId>
       </dependency>
       <dependency>
-         <groupId>jakarta.mail</groupId>
-         <artifactId>jakarta.mail-api</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.alfresco.surf</groupId>
          <artifactId>spring-webscripts</artifactId>
          <classifier>tests</classifier>
@@ -570,6 +566,7 @@
                            </build>
                         </image>
                      </images>
+                      <verbose>true</verbose>
                   </configuration>
                   <executions>
                      <execution>

--- a/packaging/distribution/src/main/resources/licenses/notice.txt
+++ b/packaging/distribution/src/main/resources/licenses/notice.txt
@@ -180,12 +180,12 @@ Lightbox JS http://lokeshdhakar.com/projects/lightbox/
 
 
 === Eclipse Public License 1.0 ===
+Angus Mail Provider https://eclipse-ee4j.github.io/angus-mail/
 AspectJ http://eclipse.org/aspectj/
 Bliki   http://code.google.com/p/gwtwiki/
 JUnit   http://junit.org/
 TrueLicense     http://truelicense.java.net/
 truezip http://truezip.java.net/
-
 
 === ICU License ===
 icu4j   http://icu-project.org/ 

--- a/packaging/tests/tas-integration/pom.xml
+++ b/packaging/tests/tas-integration/pom.xml
@@ -57,8 +57,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency.jakarta-annotation-api.version>3.0.0</dependency.jakarta-annotation-api.version>
         <dependency.jakarta-transaction-api.version>2.0.1</dependency.jakarta-transaction-api.version>
         <dependency.jakarta-jws-api.version>3.0.0</dependency.jakarta-jws-api.version>
-        <dependency.jakarta-ee-mail.version>2.0.1</dependency.jakarta-ee-mail.version>
+        <dependency.jakarta-ee-mail.version>2.1.3</dependency.jakarta-ee-mail.version>
         <dependency.jakarta-ee-activation.version>2.0.1</dependency.jakarta-ee-activation.version>
         <dependency.jakarta-ee-jms.version>3.1.0</dependency.jakarta-ee-jms.version>
         <dependency.java-ee-activation.version>1.2.0</dependency.java-ee-activation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,6 @@
                 <groupId>jakarta.mail</groupId>
                 <artifactId>jakarta.mail-api</artifactId>
                 <version>${dependency.jakarta-ee-mail.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.sun.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <dependency.jdom2.version>2.0.6.1</dependency.jdom2.version>
         <dependency.pooled-jms.version>3.1.6</dependency.pooled-jms.version>
         <dependency.kxml2.version>2.3.0</dependency.kxml2.version>
+        <dependency.angus-mail.version>2.0.3</dependency.angus-mail.version>
 
         <dependency.jakarta-ee-jaxb-api.version>4.0.2</dependency.jakarta-ee-jaxb-api.version>
         <dependency.jakarta-ee-jaxb-impl.version>4.0.5</dependency.jakarta-ee-jaxb-impl.version>
@@ -219,9 +220,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>jakarta.mail</artifactId>
-                <version>${dependency.jakarta-ee-mail.version}</version>
+                <groupId>org.eclipse.angus</groupId>
+                <artifactId>angus-mail</artifactId>
+                <version>${dependency.angus-mail.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.mail</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>com.github.davidmoten</groupId>
             <artifactId>subethasmtp</artifactId>
-            <version>6.0.6</version>
+            <version>7.1.3</version>
             <exclusions>
                 <!-- Duplicate classes from com.sun.mail:jakarta.mail -->
                 <exclusion>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -56,8 +56,8 @@
             <artifactId>jakarta.mail-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>jakarta.mail</artifactId>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
         </dependency>
 
         <dependency>

--- a/repository/src/test/java/org/alfresco/email/server/EmailServiceImplTest.java
+++ b/repository/src/test/java/org/alfresco/email/server/EmailServiceImplTest.java
@@ -2,23 +2,23 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2023 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -35,12 +35,17 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
-
 import jakarta.mail.Message;
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 
 import junit.framework.TestCase;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.angus.mail.smtp.SMTPMessage;
+import org.junit.experimental.categories.Category;
+import org.springframework.context.ApplicationContext;
 
 import org.alfresco.email.server.handler.FolderEmailMessageHandler;
 import org.alfresco.email.server.impl.subetha.SubethaEmailMessage;
@@ -48,8 +53,8 @@ import org.alfresco.model.ContentModel;
 import org.alfresco.model.ForumModel;
 import org.alfresco.repo.management.subsystems.ChildApplicationContextFactory;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
-import org.alfresco.repo.transfer.TransferModel;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.repo.transfer.TransferModel;
 import org.alfresco.service.cmr.email.EmailDelivery;
 import org.alfresco.service.cmr.email.EmailMessageException;
 import org.alfresco.service.cmr.email.EmailService;
@@ -65,30 +70,23 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.service.namespace.RegexQNamePattern;
 import org.alfresco.test_category.OwnJVMTestsCategory;
 import org.alfresco.util.ApplicationContextHelper;
-import org.alfresco.util.testing.category.LuceneTests;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.experimental.categories.Category;
-import org.springframework.context.ApplicationContext;
-
-import com.sun.mail.smtp.SMTPMessage;
 
 /**
  * Unit test of EmailServiceImplTest
+ *
  * @author mrogers
  *
  */
 @Category({OwnJVMTestsCategory.class})
-public class EmailServiceImplTest extends TestCase 
+public class EmailServiceImplTest extends TestCase
 {
     /**
      * Services used by the tests
      */
     private static ApplicationContext ctx = ApplicationContextHelper.getApplicationContext();
-    
+
     private static Log logger = LogFactory.getLog(EmailServiceImplTest.class);
-    
+
     private NodeService nodeService;
     private EmailService emailService;
     private PersonService personService;
@@ -97,311 +95,64 @@ public class EmailServiceImplTest extends TestCase
     private NamespaceService namespaceService;
     private FolderEmailMessageHandler folderEmailMessageHandler;
     private RetryingTransactionHelper transactionHelper;
-    
-    String TEST_USER="EmailServiceImplTestUser";
-    
+
+    String TEST_USER = "EmailServiceImplTestUser";
+
     @Override
     public void setUp() throws Exception
-    {  
+    {
         AuthenticationUtil.setRunAsUserSystem();
-        nodeService = (NodeService)ctx.getBean("NodeService");
+        nodeService = (NodeService) ctx.getBean("NodeService");
         assertNotNull("nodeService", nodeService);
-        authorityService = (AuthorityService)ctx.getBean("AuthorityService");
+        authorityService = (AuthorityService) ctx.getBean("AuthorityService");
         assertNotNull("authorityService", authorityService);
         ChildApplicationContextFactory emailSubsystem = (ChildApplicationContextFactory) ctx.getBean("InboundSMTP");
         assertNotNull("emailSubsystem", emailSubsystem);
         ApplicationContext emailCtx = emailSubsystem.getApplicationContext();
-        emailService = (EmailService)emailCtx.getBean("emailService");       
+        emailService = (EmailService) emailCtx.getBean("emailService");
         assertNotNull("emailService", emailService);
-        personService = (PersonService)emailCtx.getBean("PersonService");       
-        assertNotNull("personService", personService);     
-        namespaceService = (NamespaceService)emailCtx.getBean("NamespaceService");       
+        personService = (PersonService) emailCtx.getBean("PersonService");
+        assertNotNull("personService", personService);
+        namespaceService = (NamespaceService) emailCtx.getBean("NamespaceService");
         assertNotNull("namespaceService", namespaceService);
-        searchService = (SearchService)emailCtx.getBean("SearchService");  
+        searchService = (SearchService) emailCtx.getBean("SearchService");
         assertNotNull("searchService", searchService);
-        folderEmailMessageHandler = (FolderEmailMessageHandler) emailCtx.getBean("folderEmailMessageHandler");  
+        folderEmailMessageHandler = (FolderEmailMessageHandler) emailCtx.getBean("folderEmailMessageHandler");
         assertNotNull("folderEmailMessageHandler", folderEmailMessageHandler);
         transactionHelper = (RetryingTransactionHelper) emailCtx.getBean("retryingTransactionHelper");
         assertNotNull("transactionHelper", transactionHelper);
     }
-    
+
     public void tearDown() throws Exception
     {
         AuthenticationUtil.setRunAsUserSystem();
-        try 
+        try
         {
             personService.deletePerson(TEST_USER);
-        } 
-        catch (Exception e)
-        {
         }
+        catch (Exception e)
+        {}
     }
-    
+
     /**
      * Test the from name.
-     * 
-     * Step 1:
-     * User admin will map to the "unknownUser"  which out of the box is "anonymous"
-     * Sending email From "admin" will fail. 
-     * 
-     * Step 2:
-     * Send from the test user to the test' user's home folder.
+     *
+     * Step 1: User admin will map to the "unknownUser" which out of the box is "anonymous" Sending email From "admin" will fail.
+     *
+     * Step 2: Send from the test user to the test' user's home folder.
      */
-   public void testFromName() throws Exception
-   {
-     
-       folderEmailMessageHandler.setOverwriteDuplicates(true);
-       
-       logger.debug("Start testFromName");
-       
-       String TEST_EMAIL="buffy@sunnydale.high";
-       
-       // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
-       NodeRef person = personService.getPerson(TEST_USER);
-       if(person == null)
-       {
-           logger.debug("new person created");
-           Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-           props.put(ContentModel.PROP_USERNAME, TEST_USER);
-           props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
-           person = personService.createPerson(props);
-       }
-       nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
-
-       Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-       if(!auths.contains(TEST_USER))
-       {
-           authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
-       }
-       
-       String companyHomePathInStore = "/app:company_home"; 
-       String storePath = "workspace://SpacesStore";
-       StoreRef storeRef = new StoreRef(storePath);
-
-       NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
-       List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
-       NodeRef companyHomeNodeRef = nodeRefs.get(0);
-       assertNotNull("company home is null", companyHomeNodeRef);
-       String companyHomeDBID = ((Long)nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
-       assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
-       String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       
-      /**
-       * Step 1
-        * Negative test - send from "Bert" who does not exist.
-        * User will be mapped to anonymous who is not an email contributor.
-        */
-       try
-       {
-           String from = "admin";
-           String to = "bertie";
-           String content = "hello world";
-       
-           Session sess = Session.getDefaultInstance(new Properties());
-           assertNotNull("sess is null", sess);
-           SMTPMessage msg = new SMTPMessage(sess);
-           InternetAddress[] toa =  { new InternetAddress(to) };
-       
-           msg.setFrom(new InternetAddress("Bert"));
-           msg.setRecipients(Message.RecipientType.TO, toa);
-           msg.setSubject("JavaMail APIs transport.java Test");
-           msg.setContent(content, "text/plain");
-               
-           StringBuffer sb = new StringBuffer();
-           ByteArrayOutputStream bos = new ByteArrayOutputStream();
-           msg.writeTo(bos);
-           InputStream is = IOUtils.toInputStream(bos.toString());
-           assertNotNull("is is null", is);
-       
-           SubethaEmailMessage m = new SubethaEmailMessage(is); 
-           
-           EmailDelivery delivery = new EmailDelivery(to, from, null);
-
-           emailService.importMessage(delivery, m);
-           fail("anonymous user not rejected");
-       } 
-       catch (EmailMessageException e)
-       {
-           // Check the exception is for the anonymous user.
-           assertTrue("Message is not for anonymous", e.getMessage().contains("anonymous"));
-       }
-       
-       /**
-        * Step 2
-        * 
-        * Send From the test user TEST_EMAIL to the test user's home
-        */
-       {
-           logger.debug("Step 2");
-           
-       String from = TEST_EMAIL;
-       String to = testUserHomeDBID;
-       String content = "hello world";
-   
-       Session sess = Session.getDefaultInstance(new Properties());
-       assertNotNull("sess is null", sess);
-       SMTPMessage msg = new SMTPMessage(sess);
-       InternetAddress[] toa =  { new InternetAddress(to) };
-   
-       msg.setFrom(new InternetAddress(TEST_EMAIL));
-       msg.setRecipients(Message.RecipientType.TO, toa);
-       msg.setSubject("JavaMail APIs transport.java Test");
-       msg.setContent(content, "text/plain");
-           
-       StringBuffer sb = new StringBuffer();
-       ByteArrayOutputStream bos = new ByteArrayOutputStream();
-       msg.writeTo(bos);
-       InputStream is = IOUtils.toInputStream(bos.toString());
-       assertNotNull("is is null", is);
-   
-       SubethaEmailMessage m = new SubethaEmailMessage(is);  
-           
-       EmailDelivery delivery = new EmailDelivery(to, from, null);
-
-       emailService.importMessage(delivery, m);
-   }
-       
-       /**
-        * Step 3
-        * 
-        * message.from From with "name" < name@ domain > format
-        * SMTP.FROM="dummy"
-        * 
-        * Send From the test user <TEST_EMAIL> to the test user's home
-        */
-       {
-           logger.debug("Step 3");
-       
-           String from = " \"Joe Bloggs\" <" + TEST_EMAIL + ">";
-           String to = testUserHomeDBID;
-           String content = "hello world";
-   
-           Session sess = Session.getDefaultInstance(new Properties());
-           assertNotNull("sess is null", sess);
-           SMTPMessage msg = new SMTPMessage(sess);
-           InternetAddress[] toa =  { new InternetAddress(to) };
-   
-           msg.setFrom(new InternetAddress(from));
-           msg.setRecipients(Message.RecipientType.TO, toa);
-           msg.setSubject("JavaMail APIs transport.java Test");
-           msg.setContent(content, "text/plain");
-           
-           StringBuffer sb = new StringBuffer();
-           ByteArrayOutputStream bos = new ByteArrayOutputStream();
-           msg.writeTo(System.out);
-           msg.writeTo(bos);
-           InputStream is = IOUtils.toInputStream(bos.toString());
-           assertNotNull("is is null", is);
-   
-           SubethaEmailMessage m = new SubethaEmailMessage(is);
-           
-           EmailDelivery delivery = new EmailDelivery(to, "dummy", null);
-
-           emailService.importMessage(delivery,m);
-       }
-       
-       /**
-        * Step 4
-        * 
-        * From with "name" < name@ domain > format
-        * 
-        * Send From the test user <TEST_EMAIL> to the test user's home
-        */
-       {
-           logger.debug("Step 4");
-       
-           String from = " \"Joe Bloggs\" <" + TEST_EMAIL + ">";
-           String to = testUserHomeDBID;
-           String content = "hello world";
-   
-           Session sess = Session.getDefaultInstance(new Properties());
-           assertNotNull("sess is null", sess);
-           SMTPMessage msg = new SMTPMessage(sess);
-           InternetAddress[] toa =  { new InternetAddress(to) };
-   
-           msg.setFrom(new InternetAddress(from));
-           msg.setRecipients(Message.RecipientType.TO, toa);
-           msg.setSubject("JavaMail APIs transport.java Test");
-           msg.setContent(content, "text/plain");
-           
-           StringBuffer sb = new StringBuffer();
-           ByteArrayOutputStream bos = new ByteArrayOutputStream();
-           msg.writeTo(System.out);
-           msg.writeTo(bos);
-           InputStream is = IOUtils.toInputStream(bos.toString());
-           assertNotNull("is is null", is);
-   
-           SubethaEmailMessage m = new SubethaEmailMessage(is);
-           
-           InternetAddress a = new InternetAddress(from);
-           String x = a.getAddress();
-           
-           EmailDelivery delivery = new EmailDelivery(to, x, null);
-
-           emailService.importMessage(delivery,m);
-       }
-       
-//       /**
-//        * Step 5
-//        * 
-//        * From with <e=name@domain> format
-//        * 
-//        * RFC3696
-//        * 
-//        * Send From the test user <TEST_EMAIL> to the test user's home
-//        */
-//       {
-//           logger.debug("Step 4 <local tag=name@ domain > format");
-//       
-//           String from = "\"Joe Bloggs\" <e=" + TEST_EMAIL + ">";
-//           String to = testUserHomeDBID;
-//           String content = "hello world";
-//   
-//           Session sess = Session.getDefaultInstance(new Properties());
-//           assertNotNull("sess is null", sess);
-//           SMTPMessage msg = new SMTPMessage(sess);
-//           InternetAddress[] toa =  { new InternetAddress(to) };
-//   
-//           msg.setFrom(new InternetAddress(from));
-//           msg.setRecipients(Message.RecipientType.TO, toa);
-//           msg.setSubject("JavaMail APIs transport.java Test");
-//           msg.setContent(content, "text/plain");
-//           
-//           StringBuffer sb = new StringBuffer();
-//           ByteArrayOutputStream bos = new ByteArrayOutputStream();
-//           msg.writeTo(System.out);
-//           msg.writeTo(bos);
-//           InputStream is = IOUtils.toInputStream(bos.toString());
-//           assertNotNull("is is null", is);
-//   
-//           SubethaEmailMessage m = new SubethaEmailMessage(is);   
-//
-//           emailService.importMessage(m);
-//       }
-    }
-
-
-    /**
-      * ALF-9544
-      * ALF-751 
-      *  
-      * Inbound email to a folder restricts file name to 86 characters or less.
-      * 
-      * Also has tests for other variations of subject
-      */
-    public void testFolderSubject() throws Exception
+    public void testFromName() throws Exception
     {
-        logger.debug("Start testFromName");
-        
-        String TEST_EMAIL="buffy@sunnydale.high";
-        
+
         folderEmailMessageHandler.setOverwriteDuplicates(true);
-        
+
+        logger.debug("Start testFromName");
+
+        String TEST_EMAIL = "buffy@sunnydale.high";
+
         // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
         NodeRef person = personService.getPerson(TEST_USER);
-        if(person == null)
+        if (person == null)
         {
             logger.debug("new person created");
             Map<QName, Serializable> props = new HashMap<QName, Serializable>();
@@ -412,12 +163,12 @@ public class EmailServiceImplTest extends TestCase
         nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
 
         Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-        if(!auths.contains(TEST_USER))
+        if (!auths.contains(TEST_USER))
         {
             authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
         }
-        
-        String companyHomePathInStore = "/app:company_home"; 
+
+        String companyHomePathInStore = "/app:company_home";
         String storePath = "workspace://SpacesStore";
         StoreRef storeRef = new StoreRef(storePath);
 
@@ -425,373 +176,608 @@ public class EmailServiceImplTest extends TestCase
         List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
         NodeRef companyHomeNodeRef = nodeRefs.get(0);
         assertNotNull("company home is null", companyHomeNodeRef);
-        String companyHomeDBID = ((Long)nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-        String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-        NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        String companyHomeDBID = ((Long) nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        String testUserDBID = ((Long) nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
         assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
-        String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-                
+        String testUserHomeDBID = ((Long) nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+
+        /**
+         * Step 1 Negative test - send from "Bert" who does not exist. User will be mapped to anonymous who is not an email contributor.
+         */
+        try
+        {
+            String from = "admin";
+            String to = "bertie";
+            String content = "hello world";
+
+            Session sess = Session.getDefaultInstance(new Properties());
+            assertNotNull("sess is null", sess);
+            SMTPMessage msg = new SMTPMessage(sess);
+            InternetAddress[] toa = {new InternetAddress(to)};
+
+            msg.setFrom(new InternetAddress("Bert"));
+            msg.setRecipients(Message.RecipientType.TO, toa);
+            msg.setSubject("JavaMail APIs transport.java Test");
+            msg.setContent(content, "text/plain");
+
+            StringBuffer sb = new StringBuffer();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            msg.writeTo(bos);
+            InputStream is = IOUtils.toInputStream(bos.toString());
+            assertNotNull("is is null", is);
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+            EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+            emailService.importMessage(delivery, m);
+            fail("anonymous user not rejected");
+        }
+        catch (EmailMessageException e)
+        {
+            // Check the exception is for the anonymous user.
+            assertTrue("Message is not for anonymous", e.getMessage().contains("anonymous"));
+        }
+
+        /**
+         * Step 2
+         *
+         * Send From the test user TEST_EMAIL to the test user's home
+         */
+        {
+            logger.debug("Step 2");
+
+            String from = TEST_EMAIL;
+            String to = testUserHomeDBID;
+            String content = "hello world";
+
+            Session sess = Session.getDefaultInstance(new Properties());
+            assertNotNull("sess is null", sess);
+            SMTPMessage msg = new SMTPMessage(sess);
+            InternetAddress[] toa = {new InternetAddress(to)};
+
+            msg.setFrom(new InternetAddress(TEST_EMAIL));
+            msg.setRecipients(Message.RecipientType.TO, toa);
+            msg.setSubject("JavaMail APIs transport.java Test");
+            msg.setContent(content, "text/plain");
+
+            StringBuffer sb = new StringBuffer();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            msg.writeTo(bos);
+            InputStream is = IOUtils.toInputStream(bos.toString());
+            assertNotNull("is is null", is);
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+            EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+            emailService.importMessage(delivery, m);
+        }
+
+        /**
+         * Step 3
+         *
+         * message.from From with "name" < name@ domain > format SMTP.FROM="dummy"
+         *
+         * Send From the test user <TEST_EMAIL> to the test user's home
+         */
+        {
+            logger.debug("Step 3");
+
+            String from = " \"Joe Bloggs\" <" + TEST_EMAIL + ">";
+            String to = testUserHomeDBID;
+            String content = "hello world";
+
+            Session sess = Session.getDefaultInstance(new Properties());
+            assertNotNull("sess is null", sess);
+            SMTPMessage msg = new SMTPMessage(sess);
+            InternetAddress[] toa = {new InternetAddress(to)};
+
+            msg.setFrom(new InternetAddress(from));
+            msg.setRecipients(Message.RecipientType.TO, toa);
+            msg.setSubject("JavaMail APIs transport.java Test");
+            msg.setContent(content, "text/plain");
+
+            StringBuffer sb = new StringBuffer();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            msg.writeTo(System.out);
+            msg.writeTo(bos);
+            InputStream is = IOUtils.toInputStream(bos.toString());
+            assertNotNull("is is null", is);
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+            EmailDelivery delivery = new EmailDelivery(to, "dummy", null);
+
+            emailService.importMessage(delivery, m);
+        }
+
+        /**
+         * Step 4
+         *
+         * From with "name" < name@ domain > format
+         *
+         * Send From the test user <TEST_EMAIL> to the test user's home
+         */
+        {
+            logger.debug("Step 4");
+
+            String from = " \"Joe Bloggs\" <" + TEST_EMAIL + ">";
+            String to = testUserHomeDBID;
+            String content = "hello world";
+
+            Session sess = Session.getDefaultInstance(new Properties());
+            assertNotNull("sess is null", sess);
+            SMTPMessage msg = new SMTPMessage(sess);
+            InternetAddress[] toa = {new InternetAddress(to)};
+
+            msg.setFrom(new InternetAddress(from));
+            msg.setRecipients(Message.RecipientType.TO, toa);
+            msg.setSubject("JavaMail APIs transport.java Test");
+            msg.setContent(content, "text/plain");
+
+            StringBuffer sb = new StringBuffer();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            msg.writeTo(System.out);
+            msg.writeTo(bos);
+            InputStream is = IOUtils.toInputStream(bos.toString());
+            assertNotNull("is is null", is);
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+            InternetAddress a = new InternetAddress(from);
+            String x = a.getAddress();
+
+            EmailDelivery delivery = new EmailDelivery(to, x, null);
+
+            emailService.importMessage(delivery, m);
+        }
+
+        // /**
+        // * Step 5
+        // *
+        // * From with <e=name@domain> format
+        // *
+        // * RFC3696
+        // *
+        // * Send From the test user <TEST_EMAIL> to the test user's home
+        // */
+        // {
+        // logger.debug("Step 4 <local tag=name@ domain > format");
+        //
+        // String from = "\"Joe Bloggs\" <e=" + TEST_EMAIL + ">";
+        // String to = testUserHomeDBID;
+        // String content = "hello world";
+        //
+        // Session sess = Session.getDefaultInstance(new Properties());
+        // assertNotNull("sess is null", sess);
+        // SMTPMessage msg = new SMTPMessage(sess);
+        // InternetAddress[] toa = { new InternetAddress(to) };
+        //
+        // msg.setFrom(new InternetAddress(from));
+        // msg.setRecipients(Message.RecipientType.TO, toa);
+        // msg.setSubject("JavaMail APIs transport.java Test");
+        // msg.setContent(content, "text/plain");
+        //
+        // StringBuffer sb = new StringBuffer();
+        // ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        // msg.writeTo(System.out);
+        // msg.writeTo(bos);
+        // InputStream is = IOUtils.toInputStream(bos.toString());
+        // assertNotNull("is is null", is);
+        //
+        // SubethaEmailMessage m = new SubethaEmailMessage(is);
+        //
+        // emailService.importMessage(m);
+        // }
+    }
+
+    /**
+     * ALF-9544 ALF-751
+     *
+     * Inbound email to a folder restricts file name to 86 characters or less.
+     *
+     * Also has tests for other variations of subject
+     */
+    public void testFolderSubject() throws Exception
+    {
+        logger.debug("Start testFromName");
+
+        String TEST_EMAIL = "buffy@sunnydale.high";
+
+        folderEmailMessageHandler.setOverwriteDuplicates(true);
+
+        // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
+        NodeRef person = personService.getPerson(TEST_USER);
+        if (person == null)
+        {
+            logger.debug("new person created");
+            Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+            props.put(ContentModel.PROP_USERNAME, TEST_USER);
+            props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
+            person = personService.createPerson(props);
+        }
+        nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+
+        Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
+        if (!auths.contains(TEST_USER))
+        {
+            authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
+        }
+
+        String companyHomePathInStore = "/app:company_home";
+        String storePath = "workspace://SpacesStore";
+        StoreRef storeRef = new StoreRef(storePath);
+
+        NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
+        List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
+        NodeRef companyHomeNodeRef = nodeRefs.get(0);
+        assertNotNull("company home is null", companyHomeNodeRef);
+        String companyHomeDBID = ((Long) nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        String testUserDBID = ((Long) nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
+        String testUserHomeDBID = ((Long) nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+
         /**
          * Send From the test user TEST_EMAIL to the test user's home
          */
         String from = TEST_EMAIL;
         String to = testUserHomeDBID;
         String content = "hello world";
-    
-        {
-        Session sess = Session.getDefaultInstance(new Properties());
-        assertNotNull("sess is null", sess);
-        SMTPMessage msg = new SMTPMessage(sess);
-        InternetAddress[] toa =  { new InternetAddress(to) };
-    
-        msg.setFrom(new InternetAddress(TEST_EMAIL));
-        msg.setRecipients(Message.RecipientType.TO, toa);
-        msg.setSubject("This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544");
-        msg.setContent(content, "text/plain");
-            
-        StringBuffer sb = new StringBuffer();
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        msg.writeTo(bos);
-        InputStream is = IOUtils.toInputStream(bos.toString());
-        assertNotNull("is is null", is);
-    
-        SubethaEmailMessage m = new SubethaEmailMessage(is);   
-        EmailDelivery delivery = new EmailDelivery(to, from, null);
 
-        emailService.importMessage(delivery, m);
+        {
+            Session sess = Session.getDefaultInstance(new Properties());
+            assertNotNull("sess is null", sess);
+            SMTPMessage msg = new SMTPMessage(sess);
+            InternetAddress[] toa = {new InternetAddress(to)};
+
+            msg.setFrom(new InternetAddress(TEST_EMAIL));
+            msg.setRecipients(Message.RecipientType.TO, toa);
+            msg.setSubject("This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544");
+            msg.setContent(content, "text/plain");
+
+            StringBuffer sb = new StringBuffer();
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            msg.writeTo(bos);
+            InputStream is = IOUtils.toInputStream(bos.toString());
+            assertNotNull("is is null", is);
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
+            EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+            emailService.importMessage(delivery, m);
         }
-        
+
         // Check import with subject containing some "illegal chars"
         {
             Session sess = Session.getDefaultInstance(new Properties());
             assertNotNull("sess is null", sess);
             SMTPMessage msg = new SMTPMessage(sess);
-            InternetAddress[] toa =  { new InternetAddress(to) };
-        
+            InternetAddress[] toa = {new InternetAddress(to)};
+
             msg.setFrom(new InternetAddress(TEST_EMAIL));
             msg.setRecipients(Message.RecipientType.TO, toa);
             msg.setSubject("Illegal<>!*/\\.txt");
             msg.setContent(content, "text/plain");
-                
+
             StringBuffer sb = new StringBuffer();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             msg.writeTo(bos);
             InputStream is = IOUtils.toInputStream(bos.toString());
             assertNotNull("is is null", is);
-        
-            SubethaEmailMessage m = new SubethaEmailMessage(is);   
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
             EmailDelivery delivery = new EmailDelivery(to, from, null);
 
             emailService.importMessage(delivery, m);
-         }
-        
+        }
+
         // Check with null subject
         {
             Session sess = Session.getDefaultInstance(new Properties());
             assertNotNull("sess is null", sess);
             SMTPMessage msg = new SMTPMessage(sess);
-            InternetAddress[] toa =  { new InternetAddress(to) };
-        
+            InternetAddress[] toa = {new InternetAddress(to)};
+
             msg.setFrom(new InternetAddress(TEST_EMAIL));
             msg.setRecipients(Message.RecipientType.TO, toa);
-            //msg.setSubject();
+            // msg.setSubject();
             msg.setContent(content, "text/plain");
-                
+
             StringBuffer sb = new StringBuffer();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             msg.writeTo(bos);
             InputStream is = IOUtils.toInputStream(bos.toString());
             assertNotNull("is is null", is);
-        
-            SubethaEmailMessage m = new SubethaEmailMessage(is);   
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
             EmailDelivery delivery = new EmailDelivery(to, from, null);
 
             emailService.importMessage(delivery, m);
-         }
-        
-        
+        }
+
         // ALF-751 Email ends with period
         {
             Session sess = Session.getDefaultInstance(new Properties());
             assertNotNull("sess is null", sess);
             SMTPMessage msg = new SMTPMessage(sess);
-            InternetAddress[] toa =  { new InternetAddress(to) };
-        
+            InternetAddress[] toa = {new InternetAddress(to)};
+
             msg.setFrom(new InternetAddress(TEST_EMAIL));
             msg.setRecipients(Message.RecipientType.TO, toa);
             msg.setSubject("Foobar.");
             msg.setContent(content, "text/plain");
-                
+
             StringBuffer sb = new StringBuffer();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             msg.writeTo(bos);
             InputStream is = IOUtils.toInputStream(bos.toString());
             assertNotNull("is is null", is);
-        
-            SubethaEmailMessage m = new SubethaEmailMessage(is);   
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
             EmailDelivery delivery = new EmailDelivery(to, from, null);
 
             emailService.importMessage(delivery, m);
-         }
-        
+        }
+
         // ALF-751 Email ends with ...
         {
             Session sess = Session.getDefaultInstance(new Properties());
             assertNotNull("sess is null", sess);
             SMTPMessage msg = new SMTPMessage(sess);
-            InternetAddress[] toa =  { new InternetAddress(to) };
-        
+            InternetAddress[] toa = {new InternetAddress(to)};
+
             msg.setFrom(new InternetAddress(TEST_EMAIL));
             msg.setRecipients(Message.RecipientType.TO, toa);
             msg.setSubject("Foobar...");
             msg.setContent(content, "text/plain");
-                
+
             StringBuffer sb = new StringBuffer();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             msg.writeTo(bos);
             InputStream is = IOUtils.toInputStream(bos.toString());
             assertNotNull("is is null", is);
-        
-            SubethaEmailMessage m = new SubethaEmailMessage(is);   
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
             EmailDelivery delivery = new EmailDelivery(to, from, null);
 
             emailService.importMessage(delivery, m);
-         }
-        
+        }
+
         // ALF-751 Email subject is blank " ... "
         {
             Session sess = Session.getDefaultInstance(new Properties());
             assertNotNull("sess is null", sess);
             SMTPMessage msg = new SMTPMessage(sess);
-            InternetAddress[] toa =  { new InternetAddress(to) };
-        
+            InternetAddress[] toa = {new InternetAddress(to)};
+
             msg.setFrom(new InternetAddress(TEST_EMAIL));
             msg.setRecipients(Message.RecipientType.TO, toa);
             msg.setSubject(" ... ");
             msg.setContent(content, "text/plain");
-                
+
             StringBuffer sb = new StringBuffer();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             msg.writeTo(bos);
             InputStream is = IOUtils.toInputStream(bos.toString());
             assertNotNull("is is null", is);
-        
-            SubethaEmailMessage m = new SubethaEmailMessage(is);   
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
             EmailDelivery delivery = new EmailDelivery(to, from, null);
 
             emailService.importMessage(delivery, m);
-         }
-        
+        }
+
         // ALF-751 Email subject is a single .
         {
             Session sess = Session.getDefaultInstance(new Properties());
             assertNotNull("sess is null", sess);
             SMTPMessage msg = new SMTPMessage(sess);
-            InternetAddress[] toa =  { new InternetAddress(to) };
-        
+            InternetAddress[] toa = {new InternetAddress(to)};
+
             msg.setFrom(new InternetAddress(TEST_EMAIL));
             msg.setRecipients(Message.RecipientType.TO, toa);
             msg.setSubject(".");
             msg.setContent(content, "text/plain");
-                
+
             StringBuffer sb = new StringBuffer();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             msg.writeTo(bos);
             InputStream is = IOUtils.toInputStream(bos.toString());
             assertNotNull("is is null", is);
-        
-            SubethaEmailMessage m = new SubethaEmailMessage(is);   
+
+            SubethaEmailMessage m = new SubethaEmailMessage(is);
             EmailDelivery delivery = new EmailDelivery(to, from, null);
 
             emailService.importMessage(delivery, m);
-         }
-           
+        }
+
     }
-    
+
     /**
      * ALF-1878
-     * 
+     *
      * Duplicate incoming email Subjects over-write each other
      */
-   public void testMultipleMessagesToFolder() throws Exception
-   {
-       logger.debug("Start testFromName");
-       
-       String TEST_EMAIL="buffy@sunnydale.high";
-       
-       String TEST_SUBJECT="Practical Bee Keeping";
-       
-       String TEST_LONG_SUBJECT = "This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544";
-       
-       
-       // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
-       NodeRef person = personService.getPerson(TEST_USER);
-       if(person == null)
-       {
-           logger.debug("new person created");
-           Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-           props.put(ContentModel.PROP_USERNAME, TEST_USER);
-           props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
-           person = personService.createPerson(props);
-       }
-       nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+    public void testMultipleMessagesToFolder() throws Exception
+    {
+        logger.debug("Start testFromName");
 
-       Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-       if(!auths.contains(TEST_USER))
-       {
-           authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
-       }
-       
-       String companyHomePathInStore = "/app:company_home"; 
-       String storePath = "workspace://SpacesStore";
-       StoreRef storeRef = new StoreRef(storePath);
+        String TEST_EMAIL = "buffy@sunnydale.high";
 
-       NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
-       List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
-       NodeRef companyHomeNodeRef = nodeRefs.get(0);
-       assertNotNull("company home is null", companyHomeNodeRef);
-       String companyHomeDBID = ((Long)nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
-       assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
-       String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       
-       // Clean up old messages in test folder
-       List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       for(ChildAssociationRef assoc : assocs)
-       {
-           nodeService.deleteNode(assoc.getChildRef());
-       }
-               
-       /**
-        * Send From the test user TEST_EMAIL to the test user's home
-        */
-       String from = TEST_EMAIL;
-       String to = testUserHomeDBID;
-       String content = "hello world";
-   
-       Session sess = Session.getDefaultInstance(new Properties());
-       assertNotNull("sess is null", sess);
-       SMTPMessage msg = new SMTPMessage(sess);
-       InternetAddress[] toa =  { new InternetAddress(to) };
-   
-       msg.setFrom(new InternetAddress(TEST_EMAIL));
-       msg.setRecipients(Message.RecipientType.TO, toa);
-       msg.setSubject(TEST_SUBJECT);
-       msg.setContent(content, "text/plain");
-           
-       ByteArrayOutputStream bos = new ByteArrayOutputStream();
-       msg.writeTo(bos);
-       InputStream is = IOUtils.toInputStream(bos.toString());
-       assertNotNull("is is null", is);
-   
-       SubethaEmailMessage m = new SubethaEmailMessage(is);   
-       
-       /**
-        * Turn on overwriteDuplicates
-        */
-       logger.debug("Step 1: turn on Overwite Duplicates");
-       folderEmailMessageHandler.setOverwriteDuplicates(true);
-       
-       EmailDelivery delivery = new EmailDelivery(to, from, null);
+        String TEST_SUBJECT = "Practical Bee Keeping";
 
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       assertEquals("assocs not 1", 1, assocs.size());
-       assertEquals("name of link not as expected", assocs.get(0).getQName(), QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_SUBJECT));
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       assertEquals("assocs not 1", 1, assocs.size());   
-       
-       /**
-        * Turn off overwrite Duplicates
-        */
-       logger.debug("Step 2: turn off Overwite Duplicates");
-       folderEmailMessageHandler.setOverwriteDuplicates(false);
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       assertEquals("assocs not 2", 2, assocs.size());
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       assertEquals("assocs not 3", 3, assocs.size());   
+        String TEST_LONG_SUBJECT = "This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544";
 
-       /**
-        * Check assoc rename with long names.   So truncation and rename need to work together.
-        */
-       logger.debug("Step 3: turn off Overwite Duplicates with long subject name");
-       msg.setSubject(TEST_LONG_SUBJECT);
-       ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
-       msg.writeTo(bos2);
-       is = IOUtils.toInputStream(bos2.toString());
-       assertNotNull("is is null", is);
-       m = new SubethaEmailMessage(is);   
-       
-       folderEmailMessageHandler.setOverwriteDuplicates(false);
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       assertEquals("assocs not 4", 4, assocs.size());
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       assertEquals("assocs not 5", 5, assocs.size());
-       
-       /**
-        * Check assoc rename with long names and an extension. So truncation and rename need to 
-        * work together and not muck up a .extension.
-        */
-       logger.debug("Step 4: turn off Overwite Duplicates with long subject name with extension");
-       String EXT_NAME = "Blob.xls";
-       
-       msg.setSubject(EXT_NAME);
-       ByteArrayOutputStream bos3 = new ByteArrayOutputStream();
-       msg.writeTo(bos3);
-       is = IOUtils.toInputStream(bos3.toString());
-       assertNotNull("is is null", is);
-       m = new SubethaEmailMessage(is);  
-       folderEmailMessageHandler.setOverwriteDuplicates(false);
-       emailService.importMessage(delivery, m);
-       emailService.importMessage(delivery, m);
-       emailService.importMessage(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
+        NodeRef person = personService.getPerson(TEST_USER);
+        if (person == null)
+        {
+            logger.debug("new person created");
+            Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+            props.put(ContentModel.PROP_USERNAME, TEST_USER);
+            props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
+            person = personService.createPerson(props);
+        }
+        nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
 
-       List<QName> assocNames = new Vector<QName>(); 
-       for(ChildAssociationRef assoc : assocs)
-       {
-           logger.debug("assocName: " + assoc.getQName());
-           System.out.println(assoc.getQName());
-           assocNames.add(assoc.getQName());
-       }
-       assertTrue(EXT_NAME + "not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Blob.xls")));
-       assertTrue("Blob(1).xls not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Blob(1).xls")));   
-       assertTrue("Blob(2).xls not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Blob(2).xls")));      
-       assertTrue(TEST_SUBJECT + "not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_SUBJECT)));   
-       assertTrue(TEST_SUBJECT+"(1) not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Practical Bee Keeping(1)")));      
+        Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
+        if (!auths.contains(TEST_USER))
+        {
+            authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
+        }
 
-       /**
-        * Check concurrent deliver of the same message. Reuse message from the previous test.
-        */
-       logger.debug("Step 5: turn off Overwite Duplicates and check concurrent deliver of the same message");
-       folderEmailMessageHandler.setOverwriteDuplicates(false);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       int numBeforeConcurrentDeliver = assocs.size();
-       deliverConcurrently(delivery, m);
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-       int numAfterConcurrentDeliver = assocs.size();
-       assertEquals("Two messages must be added", numBeforeConcurrentDeliver + 2, numAfterConcurrentDeliver);
-   }
+        String companyHomePathInStore = "/app:company_home";
+        String storePath = "workspace://SpacesStore";
+        StoreRef storeRef = new StoreRef(storePath);
 
-   private void deliverConcurrently(final EmailDelivery delivery, final SubethaEmailMessage m) throws Exception
-   {
-       final CountDownLatch cdl = new CountDownLatch(1);
-       class ConcurrentMessageImporter implements Runnable
-       {
-           private Throwable throwable;
-           @Override
-           public void run()
-           {
+        NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
+        List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
+        NodeRef companyHomeNodeRef = nodeRefs.get(0);
+        assertNotNull("company home is null", companyHomeNodeRef);
+        String companyHomeDBID = ((Long) nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        String testUserDBID = ((Long) nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
+        String testUserHomeDBID = ((Long) nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+
+        // Clean up old messages in test folder
+        List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        for (ChildAssociationRef assoc : assocs)
+        {
+            nodeService.deleteNode(assoc.getChildRef());
+        }
+
+        /**
+         * Send From the test user TEST_EMAIL to the test user's home
+         */
+        String from = TEST_EMAIL;
+        String to = testUserHomeDBID;
+        String content = "hello world";
+
+        Session sess = Session.getDefaultInstance(new Properties());
+        assertNotNull("sess is null", sess);
+        SMTPMessage msg = new SMTPMessage(sess);
+        InternetAddress[] toa = {new InternetAddress(to)};
+
+        msg.setFrom(new InternetAddress(TEST_EMAIL));
+        msg.setRecipients(Message.RecipientType.TO, toa);
+        msg.setSubject(TEST_SUBJECT);
+        msg.setContent(content, "text/plain");
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        msg.writeTo(bos);
+        InputStream is = IOUtils.toInputStream(bos.toString());
+        assertNotNull("is is null", is);
+
+        SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+        /**
+         * Turn on overwriteDuplicates
+         */
+        logger.debug("Step 1: turn on Overwite Duplicates");
+        folderEmailMessageHandler.setOverwriteDuplicates(true);
+
+        EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        assertEquals("assocs not 1", 1, assocs.size());
+        assertEquals("name of link not as expected", assocs.get(0).getQName(), QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_SUBJECT));
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        assertEquals("assocs not 1", 1, assocs.size());
+
+        /**
+         * Turn off overwrite Duplicates
+         */
+        logger.debug("Step 2: turn off Overwite Duplicates");
+        folderEmailMessageHandler.setOverwriteDuplicates(false);
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        assertEquals("assocs not 2", 2, assocs.size());
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        assertEquals("assocs not 3", 3, assocs.size());
+
+        /**
+         * Check assoc rename with long names. So truncation and rename need to work together.
+         */
+        logger.debug("Step 3: turn off Overwite Duplicates with long subject name");
+        msg.setSubject(TEST_LONG_SUBJECT);
+        ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
+        msg.writeTo(bos2);
+        is = IOUtils.toInputStream(bos2.toString());
+        assertNotNull("is is null", is);
+        m = new SubethaEmailMessage(is);
+
+        folderEmailMessageHandler.setOverwriteDuplicates(false);
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        assertEquals("assocs not 4", 4, assocs.size());
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        assertEquals("assocs not 5", 5, assocs.size());
+
+        /**
+         * Check assoc rename with long names and an extension. So truncation and rename need to work together and not muck up a .extension.
+         */
+        logger.debug("Step 4: turn off Overwite Duplicates with long subject name with extension");
+        String EXT_NAME = "Blob.xls";
+
+        msg.setSubject(EXT_NAME);
+        ByteArrayOutputStream bos3 = new ByteArrayOutputStream();
+        msg.writeTo(bos3);
+        is = IOUtils.toInputStream(bos3.toString());
+        assertNotNull("is is null", is);
+        m = new SubethaEmailMessage(is);
+        folderEmailMessageHandler.setOverwriteDuplicates(false);
+        emailService.importMessage(delivery, m);
+        emailService.importMessage(delivery, m);
+        emailService.importMessage(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+
+        List<QName> assocNames = new Vector<QName>();
+        for (ChildAssociationRef assoc : assocs)
+        {
+            logger.debug("assocName: " + assoc.getQName());
+            System.out.println(assoc.getQName());
+            assocNames.add(assoc.getQName());
+        }
+        assertTrue(EXT_NAME + "not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Blob.xls")));
+        assertTrue("Blob(1).xls not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Blob(1).xls")));
+        assertTrue("Blob(2).xls not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Blob(2).xls")));
+        assertTrue(TEST_SUBJECT + "not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_SUBJECT)));
+        assertTrue(TEST_SUBJECT + "(1) not found", assocNames.contains(QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "Practical Bee Keeping(1)")));
+
+        /**
+         * Check concurrent deliver of the same message. Reuse message from the previous test.
+         */
+        logger.debug("Step 5: turn off Overwite Duplicates and check concurrent deliver of the same message");
+        folderEmailMessageHandler.setOverwriteDuplicates(false);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        int numBeforeConcurrentDeliver = assocs.size();
+        deliverConcurrently(delivery, m);
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        int numAfterConcurrentDeliver = assocs.size();
+        assertEquals("Two messages must be added", numBeforeConcurrentDeliver + 2, numAfterConcurrentDeliver);
+    }
+
+    private void deliverConcurrently(final EmailDelivery delivery, final SubethaEmailMessage m) throws Exception
+    {
+        final CountDownLatch cdl = new CountDownLatch(1);
+        class ConcurrentMessageImporter implements Runnable
+        {
+            private Throwable throwable;
+
+            @Override
+            public void run()
+            {
                 try
                 {
-                    transactionHelper.doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Void>()
-                    {
+                    transactionHelper.doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Void>() {
                         public Void execute() throws Throwable
                         {
                             cdl.countDown();
@@ -804,417 +790,401 @@ public class EmailServiceImplTest extends TestCase
                 {
                     throwable = t;
                 }
-           }
-       }
-       ConcurrentMessageImporter messageImporter = new ConcurrentMessageImporter();
-       final Thread messageImporterThread = new Thread(messageImporter);
-       transactionHelper.doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Void>()
-               {
-                   public Void execute() throws Throwable
-                   {
-                       emailService.importMessage(delivery, m);
-                       messageImporterThread.start();
-                       // wait until concurrent transaction has started
-                       cdl.await();
-                       return null;
-                   }
-               }, false, true);
-       messageImporterThread.join();
-       if (null != messageImporter.throwable)
-       {
-           fail(messageImporter.throwable.getMessage());
-       }
-   }
-   
-   /**
-    * MNT-9289
-    * 
-    * Change in case in email Subject causes DuplicateChildNodeNameException
-    */
-   public void testCaseSensitivity() throws Exception
-   {
-	   NodeRef person = personService.getPerson(TEST_USER);
-	   String TEST_EMAIL="buffy@sunnydale.high";
-	   NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
-       if(person == null)
-       {
-           logger.debug("new person created");
-           Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-           props.put(ContentModel.PROP_USERNAME, TEST_USER);
-           props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
-           person = personService.createPerson(props);
-       }
-       
-       nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+            }
+        }
+        ConcurrentMessageImporter messageImporter = new ConcurrentMessageImporter();
+        final Thread messageImporterThread = new Thread(messageImporter);
+        transactionHelper.doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Void>() {
+            public Void execute() throws Throwable
+            {
+                emailService.importMessage(delivery, m);
+                messageImporterThread.start();
+                // wait until concurrent transaction has started
+                cdl.await();
+                return null;
+            }
+        }, false, true);
+        messageImporterThread.join();
+        if (null != messageImporter.throwable)
+        {
+            fail(messageImporter.throwable.getMessage());
+        }
+    }
 
-       Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-       if(!auths.contains(TEST_USER))
-       {
-           authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
-       }
-       
-       String companyHomePathInStore = "/app:company_home"; 
-       String storePath = "workspace://SpacesStore";
-       StoreRef storeRef = new StoreRef(storePath);
+    /**
+     * MNT-9289
+     *
+     * Change in case in email Subject causes DuplicateChildNodeNameException
+     */
+    public void testCaseSensitivity() throws Exception
+    {
+        NodeRef person = personService.getPerson(TEST_USER);
+        String TEST_EMAIL = "buffy@sunnydale.high";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        if (person == null)
+        {
+            logger.debug("new person created");
+            Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+            props.put(ContentModel.PROP_USERNAME, TEST_USER);
+            props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
+            person = personService.createPerson(props);
+        }
 
-       NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
-       List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
-       NodeRef companyHomeNodeRef = nodeRefs.get(0);
-       assertNotNull("company home is null", companyHomeNodeRef);
-	   
-       String TEST_CASE_SENSITIVITY_SUBJECT = "Test (Mail)";
-       String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-	   
-       String from = TEST_EMAIL;
-       String to = testUserHomeDBID;
-       String content = "hello world";
-   
-       Session sess = Session.getDefaultInstance(new Properties());
-       assertNotNull("sess is null", sess);
-       SMTPMessage msg = new SMTPMessage(sess);
-       InternetAddress[] toa =  { new InternetAddress(to) };
-       
-       EmailDelivery delivery = new EmailDelivery(to, from, null);
-   
-       msg.setFrom(new InternetAddress(TEST_EMAIL));
-       msg.setRecipients(Message.RecipientType.TO, toa);
-       msg.setContent(content, "text/plain");
-	   
-       msg.setSubject(TEST_CASE_SENSITIVITY_SUBJECT);
-       ByteArrayOutputStream bos1 = new ByteArrayOutputStream();
-       msg.writeTo(bos1);
-       InputStream is = IOUtils.toInputStream(bos1.toString());
-       assertNotNull("is is null", is);
-       SubethaEmailMessage m = new SubethaEmailMessage(is);  
-       folderEmailMessageHandler.setOverwriteDuplicates(false);
-       emailService.importMessage(delivery, m);
-       
-       QName safeQName = QName.createQNameWithValidLocalName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_CASE_SENSITIVITY_SUBJECT);
-       List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, safeQName);
-       assertEquals(1, assocs.size());
-       
-       msg.setSubject(TEST_CASE_SENSITIVITY_SUBJECT.toUpperCase());
-       ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
-       msg.writeTo(bos2);
-       is = IOUtils.toInputStream(bos2.toString());
-       assertNotNull("is is null", is);
-       m = new SubethaEmailMessage(is);  
-       folderEmailMessageHandler.setOverwriteDuplicates(false);
-       emailService.importMessage(delivery, m);
-       
-       safeQName = QName.createQNameWithValidLocalName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_CASE_SENSITIVITY_SUBJECT.toUpperCase() +  "(1)");
-       assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, safeQName);
-       assertEquals(1, assocs.size());
-   }
-   
-   
-   /**
-    * ALF-12297
-    * 
-    * Test messages being sent to a cm:content node
-    */
-  public void testMessagesToDocument() throws Exception
-  {
-      logger.debug("Start testMessagesToDocument");
-      
-      String TEST_EMAIL="buffy@sunnydale.high";
-      
-      String TEST_SUBJECT="Practical Bee Keeping";
-      
-      String TEST_LONG_SUBJECT = "This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544";
-      
-      
-      // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
-      NodeRef person = personService.getPerson(TEST_USER);
-      if(person == null)
-      {
-          logger.debug("new person created");
-          Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-          props.put(ContentModel.PROP_USERNAME, TEST_USER);
-          props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
-          person = personService.createPerson(props);
-      }
-      nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+        nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
 
-      Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-      if(!auths.contains(TEST_USER))
-      {
-          authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
-      }
-      
-      String companyHomePathInStore = "/app:company_home"; 
-      String storePath = "workspace://SpacesStore";
-      StoreRef storeRef = new StoreRef(storePath);
+        Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
+        if (!auths.contains(TEST_USER))
+        {
+            authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
+        }
 
-      NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
-      List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
-      NodeRef companyHomeNodeRef = nodeRefs.get(0);
-      assertNotNull("company home is null", companyHomeNodeRef);
-      String companyHomeDBID = ((Long)nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
- //     String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-      NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
-      assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
-//      String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-      
-      // Clean up old messages in test folder
-      List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-      for(ChildAssociationRef assoc : assocs)
-      {
-          nodeService.deleteNode(assoc.getChildRef());
-      }
-      
-      
-      Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
-      properties.put(ContentModel.PROP_NAME, "bees");
-      properties.put(ContentModel.PROP_DESCRIPTION, "bees - test doc for email tests");
-      ChildAssociationRef testDoc = nodeService.createNode(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "bees"), ContentModel.TYPE_CONTENT, properties);
-      NodeRef testDocNodeRef = testDoc.getChildRef();
-      
-      String testDocDBID = ((Long)nodeService.getProperty(testDocNodeRef, ContentModel.PROP_NODE_DBID)).toString();
-      
-      /**
-       * Send From the test user TEST_EMAIL to the test user's home
-       */
-      String from = TEST_EMAIL;
-      String to = testDocDBID + "@alfresco.com";
-      String content = "hello world";
-  
-      Session sess = Session.getDefaultInstance(new Properties());
-      assertNotNull("sess is null", sess);
-      SMTPMessage msg = new SMTPMessage(sess);
-      InternetAddress[] toa =  { new InternetAddress(to) };
-  
-      msg.setFrom(new InternetAddress(TEST_EMAIL));
-      msg.setRecipients(Message.RecipientType.TO, toa);
-      msg.setSubject(TEST_SUBJECT);
-      msg.setContent(content, "text/plain");
-          
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
-      msg.writeTo(bos);
-      InputStream is = IOUtils.toInputStream(bos.toString());
-      assertNotNull("is is null", is);
-  
-      SubethaEmailMessage m = new SubethaEmailMessage(is);   
-      
-      /**
-       * Turn on overwriteDuplicates
-       */
-      logger.debug("Step 1: send an email to a doc");
-            
-      EmailDelivery delivery = new EmailDelivery(to, from, null);
+        String companyHomePathInStore = "/app:company_home";
+        String storePath = "workspace://SpacesStore";
+        StoreRef storeRef = new StoreRef(storePath);
 
-      emailService.importMessage(delivery, m);
-      
-      assertTrue(nodeService.hasAspect(testDocNodeRef, ForumModel.ASPECT_DISCUSSABLE));
-      
- 
-   
-  } // end of test sending to cm:content node
-  
-  
-  /**
-   * ENH-560 - Inbound email server not working with custom types
-   */
- public void testMessagesToSubTypeOfDocument() throws Exception
- {
-     logger.debug("Start testMessagesToSubTypesOfDocument");
-     
-     String TEST_EMAIL="buffy@sunnydale.high";
-     
-     String TEST_SUBJECT="Practical Bee Keeping";
-     
-     String TEST_LONG_SUBJECT = "This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544";
-     
-     
-     // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
-     NodeRef person = personService.getPerson(TEST_USER);
-     if(person == null)
-     {
-         logger.debug("new person created");
-         Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-         props.put(ContentModel.PROP_USERNAME, TEST_USER);
-         props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
-         person = personService.createPerson(props);
-     }
-     nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+        NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
+        List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
+        NodeRef companyHomeNodeRef = nodeRefs.get(0);
+        assertNotNull("company home is null", companyHomeNodeRef);
 
-     Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-     if(!auths.contains(TEST_USER))
-     {
-         authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
-     }
-     
-     String companyHomePathInStore = "/app:company_home"; 
-     String storePath = "workspace://SpacesStore";
-     StoreRef storeRef = new StoreRef(storePath);
+        String TEST_CASE_SENSITIVITY_SUBJECT = "Test (Mail)";
+        String testUserHomeDBID = ((Long) nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
 
-     NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
-     List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
-     NodeRef companyHomeNodeRef = nodeRefs.get(0);
-     assertNotNull("company home is null", companyHomeNodeRef);
-     String companyHomeDBID = ((Long)nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-//     String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-     NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
-     assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
-//     String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-     
-     // Clean up old messages in test folder
-     List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
-     for(ChildAssociationRef assoc : assocs)
-     {
-         nodeService.deleteNode(assoc.getChildRef());
-     }
-     
-     
-     Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
-     properties.put(ContentModel.PROP_NAME, "hamster");
-     properties.put(ContentModel.PROP_DESCRIPTION, "syrian hamsters - test doc for email tests, sending to a subtype of cm:content");
-     
-     // Transfer report is a subtype of cm:content
-     ChildAssociationRef testDoc = nodeService.createNode(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "bees"), TransferModel.TYPE_TRANSFER_REPORT, properties);
-     NodeRef testDocNodeRef = testDoc.getChildRef();
-     
-     String testDocDBID = ((Long)nodeService.getProperty(testDocNodeRef, ContentModel.PROP_NODE_DBID)).toString();
-     
-     /**
-      * Send From the test user TEST_EMAIL to the test user's home
-      */
-     String from = TEST_EMAIL;
-     String to = testDocDBID + "@alfresco.com";
-     String content = "hello world";
- 
-     Session sess = Session.getDefaultInstance(new Properties());
-     assertNotNull("sess is null", sess);
-     SMTPMessage msg = new SMTPMessage(sess);
-     InternetAddress[] toa =  { new InternetAddress(to) };
- 
-     msg.setFrom(new InternetAddress(TEST_EMAIL));
-     msg.setRecipients(Message.RecipientType.TO, toa);
-     msg.setSubject(TEST_SUBJECT);
-     msg.setContent(content, "text/plain");
-         
-     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-     msg.writeTo(bos);
-     InputStream is = IOUtils.toInputStream(bos.toString());
-     assertNotNull("is is null", is);
- 
-     SubethaEmailMessage m = new SubethaEmailMessage(is);   
-     
-     /**
-      * Turn on overwriteDuplicates
-      */
-     logger.debug("Step 1: send an email to a transfer report");
-           
-     EmailDelivery delivery = new EmailDelivery(to, from, null);
+        String from = TEST_EMAIL;
+        String to = testUserHomeDBID;
+        String content = "hello world";
 
-     emailService.importMessage(delivery, m);
-     
- } // end of test sending to trx:transferReport
+        Session sess = Session.getDefaultInstance(new Properties());
+        assertNotNull("sess is null", sess);
+        SMTPMessage msg = new SMTPMessage(sess);
+        InternetAddress[] toa = {new InternetAddress(to)};
 
+        EmailDelivery delivery = new EmailDelivery(to, from, null);
 
-   
-   
-   
-   /**
-    * The Email contributors authority controls who can add email.
-    * 
-    * This test switches between the EMAIL_CONTRIBUTORS group and EVERYONE
-    */
-   public void testEmailContributorsAuthority() throws Exception
-   {
-       EmailServiceImpl emailServiceImpl = (EmailServiceImpl)emailService;
-       
-       folderEmailMessageHandler.setOverwriteDuplicates(true);
-       
-       logger.debug("Start testEmailContributorsAuthority");
-       
-       String TEST_EMAIL="buffy@sunnydale.high";
-       
-       // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
-       NodeRef person = personService.getPerson(TEST_USER);
-       if(person == null)
-       {
-           logger.debug("new person created");
-           Map<QName, Serializable> props = new HashMap<QName, Serializable>();
-           props.put(ContentModel.PROP_USERNAME, TEST_USER);
-           props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
-           person = personService.createPerson(props);
-       }
-       nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+        msg.setFrom(new InternetAddress(TEST_EMAIL));
+        msg.setRecipients(Message.RecipientType.TO, toa);
+        msg.setContent(content, "text/plain");
 
-       Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
-       if(auths.contains(TEST_USER))
-       {
-           authorityService.removeAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
-       }
-       
-       String companyHomePathInStore = "/app:company_home"; 
-       String storePath = "workspace://SpacesStore";
-       StoreRef storeRef = new StoreRef(storePath);
+        msg.setSubject(TEST_CASE_SENSITIVITY_SUBJECT);
+        ByteArrayOutputStream bos1 = new ByteArrayOutputStream();
+        msg.writeTo(bos1);
+        InputStream is = IOUtils.toInputStream(bos1.toString());
+        assertNotNull("is is null", is);
+        SubethaEmailMessage m = new SubethaEmailMessage(is);
+        folderEmailMessageHandler.setOverwriteDuplicates(false);
+        emailService.importMessage(delivery, m);
 
-       NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
-       List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
-       NodeRef companyHomeNodeRef = nodeRefs.get(0);
-       assertNotNull("company home is null", companyHomeNodeRef);
-       String companyHomeDBID = ((Long)nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       NodeRef testUserHomeFolder = (NodeRef)nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
-       assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
-       String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
-       
-      /**
-       * Step 1
-       * Set the email contributors authority to EVERYONE 
-       * 
-       * Test that TEST_USER is allowed to send email - so even though TEST_USER is not 
-       * a contributor
-       */
-       emailServiceImpl.setEmailContributorsAuthority("EVERYONE");
-     
-       String from = "admin";
-       String to =  testUserHomeDBID;
-       String content = "hello world";
-       
-       Session sess = Session.getDefaultInstance(new Properties());
-       assertNotNull("sess is null", sess);
-       SMTPMessage msg = new SMTPMessage(sess);
-       InternetAddress[] toa =  { new InternetAddress(to) };
-       
-       msg.setFrom(new InternetAddress(TEST_EMAIL));
-       msg.setRecipients(Message.RecipientType.TO, toa);
-       msg.setSubject("JavaMail APIs transport.java Test");
-       msg.setContent(content, "text/plain");
-               
-       StringBuffer sb = new StringBuffer();
-       ByteArrayOutputStream bos = new ByteArrayOutputStream();
-       msg.writeTo(bos);
-       InputStream is = IOUtils.toInputStream(bos.toString());
-       assertNotNull("is is null", is);
-       
-       SubethaEmailMessage m = new SubethaEmailMessage(is);  
-       
-       EmailDelivery delivery = new EmailDelivery(to, from, null);
+        QName safeQName = QName.createQNameWithValidLocalName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_CASE_SENSITIVITY_SUBJECT);
+        List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, safeQName);
+        assertEquals(1, assocs.size());
 
-       emailService.importMessage(delivery, m);
-       
-       /**
-        * Step 2
-        * Negative test
-        * 
-        * Send From the test user TEST_EMAIL to the test user's home
-        */
-       try 
-       {
-           logger.debug("Step 2");
-           emailServiceImpl.setEmailContributorsAuthority("EMAIL_CONTRIBUTORS");
-           emailService.importMessage(delivery, m);
-           fail("not thrown out");
-       }
-       catch (EmailMessageException e)
-       {
-         // Check the exception is for the anonymous user.
-         // assertTrue(e.getMessage().contains("anonymous"));
-       }
-   }
- 
+        msg.setSubject(TEST_CASE_SENSITIVITY_SUBJECT.toUpperCase());
+        ByteArrayOutputStream bos2 = new ByteArrayOutputStream();
+        msg.writeTo(bos2);
+        is = IOUtils.toInputStream(bos2.toString());
+        assertNotNull("is is null", is);
+        m = new SubethaEmailMessage(is);
+        folderEmailMessageHandler.setOverwriteDuplicates(false);
+        emailService.importMessage(delivery, m);
+
+        safeQName = QName.createQNameWithValidLocalName(NamespaceService.CONTENT_MODEL_1_0_URI, TEST_CASE_SENSITIVITY_SUBJECT.toUpperCase() + "(1)");
+        assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, safeQName);
+        assertEquals(1, assocs.size());
+    }
+
+    /**
+     * ALF-12297
+     *
+     * Test messages being sent to a cm:content node
+     */
+    public void testMessagesToDocument() throws Exception
+    {
+        logger.debug("Start testMessagesToDocument");
+
+        String TEST_EMAIL = "buffy@sunnydale.high";
+
+        String TEST_SUBJECT = "Practical Bee Keeping";
+
+        String TEST_LONG_SUBJECT = "This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544";
+
+        // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
+        NodeRef person = personService.getPerson(TEST_USER);
+        if (person == null)
+        {
+            logger.debug("new person created");
+            Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+            props.put(ContentModel.PROP_USERNAME, TEST_USER);
+            props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
+            person = personService.createPerson(props);
+        }
+        nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+
+        Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
+        if (!auths.contains(TEST_USER))
+        {
+            authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
+        }
+
+        String companyHomePathInStore = "/app:company_home";
+        String storePath = "workspace://SpacesStore";
+        StoreRef storeRef = new StoreRef(storePath);
+
+        NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
+        List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
+        NodeRef companyHomeNodeRef = nodeRefs.get(0);
+        assertNotNull("company home is null", companyHomeNodeRef);
+        String companyHomeDBID = ((Long) nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        // String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
+        // String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+
+        // Clean up old messages in test folder
+        List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        for (ChildAssociationRef assoc : assocs)
+        {
+            nodeService.deleteNode(assoc.getChildRef());
+        }
+
+        Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
+        properties.put(ContentModel.PROP_NAME, "bees");
+        properties.put(ContentModel.PROP_DESCRIPTION, "bees - test doc for email tests");
+        ChildAssociationRef testDoc = nodeService.createNode(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "bees"), ContentModel.TYPE_CONTENT, properties);
+        NodeRef testDocNodeRef = testDoc.getChildRef();
+
+        String testDocDBID = ((Long) nodeService.getProperty(testDocNodeRef, ContentModel.PROP_NODE_DBID)).toString();
+
+        /**
+         * Send From the test user TEST_EMAIL to the test user's home
+         */
+        String from = TEST_EMAIL;
+        String to = testDocDBID + "@alfresco.com";
+        String content = "hello world";
+
+        Session sess = Session.getDefaultInstance(new Properties());
+        assertNotNull("sess is null", sess);
+        SMTPMessage msg = new SMTPMessage(sess);
+        InternetAddress[] toa = {new InternetAddress(to)};
+
+        msg.setFrom(new InternetAddress(TEST_EMAIL));
+        msg.setRecipients(Message.RecipientType.TO, toa);
+        msg.setSubject(TEST_SUBJECT);
+        msg.setContent(content, "text/plain");
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        msg.writeTo(bos);
+        InputStream is = IOUtils.toInputStream(bos.toString());
+        assertNotNull("is is null", is);
+
+        SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+        /**
+         * Turn on overwriteDuplicates
+         */
+        logger.debug("Step 1: send an email to a doc");
+
+        EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+        emailService.importMessage(delivery, m);
+
+        assertTrue(nodeService.hasAspect(testDocNodeRef, ForumModel.ASPECT_DISCUSSABLE));
+
+    } // end of test sending to cm:content node
+
+    /**
+     * ENH-560 - Inbound email server not working with custom types
+     */
+    public void testMessagesToSubTypeOfDocument() throws Exception
+    {
+        logger.debug("Start testMessagesToSubTypesOfDocument");
+
+        String TEST_EMAIL = "buffy@sunnydale.high";
+
+        String TEST_SUBJECT = "Practical Bee Keeping";
+
+        String TEST_LONG_SUBJECT = "This is a very very long name in particular it is greater than eitghty six characters which was a problem explored in ALF-9544";
+
+        // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
+        NodeRef person = personService.getPerson(TEST_USER);
+        if (person == null)
+        {
+            logger.debug("new person created");
+            Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+            props.put(ContentModel.PROP_USERNAME, TEST_USER);
+            props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
+            person = personService.createPerson(props);
+        }
+        nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+
+        Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
+        if (!auths.contains(TEST_USER))
+        {
+            authorityService.addAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
+        }
+
+        String companyHomePathInStore = "/app:company_home";
+        String storePath = "workspace://SpacesStore";
+        StoreRef storeRef = new StoreRef(storePath);
+
+        NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
+        List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
+        NodeRef companyHomeNodeRef = nodeRefs.get(0);
+        assertNotNull("company home is null", companyHomeNodeRef);
+        String companyHomeDBID = ((Long) nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        // String testUserDBID = ((Long)nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
+        // String testUserHomeDBID = ((Long)nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+
+        // Clean up old messages in test folder
+        List<ChildAssociationRef> assocs = nodeService.getChildAssocs(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, RegexQNamePattern.MATCH_ALL);
+        for (ChildAssociationRef assoc : assocs)
+        {
+            nodeService.deleteNode(assoc.getChildRef());
+        }
+
+        Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
+        properties.put(ContentModel.PROP_NAME, "hamster");
+        properties.put(ContentModel.PROP_DESCRIPTION, "syrian hamsters - test doc for email tests, sending to a subtype of cm:content");
+
+        // Transfer report is a subtype of cm:content
+        ChildAssociationRef testDoc = nodeService.createNode(testUserHomeFolder, ContentModel.ASSOC_CONTAINS, QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "bees"), TransferModel.TYPE_TRANSFER_REPORT, properties);
+        NodeRef testDocNodeRef = testDoc.getChildRef();
+
+        String testDocDBID = ((Long) nodeService.getProperty(testDocNodeRef, ContentModel.PROP_NODE_DBID)).toString();
+
+        /**
+         * Send From the test user TEST_EMAIL to the test user's home
+         */
+        String from = TEST_EMAIL;
+        String to = testDocDBID + "@alfresco.com";
+        String content = "hello world";
+
+        Session sess = Session.getDefaultInstance(new Properties());
+        assertNotNull("sess is null", sess);
+        SMTPMessage msg = new SMTPMessage(sess);
+        InternetAddress[] toa = {new InternetAddress(to)};
+
+        msg.setFrom(new InternetAddress(TEST_EMAIL));
+        msg.setRecipients(Message.RecipientType.TO, toa);
+        msg.setSubject(TEST_SUBJECT);
+        msg.setContent(content, "text/plain");
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        msg.writeTo(bos);
+        InputStream is = IOUtils.toInputStream(bos.toString());
+        assertNotNull("is is null", is);
+
+        SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+        /**
+         * Turn on overwriteDuplicates
+         */
+        logger.debug("Step 1: send an email to a transfer report");
+
+        EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+        emailService.importMessage(delivery, m);
+
+    } // end of test sending to trx:transferReport
+
+    /**
+     * The Email contributors authority controls who can add email.
+     *
+     * This test switches between the EMAIL_CONTRIBUTORS group and EVERYONE
+     */
+    public void testEmailContributorsAuthority() throws Exception
+    {
+        EmailServiceImpl emailServiceImpl = (EmailServiceImpl) emailService;
+
+        folderEmailMessageHandler.setOverwriteDuplicates(true);
+
+        logger.debug("Start testEmailContributorsAuthority");
+
+        String TEST_EMAIL = "buffy@sunnydale.high";
+
+        // TODO Investigate why setting PROP_EMAIL on createPerson does not work.
+        NodeRef person = personService.getPerson(TEST_USER);
+        if (person == null)
+        {
+            logger.debug("new person created");
+            Map<QName, Serializable> props = new HashMap<QName, Serializable>();
+            props.put(ContentModel.PROP_USERNAME, TEST_USER);
+            props.put(ContentModel.PROP_EMAIL, TEST_EMAIL);
+            person = personService.createPerson(props);
+        }
+        nodeService.setProperty(person, ContentModel.PROP_EMAIL, TEST_EMAIL);
+
+        Set<String> auths = authorityService.getContainedAuthorities(null, "GROUP_EMAIL_CONTRIBUTORS", true);
+        if (auths.contains(TEST_USER))
+        {
+            authorityService.removeAuthority("GROUP_EMAIL_CONTRIBUTORS", TEST_USER);
+        }
+
+        String companyHomePathInStore = "/app:company_home";
+        String storePath = "workspace://SpacesStore";
+        StoreRef storeRef = new StoreRef(storePath);
+
+        NodeRef storeRootNodeRef = nodeService.getRootNode(storeRef);
+        List<NodeRef> nodeRefs = searchService.selectNodes(storeRootNodeRef, companyHomePathInStore, null, namespaceService, false);
+        NodeRef companyHomeNodeRef = nodeRefs.get(0);
+        assertNotNull("company home is null", companyHomeNodeRef);
+        String companyHomeDBID = ((Long) nodeService.getProperty(companyHomeNodeRef, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        String testUserDBID = ((Long) nodeService.getProperty(person, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+        NodeRef testUserHomeFolder = (NodeRef) nodeService.getProperty(person, ContentModel.PROP_HOMEFOLDER);
+        assertNotNull("testUserHomeFolder is null", testUserHomeFolder);
+        String testUserHomeDBID = ((Long) nodeService.getProperty(testUserHomeFolder, ContentModel.PROP_NODE_DBID)).toString() + "@Alfresco.com";
+
+        /**
+         * Step 1 Set the email contributors authority to EVERYONE
+         *
+         * Test that TEST_USER is allowed to send email - so even though TEST_USER is not a contributor
+         */
+        emailServiceImpl.setEmailContributorsAuthority("EVERYONE");
+
+        String from = "admin";
+        String to = testUserHomeDBID;
+        String content = "hello world";
+
+        Session sess = Session.getDefaultInstance(new Properties());
+        assertNotNull("sess is null", sess);
+        SMTPMessage msg = new SMTPMessage(sess);
+        InternetAddress[] toa = {new InternetAddress(to)};
+
+        msg.setFrom(new InternetAddress(TEST_EMAIL));
+        msg.setRecipients(Message.RecipientType.TO, toa);
+        msg.setSubject("JavaMail APIs transport.java Test");
+        msg.setContent(content, "text/plain");
+
+        StringBuffer sb = new StringBuffer();
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        msg.writeTo(bos);
+        InputStream is = IOUtils.toInputStream(bos.toString());
+        assertNotNull("is is null", is);
+
+        SubethaEmailMessage m = new SubethaEmailMessage(is);
+
+        EmailDelivery delivery = new EmailDelivery(to, from, null);
+
+        emailService.importMessage(delivery, m);
+
+        /**
+         * Step 2 Negative test
+         *
+         * Send From the test user TEST_EMAIL to the test user's home
+         */
+        try
+        {
+            logger.debug("Step 2");
+            emailServiceImpl.setEmailContributorsAuthority("EMAIL_CONTRIBUTORS");
+            emailService.importMessage(delivery, m);
+            fail("not thrown out");
+        }
+        catch (EmailMessageException e)
+        {
+            // Check the exception is for the anonymous user.
+            // assertTrue(e.getMessage().contains("anonymous"));
+        }
+    }
+
 } // end of EmailServiceImplTest


### PR DESCRIPTION
Since `subethasmtp` [switched to Jakarta Mail 2.1](https://github.com/davidmoten/subethasmtp/pull/124/files), some tests failed due to the incompatible `com.sun.mail:jakarta.mail` implementation (See: https://github.com/Alfresco/alfresco-community-repo/actions/runs/12918991059/job/36029451587#step:13:603)
This PR is to bump `subethasmtp` version to `7.1.3` and use `org.eclipse.angus:angus-mail:2.0.3` which is a compatible implementation of the [Jakarta Mail Specification 2.1+](https://jakarta.ee/specifications/mail/).

Ref. https://eclipse-ee4j.github.io/angus-mail/