### PR TITLE
[MNT-24937] Fix EventTableOutbox messages flooding the logs on bootstrap failure

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventGenerator.java
@@ -542,10 +542,7 @@ public class EventGenerator extends AbstractLifecycleBean implements Initializin
     @Override
     protected void onShutdown(ApplicationEvent applicationEvent)
     {
-        if (eventSender != null)
-        {
-            eventSender.destroy();
-        }
+        // NOOP
     }
 
     protected class EventTransactionListener extends TransactionListenerAdapter

--- a/repository/src/main/java/org/alfresco/repo/event2/EventSender.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventSender.java
@@ -52,7 +52,7 @@ public interface EventSender
     }
 
     /**
-     * It's called when the application context is closing, allowing {@link org.alfresco.repo.event2.EventGenerator} to perform cleanup operations.
+     * It's called when the bean instance is destroyed, allowing to perform cleanup operations.
      */
     default void destroy()
     {

--- a/repository/src/main/java/org/alfresco/repo/event2/EventSenderFactoryBean.java
+++ b/repository/src/main/java/org/alfresco/repo/event2/EventSenderFactoryBean.java
@@ -156,4 +156,13 @@ public class EventSenderFactoryBean extends AbstractFactoryBean<EventSender>
     {
         return event2MessageProducer;
     }
+
+    @Override
+    protected void destroyInstance(EventSender eventSender)
+    {
+        if (eventSender != null)
+        {
+            eventSender.destroy();
+        }
+    }
 }


### PR DESCRIPTION
Explanation:
https://hyland.atlassian.net/browse/MNT-24937

community config:
`<bean id="eventSender" class="org.alfresco.repo.event2.EventSenderFactoryBean" autowire="constructor" parent="baseEventSender" />`

enterprise config:
`<bean id="eventSender" class="org.alfresco.enterprise.repo.event2.EnterpriseEventSenderFactoryBean" autowire="constructor" parent="baseEventSender">
	<property name="outboxEventSenderFactory" ref="outboxEventSenderFactory" />
</bean>`

![Screenshot 2025-03-27 at 13 35 33](https://github.com/user-attachments/assets/67412f45-60c2-46b8-9329-10727276113e)
[logAfterFixVersion2.txt](https://github.com/user-attachments/files/19486463/logAfterFixVersion2.txt)
[gracefulExitAfterFixVersion2.txt](https://github.com/user-attachments/files/19486462/gracefulExitAfterFixVersion2.txt)

Initial solution:
https://github.com/Alfresco/alfresco-enterprise-repo/pull/2396