### PR TITLE
[MNT-24146] - Unable to update password for 'admin' user

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/PeopleImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/PeopleImpl.java
@@ -712,7 +712,7 @@ public class PeopleImpl implements People
         Boolean isEnabled = person.isEnabled();
         if (isEnabled != null)
         {
-            if (isAdminAuthority(personIdToUpdate))
+            if (!isEnabled && isAdminAuthority(personIdToUpdate))
             {
                 throw new PermissionDeniedException("Admin authority cannot be disabled.");
             }

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/Person.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/Person.java
@@ -266,7 +266,7 @@ public class Person implements Serializable
 
     public Boolean isEnabled()
     {
-        return enabled == null ? Boolean.FALSE : enabled;
+        return enabled;
     }
 
     public void setEnabled(Boolean enabled)

--- a/remote-api/src/main/java/org/alfresco/rest/api/model/Person.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/model/Person.java
@@ -266,7 +266,7 @@ public class Person implements Serializable
 
     public Boolean isEnabled()
     {
-        return enabled;
+        return enabled == null ? Boolean.FALSE : enabled;
     }
 
     public void setEnabled(Boolean enabled)


### PR DESCRIPTION
Allowing admin user to update password when user is already enabled or trying to enable. If admin user tries to update the password by unchecking the enabled checkbox or send enabled flag as false through payload will throw error like "Admin authority cannot be disabled"