### PR TITLE
Revert Unlock Document Changes

### DIFF
--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/action/unlock-document.post.json.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/action/unlock-document.post.json.js
@@ -23,10 +23,6 @@ function runAction(p_params)
       if (p_params.destNode.hasAspect("cm:lockable") && !p_params.destNode.hasAspect("trx:transferred"))
       {
          p_params.destNode.unlock();
-         if(p_params.destNode.hasAspect("gd2:editingInGoogle"))
-         {
-             p_params.destNode.removeAspect("gd2:editingInGoogle");
-         }
       }
 
       var resultId = originalDoc.name,


### PR DESCRIPTION
This PR includes the the changes to revert the commit done as a part of task https://hyland.atlassian.net/browse/AFI-203.

The MNT says that the code should be reverted and the code which was  added earlier must be moved to Google Docs code and leave this resource in Share Services as it was before the commit. So we have reverted the commit.

Created a new task https://hyland.atlassian.net/browse/APPS-3230 to move this code to GoogleDocs. As there is no GoogleDocs Release planned so will take this up in upcoming release.