### PR TITLE
[ACS-9167] [Share][ADW] Certain smart folders return incorrect pagination information

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 

--- a/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
@@ -204,7 +204,7 @@ public class VirtualQueryImpl implements VirtualQuery
             }
         }
         final int totalSecond = !hasMore ? (int) result.getNumberFound() : (int) (start + result.getNumberFound());
-        final Pair<Integer, Integer> total = new Pair<Integer, Integer>(totalFirst, totalSecond);
+        final Pair<Integer, Integer> total = new Pair<>(totalFirst, totalSecond);
         return new PagingResults<Reference>() {
 
             @Override

--- a/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/virtual/template/VirtualQueryImpl.java
@@ -203,9 +203,8 @@ public class VirtualQueryImpl implements VirtualQuery
                 start = 0;
             }
         }
-        final int totlaSecond = !hasMore ? (int) result.getNumberFound() : (int) (start + result.getNumberFound() + 1);
-        final Pair<Integer, Integer> total = new Pair<Integer, Integer>(totalFirst,
-                totlaSecond);
+        final int totalSecond = !hasMore ? (int) result.getNumberFound() : (int) (start + result.getNumberFound());
+        final Pair<Integer, Integer> total = new Pair<Integer, Integer>(totalFirst, totalSecond);
         return new PagingResults<Reference>() {
 
             @Override

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/metadata-query-SqlMap.xml
@@ -8,4 +8,10 @@
     <include refid="sql_select_byDynamicQuery"/>   
   </select>
 
+  <select id="count_byDynamicQuery" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultType="int">
+    SELECT COUNT(DISTINCT nodes.id)
+    FROM (
+      <include refid="sql_select_byDynamicQuery"/>
+    ) nodes
+  </select>
 </mapper>

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/metadata-query-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.MySQLInnoDBDialect/metadata-query-SqlMap.xml
@@ -8,4 +8,10 @@
       <include refid="sql_select_byDynamicQuery"/>   
   </select>
 
+  <select id="count_byDynamicQuery" parameterType="org.alfresco.repo.search.impl.querymodel.impl.db.DBQuery" resultType="int">
+    SELECT COUNT(DISTINCT nodes.id)
+    FROM (
+      <include refid="sql_select_byDynamicQuery"/>
+    ) nodes
+  </select>
 </mapper>

--- a/repository/src/test/java/org/alfresco/AllDBTestsTestSuite.java
+++ b/repository/src/test/java/org/alfresco/AllDBTestsTestSuite.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/test/java/org/alfresco/AllDBTestsTestSuite.java
+++ b/repository/src/test/java/org/alfresco/AllDBTestsTestSuite.java
@@ -80,6 +80,7 @@ import org.alfresco.util.testing.category.NonBuildTests;
 
         // ACS-1907
         org.alfresco.repo.search.impl.querymodel.impl.db.ACS1907Test.class,
+        org.alfresco.repo.search.impl.querymodel.impl.db.ACS9167Test.class,
 
         // REPO-2963 : Tests causing a cascade of failures in AllDBTestsTestSuite on PostgreSQL/MySQL
         // Moved at the bottom of the suite because DbNodeServiceImplTest.testNodeCleanupRegistry() takes a long time on a clean DB.

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/ACS9167Test.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/ACS9167Test.java
@@ -1,0 +1,200 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.search.impl.querymodel.impl.db;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
+import org.springframework.context.ApplicationContext;
+
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.cache.TransactionalCache;
+import org.alfresco.repo.security.authentication.AuthenticationComponent;
+import org.alfresco.repo.security.permissions.AccessControlList;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.search.QueryConsistency;
+import org.alfresco.service.cmr.search.ResultSet;
+import org.alfresco.service.cmr.search.SearchParameters;
+import org.alfresco.service.cmr.search.SearchService;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.service.transaction.TransactionService;
+import org.alfresco.test_category.OwnJVMTestsCategory;
+import org.alfresco.util.ApplicationContextHelper;
+import org.alfresco.util.testing.category.DBTests;
+
+@Category({OwnJVMTestsCategory.class, DBTests.class})
+public class ACS9167Test extends TestCase
+{
+    private ApplicationContext ctx;
+
+    private NodeService nodeService;
+    private AuthenticationComponent authenticationComponent;
+    private SearchService pubSearchService;
+    private TransactionService transactionService;
+    private RetryingTransactionHelper txnHelper;
+
+    private TransactionalCache<Serializable, AccessControlList> aclCache;
+    private TransactionalCache<Serializable, Object> aclEntityCache;
+    private TransactionalCache<Serializable, Object> permissionEntityCache;
+    private TransactionalCache<Serializable, Object> nodeOwnerCache;
+
+    @Override
+    public void setUp() throws Exception
+    {
+        setupServices();
+        txnHelper = new RetryingTransactionHelper();
+        txnHelper.setTransactionService(transactionService);
+        txnHelper.setReadOnly(false);
+        txnHelper.setMaxRetries(1);
+        authenticationComponent.setSystemUserAsCurrentUser();
+        dropCaches();
+    }
+
+    private void setupServices()
+    {
+        ctx = ApplicationContextHelper.getApplicationContext();
+        nodeService = (NodeService) ctx.getBean("dbNodeService");
+        authenticationComponent = (AuthenticationComponent) ctx.getBean("authenticationComponent");
+        pubSearchService = (SearchService) ctx.getBean("SearchService");
+        transactionService = (TransactionService) ctx.getBean("TransactionService");
+        aclCache = (TransactionalCache) ctx.getBean("aclCache");
+        aclEntityCache = (TransactionalCache) ctx.getBean("aclEntityCache");
+        permissionEntityCache = (TransactionalCache) ctx.getBean("permissionEntityCache");
+        nodeOwnerCache = (TransactionalCache) ctx.getBean("nodeOwnerCache");
+    }
+
+    private void dropCaches()
+    {
+        aclCache.clear();
+        aclEntityCache.clear();
+        permissionEntityCache.clear();
+        nodeOwnerCache.clear();
+    }
+
+    @Override
+    protected void tearDown() throws Exception
+    {
+        authenticationComponent.clearCurrentSecurityContext();
+    }
+
+    public void testPagination()
+    {
+        String searchMarker = UUID.randomUUID().toString();
+        int contentFilesCount = 185;
+        createFolderWithContentNodes(searchMarker, contentFilesCount);
+
+        prepareParametersQueryAndAssertResult(searchMarker, 0, 50, 50, contentFilesCount);
+        prepareParametersQueryAndAssertResult(searchMarker, 50, 50, 50, contentFilesCount);
+        prepareParametersQueryAndAssertResult(searchMarker, 150, 50, 35, contentFilesCount);
+        prepareParametersQueryAndAssertResult(searchMarker, 200, 50, 0, contentFilesCount);
+
+        prepareParametersQueryAndAssertResult(searchMarker, 0, 100, 100, contentFilesCount);
+        prepareParametersQueryAndAssertResult(searchMarker, 100, 100, 85, contentFilesCount);
+        prepareParametersQueryAndAssertResult(searchMarker, 200, 100, 0, contentFilesCount);
+
+        prepareParametersQueryAndAssertResult(searchMarker, 0, 200, contentFilesCount, contentFilesCount);
+    }
+
+    public void testLargeFilesCount()
+    {
+        String searchMarker = UUID.randomUUID().toString();
+        int contentFilesCount = 10_000;
+        createFolderWithContentNodes(searchMarker, contentFilesCount);
+
+        prepareParametersQueryAndAssertResult(searchMarker, 0, Integer.MAX_VALUE, contentFilesCount, contentFilesCount);
+    }
+
+    private void createFolderWithContentNodes(String searchMarker, int contentFilesCount)
+    {
+        txnHelper.doInTransaction(() -> {
+            NodeRef testFolder = createFolderNode();
+            for (int c = 1; c <= contentFilesCount; c++)
+            {
+                createContentNode(searchMarker, testFolder);
+            }
+            return null;
+        }, false, false);
+    }
+
+    private void prepareParametersQueryAndAssertResult(String searchMarker, int parameterSkipCount, int parameterMaxItems, int expectedLength, int expectedNumberFound)
+    {
+        txnHelper.doInTransaction(() -> {
+            // given
+            SearchParameters sp = new SearchParameters();
+            sp.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
+            sp.setLanguage(SearchService.LANGUAGE_FTS_ALFRESCO);
+            sp.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
+            sp.setQuery("(+TYPE:'cm:content') and !ASPECT:'cm:checkedOut' and !TYPE:'fm:forum' and !TYPE:'fm:topic' and !TYPE:'cm:systemfolder' and !TYPE:'fm:post' and !TYPE:'fm:forums' and =cm:description:'" + searchMarker + "'");
+            sp.setSkipCount(parameterSkipCount);
+            sp.setMaxItems(parameterMaxItems);
+            sp.setMaxPermissionChecks(Integer.MAX_VALUE);
+            sp.setMaxPermissionCheckTimeMillis(Duration.ofSeconds(60).toMillis());
+            // when
+            ResultSet resultSet = pubSearchService.query(sp);
+            // then
+            assertEquals(expectedLength, resultSet.length());
+            assertEquals(expectedNumberFound, resultSet.getNumberFound());
+            return null;
+        }, false, false);
+    }
+
+    private NodeRef createFolderNode()
+    {
+        NodeRef rootNodeRef = nodeService.getRootNode(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
+        Map<QName, Serializable> testFolderProps = new HashMap<>();
+        String folderName = "folder" + UUID.randomUUID();
+        testFolderProps.put(ContentModel.PROP_NAME, folderName);
+        return nodeService.createNode(
+                rootNodeRef,
+                ContentModel.ASSOC_CHILDREN,
+                QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, folderName),
+                ContentModel.TYPE_FOLDER,
+                testFolderProps).getChildRef();
+    }
+
+    private void createContentNode(String searchMarker, NodeRef testFolder)
+    {
+        Map<QName, Serializable> testContentProps = new HashMap<>();
+        String fileName = "content" + UUID.randomUUID();
+        testContentProps.put(ContentModel.PROP_NAME, fileName);
+        testContentProps.put(ContentModel.PROP_DESCRIPTION, searchMarker);
+        nodeService.createNode(
+                testFolder,
+                ContentModel.ASSOC_CONTAINS,
+                QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, fileName),
+                ContentModel.TYPE_CONTENT,
+                testContentProps);
+    }
+}

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/ACS9167Test.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/ACS9167Test.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -60,7 +60,8 @@ import org.alfresco.util.Pair;
 
 public class DBQueryEngineTest
 {
-    private static final String SQL_TEMPLATE_PATH = "alfresco.metadata.query.select_byDynamicQuery";
+    private static final String SQL_SELECT_TEMPLATE_PATH = "alfresco.metadata.query.select_byDynamicQuery";
+    private static final String SQL_COUNT_TEMPLATE_PATH = "alfresco.metadata.query.count_byDynamicQuery";
 
     private DBQueryEngine engine;
     private SqlSessionTemplate template;
@@ -94,6 +95,7 @@ public class DBQueryEngineTest
     public void shouldGetAFilteringResultSetFromAcceleratedNodeSelection()
     {
         withMaxItems(10);
+        when(template.selectOne(any(), eq(dbQuery))).thenReturn(10);
 
         ResultSet result = engine.acceleratedNodeSelection(options, dbQuery, assessor);
 
@@ -226,7 +228,9 @@ public class DBQueryEngineTest
             }
             return null;
 
-        }).when(template).select(eq(SQL_TEMPLATE_PATH), eq(dbQuery), any());
+        }).when(template).select(eq(SQL_SELECT_TEMPLATE_PATH), eq(dbQuery), any());
+
+        when(template.selectOne(eq(SQL_COUNT_TEMPLATE_PATH), eq(dbQuery))).thenReturn(nodes.size());
     }
 
     private QueryOptions createQueryOptions()

