### PR TITLE
Fix category picker visibility to show only permitted categories based on local permissions

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/forms/pickerresults.lib.ftl
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/forms/pickerresults.lib.ftl
@@ -40,6 +40,7 @@
 		"items":
 		[
 		<#list results as row>
+			<#if row.item.hasPermission("Read")>
 			{
 				"type": "${row.item.typeShort}",
 				"parentType": "${row.item.parentTypeShort!""}",
@@ -75,6 +76,7 @@
 				"nodeRef": "${row.item.nodeRef}"<#if row.selectable?exists>,
 				"selectable" : ${row.selectable?string}</#if>
 			}<#if row_has_next>,</#if>
+			</#if>
 		</#list>
 		]
 	}


### PR DESCRIPTION
This PR resolves an issue where users without access to certain categories could not see any categories in the category picker. Instead of displaying only the categories the user has permission to access, the picker failed completely, resulting in an empty list and log errors.