### PR TITLE
MNT-25069 doc url update backport to 23.N

### DIFF
--- a/amps/ags/rm-community/documentation/destruction/README.md
+++ b/amps/ags/rm-community/documentation/destruction/README.md
@@ -23,7 +23,7 @@ Recorded content can be explicitly destroyed whilst maintaining the original nod
 * License: Alfresco Community
 * Issue Tracker Link: [JIRA RM](https://issues.alfresco.com/jira/projects/RM/summary)
 * Contribution Model: Alfresco Closed Source
-* Documentation: [docs.alfresco.com (Records Management)](http://docs.alfresco.com/rm2.4/concepts/welcome-rm.html)
+* Documentation: [docs.alfresco.com (Records Management)](https://support.hyland.com/r/Alfresco/Alfresco-Governance-Services-Community-Edition/23.4/Alfresco-Governance-Services-Community-Edition/Introduction)
 
 *** 
 

--- a/amps/ags/rm-community/documentation/overview.md
+++ b/amps/ags/rm-community/documentation/overview.md
@@ -21,18 +21,18 @@ RM is split into two main parts - a repository integration and a Share integrati
 * [Community License](../LICENSE.txt)
 * [Enterprise License](../../rm-enterprise/LICENSE.txt) (this file will only be present in clones of the Enterprise repository)
 * [Issue Tracker Link](https://issues.alfresco.com/jira/projects/RM)
-* [Community Documentation Link](http://docs.alfresco.com/rm-community/concepts/welcome-rm.html)
-* [Enterprise Documentation Link](http://docs.alfresco.com/rm/concepts/welcome-rm.html)
+* [Community Documentation Link](https://support.hyland.com/r/Alfresco/Alfresco-Governance-Services-Community-Edition/23.4/Alfresco-Governance-Services-Community-Edition/Introduction)
+* [Enterprise Documentation Link](https://support.hyland.com/r/Alfresco/Alfresco-Governance-Services/23.4/Alfresco-Governance-Services/Introduction)
 * [Contribution Model](../../CONTRIBUTING.md)
 
 *** 
 
 ### Prerequisite Knowledge
-An understanding of Alfresco Content Services is assumed. The following pages from the [developer documentation](http://docs.alfresco.com/5.2/concepts/dev-for-developers.html) give useful background information:
+An understanding of Alfresco Content Services is assumed. The following pages from the [developer documentation](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services-Community-Edition/23.4/Alfresco-Content-Services-Community-Edition/Develop) give useful background information:
 
-* [ACS Architecture](http://docs.alfresco.com/5.2/concepts/dev-arch-overview.html)
-* [Platform Extensions](http://docs.alfresco.com/5.2/concepts/dev-platform-extensions.html)
-* [Share Extensions](http://docs.alfresco.com/5.2/concepts/dev-extensions-share.html)
+* [ACS Architecture](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Software-Architecture)
+* [Platform Extensions](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Extension-Points-Overview)
+* [Share Extensions](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Share-UI-Extension-Points)
 
 *** 
 
@@ -44,12 +44,12 @@ The RM Share module communicates with the repository module via REST APIs. Inter
 * A DAO layer responsible for CRUD operations against the database.
 
 #### REST API
-The REST API endpoints fall into two main types - v0 (Webscripts) and v1. The [v0 API](http://docs.alfresco.com/5.2/references/dev-extension-points-webscripts.html) is older and not recommended for integrations. The [v1 API](http://docs.alfresco.com/5.1/pra/1/topics/pra-welcome-aara.html) is newer but isn't yet feature complete. If you are running RM locally then the GS API Explorer will be available at [this link](http://localhost:8080/gs-api-explorer/).
+The REST API endpoints fall into two main types - v0 (Webscripts) and v1. The [v0 API](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/In-Process-Platform-Extension-Points/Web-Scripts) is older and not recommended for integrations. The [v1 API](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide) is newer but isn't yet feature complete. If you are running RM locally then the GS API Explorer will be available at [this link](http://localhost:8080/gs-api-explorer/).
 
 Internally the GS v1 REST API is built on the [Alfresco v1 REST API framework](https://community.alfresco.com/community/ecm/blog/2016/10/11/v1-rest-api-part-1-introduction). It aims to be consistent with this in terms of behaviour and naming.
 
 #### Java Public API
-The Java service layer is fronted by a [Java Public API](http://docs.alfresco.com/5.2/concepts/java-public-api-list.html), which we will ensure backward compatible with previous releases. Before we remove any methods there will first be a release containing that method deprecated to allow third party integrations to migrate to a new method.  The Java Public API also includes a set of POJO objects which are needed to communicate with the services. It is easy to identify classes that are part of the Java Public API as they are annotated `@AlfrescoPublicApi`.
+The Java service layer is fronted by a [Java Public API](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Reference/Java-Foundation-API), which we will ensure backward compatible with previous releases. Before we remove any methods there will first be a release containing that method deprecated to allow third party integrations to migrate to a new method.  The Java Public API also includes a set of POJO objects which are needed to communicate with the services. It is easy to identify classes that are part of the Java Public API as they are annotated `@AlfrescoPublicApi`.
 
 Each Java service will have at least four beans defined for it:
 
@@ -61,7 +61,7 @@ Each Java service will have at least four beans defined for it:
 #### DAOs
 The DAOs are not part of the Java Public API, but handle CRUD operations against RM stored data. We have some custom queries to improve performance for particularly heavy operations.
 
-We use standard Alfresco [data modelling](http://docs.alfresco.com/5.2/references/dev-extension-points-content-model.html) to store RM metadata. We extend the [Alfresco patching mechanism](http://docs.alfresco.com/5.2/references/dev-extension-points-patch.html) to provide community and enterprise schema upgrades.
+We use standard Alfresco [data modelling](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/In-Process-Platform-Extension-Points/Content-Model-Extension-Point) to store RM metadata. We extend the [Alfresco patching mechanism](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/In-Process-Platform-Extension-Points/Patches) to provide community and enterprise schema upgrades.
 
 ***
 

--- a/packaging/tests/tas-cmis/README.md
+++ b/packaging/tests/tas-cmis/README.md
@@ -27,7 +27,7 @@
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](http://docs.alfresco.com/5.1/pra/1/topics/cmis-welcome.html). 
+**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/Reference/CMIS-API). 
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 

--- a/packaging/tests/tas-restapi/README.md
+++ b/packaging/tests/tas-restapi/README.md
@@ -27,7 +27,7 @@ Back to [TAS Master Documentation](https://git.alfresco.com/tas/alfresco-tas-uti
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **RESTAPI** is the project that handles the automated tests related only to [Alfresco REST API](http://docs.alfresco.com/5.1/pra/1/topics/pra-welcome.html).
+**TAS**( **T**est **A**utomation **S**ystem)- **RESTAPI** is the project that handles the automated tests related only to [Alfresco REST API](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide).
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 
@@ -271,7 +271,7 @@ restClient.onResponse().assertThat().body("entry.modifiedBy.firstName", org.hamc
 
 ### How to generate models or check coverage
 
-There are some simple generators that could parse [Swagger YAML](http://docs.alfresco.com/community/concepts/alfresco-sdk-tutorials-using-rest-api-explorer.html) files and provide some usefull information to you like:
+There are some simple generators that could parse [Swagger YAML](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some usefull information to you like:
  
 a) Show on screen the actual coverage of TAS vs requests that exists in each YAML file - defined in pom.xml) 
 

--- a/packaging/war/src/main/webapp/index.jsp
+++ b/packaging/war/src/main/webapp/index.jsp
@@ -74,7 +74,7 @@ ModuleDetails shareServicesModule = moduleService.getModule("alfresco-share-serv
          <div class="index-list">
             <h4><%=descriptorService.getServerDescriptor().getEdition()%></h4>
             <p></p>
-            <p><a href="http://docs.alfresco.com/">Online Documentation</a></p>
+            <p><a href="https://support.hyland.com/p/alfresco">Online Documentation</a></p>
             <p></p>
              <%
                  if (shareServicesModule != null && ModuleInstallState.INSTALLED.equals(shareServicesModule.getInstallState()))

--- a/remote-api/src/main/resources/alfresco/messages/admin-console.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Admin Console
 admin-console.help=Help
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Successfully saved values.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_cs.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_cs.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Konzole pro spr\u00e1vce
 admin-console.help=N\u00e1pov\u011bda
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Hodnoty byly \u00fasp\u011b\u0161n\u011b ulo\u017eeny.
 
 admin-console.host=Hostitel

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_da.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_da.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Administrationskonsol
 admin-console.help=Hj\u00e6lp
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=V\u00e6rdierne blev gemt.
 
 admin-console.host=V\u00e6rt

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_de.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_de.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Administratorkonsole
 admin-console.help=Hilfe
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Erfolgreich gespeicherte Werte.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_es.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_es.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Consola de administraci\u00f3n
 admin-console.help=Ayuda
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Valores guardados correctamente.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_fi.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_fi.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Hallintakonsoli
 admin-console.help=Ohje
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Arvot tallennettiin.
 
 admin-console.host=Is\u00e4nt\u00e4

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_fr.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_fr.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Console d'administration
 admin-console.help=Aide
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Les valeurs ont bien \u00e9t\u00e9 enregistr\u00e9es.
 
 admin-console.host=H\u00f4te

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_it.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_it.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Console di amministrazione
 admin-console.help=Aiuto
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=I valori sono stati salvati.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_ja.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_ja.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=\u7ba1\u7406\u30b3\u30f3\u30bd\u30fc\u30eb
 admin-console.help=\u30d8\u30eb\u30d7
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=\u5024\u3092\u6b63\u5e38\u306b\u4fdd\u5b58\u3057\u307e\u3057\u305f\u3002
 
 admin-console.host=\u30db\u30b9\u30c8

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_nb.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_nb.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Admin-konsoll
 admin-console.help=Hjelp
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Verdier som ble lagret.
 
 admin-console.host=Vert

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_nl.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_nl.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Beheerconsole
 admin-console.help=Help
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Waarden zijn opgeslagen.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_pl.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_pl.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Konsola administracyjna
 admin-console.help=Pomoc
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Warto\u015bci zosta\u0142y zapisane pomy\u015blnie.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_pt_BR.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_pt_BR.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Console de administra\u00e7\u00e3o
 admin-console.help=Ajuda
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=Valores salvos com sucesso.
 
 admin-console.host=Host

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_ru.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_ru.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=\u041a\u043e\u043d\u0441\u043e\u043b\u044c \u0430\u0434\u043c\u0438\u043d\u0438\u0441\u0442\u0440\u0430\u0442\u043e\u0440\u0430
 admin-console.help=\u0421\u043f\u0440\u0430\u0432\u043a\u0430
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=\u0423\u0441\u043f\u0435\u0448\u043d\u043e \u0441\u043e\u0445\u0440\u0430\u043d\u0435\u043d\u043d\u044b\u0435 \u0437\u043d\u0430\u0447\u0435\u043d\u0438\u044f.
 
 admin-console.host=\u0425\u043e\u0441\u0442

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_sv.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_sv.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=Admin-konsol
 admin-console.help=Hj\u00e4lp
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=V\u00e4rden sparades.
 
 admin-console.host=V\u00e4rd

--- a/remote-api/src/main/resources/alfresco/messages/admin-console_zh_CN.properties
+++ b/remote-api/src/main/resources/alfresco/messages/admin-console_zh_CN.properties
@@ -1,7 +1,7 @@
 # I18N messages for the Repository Admin Console
 admin-console.header=\u7ba1\u7406\u63a7\u5236\u53f0
 admin-console.help=\u5e2e\u52a9
-admin-console.help-link=http://docs.alfresco.com/{0}/concepts/ch-administering.html
+admin-console.help-link=https://support.hyland.com/p/alfresco
 admin-console.success=\u5df2\u6210\u529f\u4fdd\u5b58\u7684\u503c\u3002
 
 admin-console.host=\u4e3b\u673a

--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/admin-template.ftl
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/admin/admin-template.ftl
@@ -12,9 +12,9 @@
 <#macro page title readonly=false controller=DEFAULT_CONTROLLER!"/admin" params="" dialog=false>
 <#assign FORM_ID="admin-jmx-form" />
 <#if server.edition == "Community">
-    <#assign docsEdition = "community" />
+    <#assign docsEdition = "/Alfresco-Content-Services-Community-Edition/" + server.getVersionMajor() + "." + server.getVersionMinor() + "/Alfresco-Content-Services-Community-Edition" />
 <#elseif server.edition == "Enterprise" >
-    <#assign docsEdition = server.getVersionMajor() + "." + server.getVersionMinor() />
+    <#assign docsEdition = "/Alfresco-Content-Services/" + server.getVersionMajor() + "." + server.getVersionMinor() + "/Alfresco-Content-Services" />
 </#if>
 <#if metadata??>
 <#assign HOSTNAME>${msg("admin-console.host")}: ${metadata.hostname}</#assign>
@@ -551,7 +551,7 @@ Admin.addEventListener(window, 'load', function() {
        Template for a full page view
    -->
    <div class="sticky-wrapper">
-      
+
       <div class="header">
          <span><a href="${url.serviceContext}${DEFAULT_CONTROLLER!"/admin"}">${msg("admin-console.header")}</a></span><#if metadata??><span class="meta">${HOSTNAME}</span><span class="meta">${HOSTADDR}</span></#if>
          <div style="float:right"><a href="${msg("admin-console.help-link", docsEdition)}" target="_blank">${msg("admin-console.help")}</a></div>

--- a/repository/docs/identity-provider/authentication/README.md
+++ b/repository/docs/identity-provider/authentication/README.md
@@ -27,7 +27,7 @@ to integrate with a number of external Authentication providers including
   * https://github.com/Alfresco/alfresco-data-model/tree/master/src/main/java/org/alfresco/repo/security/authentication
 * License: LGPL
 * Issue Tracker Link: https://issues.alfresco.com/jira/issues/?jql=project%3DREPO
-* Documentation Link: http://docs.alfresco.com/5.2/concepts/auth-intro.html
+* Documentation Link: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services-Community-Edition/23.4/Alfresco-Content-Services-Community-Edition/Administer/Manage-Security/Authentication-and-sync
 * Contribution Model: Alfresco Open Source
 ***
 

--- a/repository/docs/meta-data-services/versions/README.md
+++ b/repository/docs/meta-data-services/versions/README.md
@@ -16,7 +16,7 @@
 * Source Code Link:m https://svn.alfresco.com/repos/alfresco-enterprise/alfresco/
 * License: LGPL
 * Issue Tracker Link: https://issues.alfresco.com/jira/secure/RapidBoard.jspa?projectKey=REPO&useStoredSettings=true&rapidView=379
-* Documentation Link: http://docs.alfresco.com/5.1/concepts/versioning.html
+* Documentation Link: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Configure/Repository/About-Versioning
 * Contribution Model: Alfresco publishes the source code and will review proposed patch requests
 ***
 

--- a/repository/src/main/resources/alfresco/messages/system-messages.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_cs.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_cs.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Vlastnost ''{0}'' nebyla nastavena: {1} ({2})
 system.err.duplicate_name=Duplicitn\u00ed n\u00e1zvy pod\u0159\u00edzen\u00fdch objekt\u016f nejsou povoleny ({0})
-system.err.lucene_not_supported=Subsyst\u00e9m hled\u00e1n\u00ed Lucene nen\u00ed podporov\u00e1n. Viz http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=Subsyst\u00e9m hled\u00e1n\u00ed Lucene nen\u00ed podporov\u00e1n. Viz https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_da.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_da.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Egenskaben ''{0}'' er ikke blevet indstillet: {1} ({2})
 system.err.duplicate_name=Duplikeret navn p\u00e5 underordnet er ikke tilladt: {0}
-system.err.lucene_not_supported=Lucene-s\u00f8geundersystemet underst\u00f8ttes ikke. Se http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=Lucene-s\u00f8geundersystemet underst\u00f8ttes ikke. Se https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_de.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_de.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_es.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_es.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_fi.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_fi.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Ominaisuutta {0} ei ole m\u00e4\u00e4ritetty: {1} ({2})
 system.err.duplicate_name=P\u00e4\u00e4llekk\u00e4ist\u00e4 alatasonime\u00e4 ei sallita: {0}
-system.err.lucene_not_supported=Lucene-hakualij\u00e4rjestelm\u00e4\u00e4 ei tueta. Saat lis\u00e4tietoja osoitteesta http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=Lucene-hakualij\u00e4rjestelm\u00e4\u00e4 ei tueta. Saat lis\u00e4tietoja osoitteesta https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_fr.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_fr.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set : {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed : {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_it.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_it.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_ja.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_ja.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_nb.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_nb.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_nl.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_nl.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_pl.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_pl.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Nie ustawiono w\u0142a\u015bciwo\u015bci ''{0}'': {1} ({2})
 system.err.duplicate_name=Zduplikowane nazwy element\u00f3w podrz\u0119dnych s\u0105 niedozwolone: {0}
-system.err.lucene_not_supported=Podsystem wyszukiwania Lucene nie jest obs\u0142ugiwany. Zobacz http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=Podsystem wyszukiwania Lucene nie jest obs\u0142ugiwany. Zobacz https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_pt_BR.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_pt_BR.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_ru.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_ru.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_sv.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_sv.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Egenskap ''{0}'' har inte st\u00e4llts in: {1} ({2})
 system.err.duplicate_name=Dubbelt underordnat namn inte till\u00e5tet: {0}
-system.err.lucene_not_supported=Lucene-s\u00f6kundersystemet st\u00f6ds inte. Se http://docs.alfresco.com/{0}/uppgifter/lucene-solr4-migration.html
+system.err.lucene_not_supported=Lucene-s\u00f6kundersystemet st\u00f6ds inte. Se https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/messages/system-messages_zh_CN.properties
+++ b/repository/src/main/resources/alfresco/messages/system-messages_zh_CN.properties
@@ -5,7 +5,7 @@
 
 system.err.property_not_set=Property ''{0}'' has not been set: {1} ({2})
 system.err.duplicate_name=Duplicate child name not allowed: {0}
-system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see http://docs.alfresco.com/{0}/tasks/lucene-solr4-migration.html
+system.err.lucene_not_supported=The lucene search subsystem is not supported. Please see https://support.hyland.com/p/alfresco
 
 # Bootstrap configuration check messages
 

--- a/repository/src/main/resources/alfresco/subsystems/email/OutboundSMTP/mail-template-services-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/email/OutboundSMTP/mail-template-services-context.xml
@@ -161,5 +161,4 @@
             <ref bean="ServiceRegistry"/>
         </property>
     </bean>
-    
 </beans>

--- a/repository/src/main/resources/alfresco/template-services-context.xml
+++ b/repository/src/main/resources/alfresco/template-services-context.xml
@@ -171,5 +171,4 @@
             <value>urldecode</value>
         </property>
     </bean>
-    
 </beans>


### PR DESCRIPTION
Documentation url update was done for 25.x as part of [ACS-9080](https://hyland.atlassian.net/browse/ACS-9080). 

This pr for backport of the same changes to 23.N. Commits cherry picked from the https://github.com/Alfresco/alfresco-community-repo/pull/3239.



[ACS-9080]: https://hyland.atlassian.net/browse/ACS-9080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