--- a/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngineTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2021 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software. 
  * If the software was purchased under a paid Alfresco license, the terms of 


### PR DESCRIPTION
See https://hyland.atlassian.net/browse/ACS-9167?focusedCommentId=2314798

Summary:
Added second query to count all nodes matching the query to fix pagination having incorrect totalItems which in turn breaks pagination on frontend when using smart folders.

COMMUNITY:
```
{
  "paging": {
    "maxItems": 50,
    "skipCount": 0
  },
  "query": {
    "language": "afts",
    "query": "(+TYPE:'cm:content') and !ASPECT:'cm:checkedOut' and !TYPE:'fm:forum' and !TYPE:'fm:topic' and !TYPE:'cm:systemfolder' and !TYPE:'fm:post' and !TYPE:'fm:forums'"
  },
  "sort": [
    {
      "ascending": false,
      "field": "cm:name",
      "type": "FIELD"
    }
  ]
}
```

In community this is translated to:
```
select node.id as id, node.version as version, node.store_id as store_id, node.uuid as uuid, node.type_qname_id as type_qname_id, node.locale_id as locale_id, node.acl_id as acl_id, txn.id as txn_id, txn.change_txn_id as txn_change_id, node.audit_creator as audit_creator, node.audit_created as audit_created, node.audit_modifier as audit_modifier, node.audit_modified as audit_modified, node.audit_accessed as audit_accessed 
from alf_node node join alf_transaction txn on (txn.id = node.transaction_id) left outer join alf_node_properties PROP_0 on ((PROP_0.node_id = node.id) AND (28 = PROP_0.qname_id)) 
where node.type_qname_id <> 148 AND node.store_id = 6 AND ( ( node.type_qname_id IN ( 212 , 205 , 53 , 198 , 199 , 105 ) ) AND NOT node.id IN (select aspect.node_id from alf_node_aspects aspect where aspect.qname_id IN ( -1 ) ) AND NOT ( node.type_qname_id IN ( 195 ) ) AND NOT ( node.type_qname_id IN ( 197 ) ) AND NOT ( node.type_qname_id IN ( 61 ) ) AND NOT ( node.type_qname_id IN ( 198 ) ) AND NOT ( node.type_qname_id IN ( -1 ) ) ) 
order by PROP_0.string_value ASC
```

