### PR TITLE
[MNT-24859] Basic Auth still possible with Keycloak enabled

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/springframework/extensions/webscripts/index.get
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/springframework/extensions/webscripts/index.get
@@ -1,0 +1,15 @@
+<import resource="classpath:alfresco/templates/webscripts/org/alfresco/repository/admin/admin-common.lib.js">
+
+/**
+ * Repository Admin Console
+ *
+ * Root page GET method
+ */
+function main()
+{
+   status.code = 301;
+   status.location = url.serviceContext + Admin.getDefaultToolURI();
+   status.redirect = true;
+}
+
+main();

--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/springframework/extensions/webscripts/index.get.desc.xml
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/springframework/extensions/webscripts/index.get.desc.xml
@@ -1,0 +1,11 @@
+<webscript>
+    <shortname>Index - root page</shortname>
+    <description><![CDATA[Index WebScript]]></description>
+    <url>/index</url>
+    <url>/index/</url>
+    <family>Index</family>
+    <format default="html">argument</format>
+    <authentication>sysadmin</authentication>
+    <lifecycle>internal</lifecycle>
+    <transaction allow="readonly">required</transaction>
+</webscript>

--- a/remote-api/src/main/resources/alfresco/web-scripts-application-context.xml
+++ b/remote-api/src/main/resources/alfresco/web-scripts-application-context.xml
@@ -224,6 +224,7 @@
          <list>
             <value>AdminConsole</value>
             <value>AdminConsoleHelper</value>
+            <value>Index</value>
          </list>
       </property>
    </bean>

--- a/repository/src/main/java/org/alfresco/repo/security/authentication/identityservice/admin/IdentityServiceAdminConsoleAuthenticator.java
+++ b/repository/src/main/java/org/alfresco/repo/security/authentication/identityservice/admin/IdentityServiceAdminConsoleAuthenticator.java
@@ -239,7 +239,12 @@ public class IdentityServiceAdminConsoleAuthenticator implements AdminConsoleAut
         try
         {
             URI originalUri = new URI(requestURL);
-            URI redirectUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), identityServiceConfig.getAdminConsoleRedirectPath(), originalUri.getQuery(), originalUri.getFragment());
+            String redirectPath = identityServiceConfig.getAdminConsoleRedirectPath();
+            if (requestURL.contains("index"))
+            {
+                redirectPath = originalUri.getPath();
+            }
+            URI redirectUri = new URI(originalUri.getScheme(), originalUri.getAuthority(), redirectPath, originalUri.getQuery(), originalUri.getFragment());
             return redirectUri.toASCIIString();
         }
         catch (URISyntaxException e)


### PR DESCRIPTION
https://hyland.atlassian.net/browse/MNT-24859.

Keycloak authentication only handled for Alfresco Administration Console. Now we implemented for Alfresco WebScripts Home as well.