### PR TITLE
PRODSEC-10029 - to bumping apache camel and netty to latest safe comp…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.3.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.6.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.117.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.10.2</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.118.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
         <dependency.activemq.version>5.18.3</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/repository/src/test/resources/testRoutes.xml
+++ b/repository/src/test/resources/testRoutes.xml
@@ -31,7 +31,7 @@
              </onException>
              <transacted />
             <loadBalance>        
-                <roundRobin/>
+                <roundRobinLoadBalancer/>
                 <to uri="bean:mockExceptionThrowingConsumer"/>
                 <to uri="bean:mockConsumer"/>
             </loadBalance>


### PR DESCRIPTION
Bumps dependency.camel.version from 4.6.0 to 4.10.2
Bumps dependency.netty.version from 4.1.117.Final to 4.1.118.Final