### PR TITLE
fix/MNT-24891-BackPort - Skip actionContext to classify as an adhoc property in add-features action logic

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuter.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/main/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuter.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.alfresco.repo.action.ParameterDefinitionImpl;
+import org.alfresco.repo.action.access.ActionAccessRestriction;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.action.ParameterDefinition;
@@ -42,7 +43,7 @@ import org.alfresco.service.transaction.TransactionService;
 
 /**
  * Add features action executor implementation.
- * 
+ *
  * @author Roy Wetherall
  */
 public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
@@ -53,35 +54,37 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
     public static final String NAME = "add-features";
     public static final String PARAM_ASPECT_NAME = "aspect-name";
     public static final String PARAM_CONSTRAINT = "ac-aspects";
-    
+
     /**
      * The node service
      */
     private NodeService nodeService;
-    
+
     /** Transaction Service, used for retrying operations */
     private TransactionService transactionService;
-    
+
     /**
      * Set the node service
-     * 
-     * @param nodeService  the node service 
+     *
+     * @param nodeService
+     *         the node service
      */
-    public void setNodeService(NodeService nodeService) 
+    public void setNodeService(NodeService nodeService)
     {
         this.nodeService = nodeService;
     }
-    
+
     /**
      * Set the transaction service
-     * 
-     * @param transactionService    the transaction service
+     *
+     * @param transactionService
+     *         the transaction service
      */
     public void setTransactionService(TransactionService transactionService)
     {
         this.transactionService = transactionService;
     }
-    
+
     /**
      * Adhoc properties are allowed for this executor
      */
@@ -98,43 +101,44 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
     {
         if (this.nodeService.exists(actionedUponNodeRef))
         {
-           transactionService.getRetryingTransactionHelper().doInTransaction(
-              new RetryingTransactionCallback<Void>()
-              {
-                 public Void execute() throws Throwable
-                 {
-                     Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
-                     QName aspectQName = null;
+            transactionService.getRetryingTransactionHelper().doInTransaction(
+                    new RetryingTransactionCallback<Void>()
+                    {
+                        public Void execute() throws Throwable
+                        {
+                            Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
+                            QName aspectQName = null;
 
-                     if(! nodeService.exists(actionedUponNodeRef))
-                     {
-                         // Node has gone away, skip
-                         return null;
-                     }
+                            if (!nodeService.exists(actionedUponNodeRef))
+                            {
+                                // Node has gone away, skip
+                                return null;
+                            }
 
-                     // Build the aspect details
-                     Map<String, Serializable> paramValues = ruleAction.getParameterValues();
-                     for (Map.Entry<String, Serializable> entry : paramValues.entrySet())
-                     {
-                         if (entry.getKey().equals(PARAM_ASPECT_NAME) == true)
-                         {
-                             aspectQName = (QName)entry.getValue();
-                         }
-                         else
-                         {
-                             // Must be an adhoc property
-                             QName propertyQName = QName.createQName(entry.getKey());
-                             Serializable propertyValue = entry.getValue();
-                             properties.put(propertyQName, propertyValue);
-                         }
-                     }
+                            // Build the aspect details
+                            Map<String, Serializable> paramValues = ruleAction.getParameterValues();
+                            removeActionContextParameter(paramValues);
+                            for (Map.Entry<String, Serializable> entry : paramValues.entrySet())
+                            {
+                                if (entry.getKey().equals(PARAM_ASPECT_NAME) == true)
+                                {
+                                    aspectQName = (QName) entry.getValue();
+                                }
+                                else
+                                {
+                                    // Must be an adhoc property
+                                    QName propertyQName = QName.createQName(entry.getKey());
+                                    Serializable propertyValue = entry.getValue();
+                                    properties.put(propertyQName, propertyValue);
+                                }
+                            }
 
-                     // Add the aspect
-                     nodeService.addAspect(actionedUponNodeRef, aspectQName, properties);
-                     return null;
-                 }
-              }
-           );
+                            // Add the aspect
+                            nodeService.addAspect(actionedUponNodeRef, aspectQName, properties);
+                            return null;
+                        }
+                    }
+            );
         }
     }
 