ENTERPRISE:
```
{
  "paging": {
    "maxItems": 50,
    "skipCount": 0
  },
  "query": {
    "language": "afts",
    "query": "(+TYPE:'cm:content') and ASPECT:'cm:versionable' and !TYPE:'fm:forum' and !TYPE:'fm:topic' and !TYPE:'cm:systemfolder' and !TYPE:'fm:post' and !TYPE:'fm:forums'"
  },
  "sort": [
    {
      "ascending": false,
      "field": "cm:name",
      "type": "FIELD"
    }
  ]
}
```
Compared to community, I changed the ASPECT part because ASPECT negation is not supported in query acceleration and it defaults to community in that case.

In enterprise this is translated to:
```
select denorm.node_id as id, denorm.owner_id as owner_id, node.version as version, node.store_id as store_id, node.uuid as uuid, node.type_qname_id as type_qname_id, node.locale_id as locale_id, node.acl_id as acl_id, txn.id as txn_id, txn.change_txn_id as txn_change_id, node.audit_creator as audit_creator, node.audit_created as audit_created, node.audit_modifier as audit_modifier, node.audit_modified as audit_modified, node.audit_accessed as audit_accessed 
from alf_qs_test01_v1 denorm join alf_node node on (node.id = denorm.node_id) join alf_transaction txn on (txn.id = node.transaction_id) 
where node.type_qname_id <> 148 AND node.store_id = 6 AND ( node.type_qname_id IN ( 212 , 205 , 53 , 198 , 199 , 105 ) AND denorm.cm_versionable = true AND NOT node.type_qname_id IN ( 195 ) AND NOT node.type_qname_id IN ( 197 ) AND NOT node.type_qname_id IN ( 61 ) AND NOT node.type_qname_id IN ( 198 ) AND NOT node.type_qname_id IN ( -1 ) ) 
order by denorm.cm_name DESC
```

