### PR TITLE
ACS-9578 Compatibility ACS 23.3 with ES Connector 5.1 (linked snapshots)

### DIFF
--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/hold/AddToHoldsBulkV1Tests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/hold/AddToHoldsBulkV1Tests.java
@@ -134,6 +134,15 @@ public class AddToHoldsBulkV1Tests extends BaseRMRestTest
                 .until(() -> getRestAPIFactory().getSearchAPI(null).search(searchRequest).getPagination()
                         .getTotalItems() == NUMBER_OF_FILES);
 
+        RestRequestQueryModel ancestorReq = getContentFromFolderAndAllSubfoldersQuery(rootFolder.getNodeRefWithoutVersion());
+        SearchRequest ancestorSearchRequest = new SearchRequest();
+        ancestorSearchRequest.setQuery(ancestorReq);
+
+        STEP("Wait until paths are indexed.");
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> getRestAPIFactory().getSearchAPI(null).search(ancestorSearchRequest).getPagination()
+                        .getTotalItems() == NUMBER_OF_FILES);
+
         holdBulkOperation = HoldBulkOperation.builder()
                 .query(queryReq)
                 .op(HoldBulkOperationType.ADD).build();

--- a/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/hold/AddToHoldsBulkV1Tests.java
+++ b/amps/ags/rm-automation/rm-automation-community-rest-api/src/test/java/org/alfresco/rest/rm/community/hold/AddToHoldsBulkV1Tests.java
@@ -139,7 +139,7 @@ public class AddToHoldsBulkV1Tests extends BaseRMRestTest
         ancestorSearchRequest.setQuery(ancestorReq);
 
         STEP("Wait until paths are indexed.");
-        await().atMost(30, TimeUnit.SECONDS)
+        await().atMost(60, TimeUnit.SECONDS)
                 .until(() -> getRestAPIFactory().getSearchAPI(null).search(ancestorSearchRequest).getPagination()
                         .getTotalItems() == NUMBER_OF_FILES);
 


### PR DESCRIPTION
Improved AGS tests reliability.  All details in ticket link attached below:
https://hyland.atlassian.net/browse/ACS-9578