@@ -142,9 +146,16 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
      * @see org.alfresco.repo.action.ParameterizedItemAbstractBase#addParameterDefinitions(java.util.List)
      */
     @Override
-    protected void addParameterDefinitions(List<ParameterDefinition> paramList) 
+    protected void addParameterDefinitions(List<ParameterDefinition> paramList)
     {
         paramList.add(new ParameterDefinitionImpl(PARAM_ASPECT_NAME, DataTypeDefinition.QNAME, true, getParamDisplayLabel(PARAM_ASPECT_NAME), false, "ac-aspects"));
     }
 
+    /**
+     * Remove actionContext from the parameter values to declassify as an adhoc property
+     */
+    private void removeActionContextParameter(Map<String, Serializable> paramValues)
+    {
+        paramValues.remove(ActionAccessRestriction.ACTION_CONTEXT_PARAM_NAME);
+    }
 }

--- a/repository/src/main/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuter.java
@@ -67,7 +67,7 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
      * Set the node service
      *
      * @param nodeService
-     *         the node service
+     *            the node service
      */
     public void setNodeService(NodeService nodeService)
     {
@@ -78,7 +78,7 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
      * Set the transaction service
      *
      * @param transactionService
-     *         the transaction service
+     *            the transaction service
      */
     public void setTransactionService(TransactionService transactionService)
     {
@@ -102,8 +102,7 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
         if (this.nodeService.exists(actionedUponNodeRef))
         {
             transactionService.getRetryingTransactionHelper().doInTransaction(
-                    new RetryingTransactionCallback<Void>()
-                    {
+                    new RetryingTransactionCallback<Void>() {
                         public Void execute() throws Throwable
                         {
                             Map<QName, Serializable> properties = new HashMap<QName, Serializable>();
@@ -137,8 +136,7 @@ public class AddFeaturesActionExecuter extends ActionExecuterAbstractBase
                             nodeService.addAspect(actionedUponNodeRef, aspectQName, properties);
                             return null;
                         }
-                    }
-            );
+                    });
         }
     }
 

--- a/repository/src/test/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuterTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco Repository
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/repository/src/test/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuterTest.java
@@ -28,6 +28,11 @@ package org.alfresco.repo.action.executer;
 import java.util.List;
 import java.util.Locale;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.extensions.surf.util.I18NUtil;
+import org.springframework.transaction.annotation.Transactional;
+
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.action.ActionImpl;
 import org.alfresco.repo.action.access.ActionAccessRestriction;
@@ -40,10 +45,6 @@ import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.BaseSpringTest;
 import org.alfresco.util.GUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.extensions.surf.util.I18NUtil;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Add features action execution test
@@ -102,7 +103,7 @@ public class AddFeaturesActionExecuterTest extends BaseSpringTest
                 QName.createQName("{test}testnode"),
                 ContentModel.TYPE_CONTENT).getChildRef();
 
-        // Get the executer instance 
+        // Get the executer instance
         this.executer = (AddFeaturesActionExecuter) this.applicationContext.getBean(AddFeaturesActionExecuter.NAME);
     }
 

--- a/repository/src/test/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/AddFeaturesActionExecuterTest.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -30,6 +30,7 @@ import java.util.Locale;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.action.ActionImpl;
+import org.alfresco.repo.action.access.ActionAccessRestriction;
 import org.alfresco.repo.security.authentication.AuthenticationComponent;
 import org.alfresco.service.cmr.action.ActionDefinition;
 import org.alfresco.service.cmr.action.ParameterDefinition;