THE SOLUTION FOR BOTH COMMUNITY AND ENTERPRISE:
I added second database query to get total nodes:
```
SELECT COUNT(DISTINCT nodes.id) FROM ( <whole select above> ) nodes
```
[enterprise_explain_analyze_count.txt](https://github.com/user-attachments/files/19343083/enterprise_explain_analyze_count.txt)
[enterprise_explain_analyze_select.txt](https://github.com/user-attachments/files/19343084/enterprise_explain_analyze_select.txt)
[explain_analyze_count.txt](https://github.com/user-attachments/files/19343085/explain_analyze_count.txt)
[explain_analyze_select.txt](https://github.com/user-attachments/files/19343086/explain_analyze_select.txt)

---
Performance testing results:
mysql 8 with 580,734 nodes in alf_node on MacBook Apple M3 Pro using `ACS9167Test`
```
extreme scenario 1:
	1 query for 50_000 nodes:
		select_byDynamicQuery batchsize=10_000 8s
		select_byDynamicQuery batchsize=10_000 15s
		select_byDynamicQuery batchsize=10_000 22s
		select_byDynamicQuery batchsize=10_000 26s
		select_byDynamicQuery batchsize=10_000 29s
		count_byDynamicQuery 26s
	total: 1min 56s

normal scenario 1:
	1 query for first 50 items out of 185
		select_byDynamicQuery 6ms
		count_byDynamicQuery 1ms
	1 query for second 50 items out of 185
		select_byDynamicQuery 3ms
		count_byDynamicQuery 1ms
	1 query for third 50 items out of 185
		select_byDynamicQuery 3ms
		count_byDynamicQuery 1ms
	1 query for remaining 35 items out of 185
		select_byDynamicQuery 3ms
		count_byDynamicQuery 1ms
normal scenario 2:
 	1 query for 100 items out of 185
		select_byDynamicQuery 4ms
		count_byDynamicQuery 1ms
	1 query for remaining 85 items out of 185
		select_byDynamicQuery 3ms
		count_byDynamicQuery 2ms
	1 query for 0 items out of 185
		select_byDynamicQuery 2ms
		count_byDynamicQuery 2ms
normal scenario 3:
	1 query for all 185 items out of 185
		select_byDynamicQuery 3ms
		count_byDynamicQuery 2ms
```
[performanceResults.txt](https://github.com/user-attachments/files/19391902/performanceResults.txt)

