### PR TITLE
MNT-24308 On click of 'My Favorites' under 'Documents' 

### DIFF
--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary-v2/filters.lib.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary-v2/filters.lib.js
@@ -189,7 +189,7 @@ var Filters =
                filterQuery += "ID:\"" + favourite + "\"";
             }
             
-            if (filterQuery.length !== 0)
+            if (filterQuery.length !== 0 && filterQuery !== "ID:\"\"")
             {
                filterQuery = "+(" + filterQuery + ")";
                // no need to specify path here for all sites - IDs are exact matches
@@ -201,7 +201,7 @@ var Filters =
             else
             {
                // empty favourites query
-               filterQuery = "+ID:\"\"";
+               filterQuery = "+ID:\"default\"";
             }
             
             filterParams.query = filterQuery;


### PR DESCRIPTION
When user clicks on **My Favorites** under **Document** in **Document Library** page, all the links under Documents node are appear grayed out while using elastic search. As elastic search not allowing to search with empty string literal. So handled this fix by passing "default" value instead of empty string literal 