@@ -46,53 +47,48 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Add features action execution test
- * 
+ *
  * @author Roy Wetherall
  */
 @Transactional
 public class AddFeaturesActionExecuterTest extends BaseSpringTest
 {
     /**
+     * Id used to identify the test action created
+     */
+    private final static String ID = GUID.generate();
+    /**
      * The node service
      */
     private NodeService nodeService;
-    
     /**
      * The store reference
      */
     private StoreRef testStoreRef;
-    
     /**
      * The root node reference
      */
     private NodeRef rootNodeRef;
-    
     /**
      * The test node reference
      */
     private NodeRef nodeRef;
-    
     /**
      * The add features action executer
      */
     private AddFeaturesActionExecuter executer;
-    
-    /**
-     * Id used to identify the test action created
-     */
-    private final static String ID = GUID.generate();
-    
+
     /**
      * Called at the begining of all tests
      */
     @Before
     public void before() throws Exception
     {
-        this.nodeService = (NodeService)this.applicationContext.getBean("nodeService");
-        
-        AuthenticationComponent authenticationComponent = (AuthenticationComponent)applicationContext.getBean("authenticationComponent");
+        this.nodeService = (NodeService) this.applicationContext.getBean("nodeService");
+
+        AuthenticationComponent authenticationComponent = (AuthenticationComponent) applicationContext.getBean("authenticationComponent");
         authenticationComponent.setCurrentUser(authenticationComponent.getSystemUserName());
-        
+
         // Create the store and get the root node
         this.testStoreRef = this.nodeService.createStore(
                 StoreRef.PROTOCOL_WORKSPACE, "Test_"
@@ -105,11 +101,11 @@ public class AddFeaturesActionExecuterTest extends BaseSpringTest
                 ContentModel.ASSOC_CHILDREN,
                 QName.createQName("{test}testnode"),
                 ContentModel.TYPE_CONTENT).getChildRef();
-        
+
         // Get the executer instance 
-        this.executer = (AddFeaturesActionExecuter)this.applicationContext.getBean(AddFeaturesActionExecuter.NAME);
+        this.executer = (AddFeaturesActionExecuter) this.applicationContext.getBean(AddFeaturesActionExecuter.NAME);
     }
-    
+
     /**
      * Test execution
      */
@@ -118,16 +114,16 @@ public class AddFeaturesActionExecuterTest extends BaseSpringTest
     {
         // Check that the node does not have the classifiable aspect
         assertFalse(this.nodeService.hasAspect(this.nodeRef, ContentModel.ASPECT_CLASSIFIABLE));
-        
+
         // Execute the action
         ActionImpl action = new ActionImpl(null, ID, AddFeaturesActionExecuter.NAME, null);
         action.setParameterValue(AddFeaturesActionExecuter.PARAM_ASPECT_NAME, ContentModel.ASPECT_CLASSIFIABLE);
         this.executer.execute(action, this.nodeRef);
-        
+
         // Check that the node now has the classifiable aspect applied
         assertTrue(this.nodeService.hasAspect(this.nodeRef, ContentModel.ASPECT_CLASSIFIABLE));
     }
-    
+
     /**
      * MNT-15802
      */
@@ -160,5 +156,21 @@ public class AddFeaturesActionExecuterTest extends BaseSpringTest
 
         I18NUtil.setLocale(Locale.getDefault());
 
+    }
+
+    /**
+     * Test check actionContext param is removed from adhoc properties
+     */
+    @Test
+    public void testCheckActionContext()
+    {
+        // Execute the action
+        ActionImpl action = new ActionImpl(null, ID, AddFeaturesActionExecuter.NAME, null);
+        action.setParameterValue(ActionAccessRestriction.ACTION_CONTEXT_PARAM_NAME, ActionAccessRestriction.V1_ACTION_CONTEXT);
+        action.setParameterValue(AddFeaturesActionExecuter.PARAM_ASPECT_NAME, ContentModel.ASPECT_CLASSIFIABLE);
+        this.executer.execute(action, this.nodeRef);
+
+        // Ensure the actionContext parameter has been removed
+        assertFalse(nodeService.getProperties(this.nodeRef).containsKey(QName.createQName(ActionAccessRestriction.ACTION_CONTEXT_PARAM_NAME)));
     }
 }


### PR DESCRIPTION
fix/MNT-24891-BackPort - Skip actionContext to classify as an adhoc property in add-features action logic