### PR TITLE
[ACS-9572] show proper message for duplicate unzipping

### DIFF
--- a/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/action/unzip-to.post.json.js
+++ b/amps/share-services/src/main/resources/alfresco/templates/webscripts/org/alfresco/slingshot/documentlibrary/action/unzip-to.post.json.js
@@ -80,6 +80,11 @@ function runAction(p_params)
          {
             result.fileExist = true;
          }
+         if (error.indexOf("FolderExistsException") != -1)
+         {
+            result.fileExist = true;
+            result.type = "folder";
+         }
       }
       
       results.push(result);

--- a/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipException;
 
+import org.alfresco.service.cmr.model.FolderExistsException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.InputStreamStatistics;
@@ -366,7 +367,11 @@ public class ImporterActionExecuter extends ActionExecuterAbstractBase
             catch (FileExistsException e)
             {
                 // TODO: add failed file info to status message?
-                throw new AlfrescoRuntimeException("Failed to process ZIP file.", e);
+                if (e.getType().equalsIgnoreCase("folder"))
+                {
+                    throw new FolderExistsException(root, file.getName());
+                }
+                throw e;
             }
         }
     }

--- a/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
+++ b/repository/src/main/java/org/alfresco/repo/action/executer/ImporterActionExecuter.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipException;
 
-import org.alfresco.service.cmr.model.FolderExistsException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.InputStreamStatistics;
@@ -59,6 +58,7 @@ import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.model.FileExistsException;
 import org.alfresco.service.cmr.model.FileFolderService;
 import org.alfresco.service.cmr.model.FileInfo;
+import org.alfresco.service.cmr.model.FolderExistsException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.ContentWriter;

--- a/repository/src/main/java/org/alfresco/repo/model/filefolder/FileFolderServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/model/filefolder/FileFolderServiceImpl.java
@@ -40,6 +40,7 @@ import java.util.ResourceBundle.Control;
 import java.util.Set;
 import java.util.Stack;
 
+import org.alfresco.service.cmr.model.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.surf.util.I18NUtil;
@@ -63,13 +64,6 @@ import org.alfresco.repo.security.permissions.PermissionCheckedValue.PermissionC
 import org.alfresco.service.Auditable;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
-import org.alfresco.service.cmr.model.FileExistsException;
-import org.alfresco.service.cmr.model.FileFolderService;
-import org.alfresco.service.cmr.model.FileFolderServiceType;
-import org.alfresco.service.cmr.model.FileFolderUtil;
-import org.alfresco.service.cmr.model.FileInfo;
-import org.alfresco.service.cmr.model.FileNotFoundException;
-import org.alfresco.service.cmr.model.SubFolderFilter;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.ContentReader;
@@ -1314,7 +1308,7 @@ public class FileFolderServiceImpl extends AbstractBaseCopyService implements Fi
         }
         catch (DuplicateChildNodeNameException e)
         {
-            throw new FileExistsException(parentNodeRef, name);
+            throw new FileExistsException(parentNodeRef, name, typeQName.getLocalName());
         }
 
         NodeRef nodeRef = assocRef.getChildRef();

--- a/repository/src/main/java/org/alfresco/repo/model/filefolder/FileFolderServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/model/filefolder/FileFolderServiceImpl.java
@@ -40,7 +40,6 @@ import java.util.ResourceBundle.Control;
 import java.util.Set;
 import java.util.Stack;
 
-import org.alfresco.service.cmr.model.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.surf.util.I18NUtil;
@@ -64,6 +63,7 @@ import org.alfresco.repo.security.permissions.PermissionCheckedValue.PermissionC
 import org.alfresco.service.Auditable;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
+import org.alfresco.service.cmr.model.*;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.ContentReader;

--- a/repository/src/main/java/org/alfresco/service/cmr/model/FileExistsException.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/model/FileExistsException.java
@@ -52,7 +52,7 @@ public class FileExistsException extends AlfrescoRuntimeException
         this.name = name;
     }
 
-    public FileExistsException(NodeRef parentNodeRef, String name,String type)
+    public FileExistsException(NodeRef parentNodeRef, String name, String type)
     {
         super(MESSAGE_ID, new Object[]{name});
         this.parentNodeRef = parentNodeRef;
@@ -70,5 +70,8 @@ public class FileExistsException extends AlfrescoRuntimeException
         return name;
     }
 
-    public String getType() { return type; }
+    public String getType()
+    {
+        return type;
+    }
 }

--- a/repository/src/main/java/org/alfresco/service/cmr/model/FolderExistsException.java
+++ b/repository/src/main/java/org/alfresco/service/cmr/model/FolderExistsException.java
@@ -4,21 +4,21 @@
  * %%
  * Copyright (C) 2005 - 2016 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -30,12 +30,11 @@ import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
- * Common exception thrown when an operation fails because of a name clash.
- * 
- * @author Derek Hulley
+ * Common exception thrown when an operation fails because of a name clash of folder.
+ *
  */
 @AlfrescoPublicApi
-public class FileExistsException extends AlfrescoRuntimeException
+public class FolderExistsException extends AlfrescoRuntimeException
 {
     private static final String MESSAGE_ID = "file_folder_service.file_exists_message";
 
@@ -43,21 +42,12 @@ public class FileExistsException extends AlfrescoRuntimeException
 
     private NodeRef parentNodeRef;
     private String name;
-    private String type;
 
-    public FileExistsException(NodeRef parentNodeRef, String name)
+    public FolderExistsException(NodeRef parentNodeRef, String name)
     {
         super(MESSAGE_ID, new Object[]{name});
         this.parentNodeRef = parentNodeRef;
         this.name = name;
-    }
-
-    public FileExistsException(NodeRef parentNodeRef, String name,String type)
-    {
-        super(MESSAGE_ID, new Object[]{name});
-        this.parentNodeRef = parentNodeRef;
-        this.name = name;
-        this.type = type;
     }
 
     public NodeRef getParentNodeRef()
@@ -69,6 +59,4 @@ public class FileExistsException extends AlfrescoRuntimeException
     {
         return name;
     }
-
-    public String getType() { return type; }
 }

--- a/repository/src/test/java/org/alfresco/repo/action/executer/ImporterActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/ImporterActionExecuterTest.java
@@ -367,7 +367,7 @@ public class ImporterActionExecuterTest
                 }
                 catch (FileExistsException e)
                 {
-                    assertEquals(e.getMessage(), "File or folder accentCharTestZip already exists");
+                    assertTrue(e.getMessage().contains("File or folder accentCharTestZip already exists"));
                 }
                 finally
                 {

--- a/repository/src/test/java/org/alfresco/repo/action/executer/ImporterActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/ImporterActionExecuterTest.java
@@ -45,7 +45,7 @@ import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.action.Action;
-import org.alfresco.service.cmr.model.FileExistsException;
+import org.alfresco.service.cmr.model.FolderExistsException;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -365,7 +365,7 @@ public class ImporterActionExecuterTest
                     // unzip again to duplicate node
                     importerActionExecuter.execute(action, zipFileNodeRef);
                 }
-                catch (FileExistsException e)
+                catch (FolderExistsException e)
                 {
                     assertTrue(e.getMessage().contains("File or folder accentCharTestZip already exists"));
                 }

--- a/repository/src/test/java/org/alfresco/repo/action/executer/ImporterActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/ImporterActionExecuterTest.java
@@ -25,11 +25,12 @@
  */
 package org.alfresco.repo.action.executer;
 
+import static org.junit.Assert.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-import org.alfresco.service.cmr.model.FileExistsException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.ServiceRegistry;
 import org.alfresco.service.cmr.action.Action;
+import org.alfresco.service.cmr.model.FileExistsException;
 import org.alfresco.service.cmr.repository.ContentService;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -52,8 +54,6 @@ import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.QName;
 import org.alfresco.util.GUID;
 import org.alfresco.util.test.junitrules.ApplicationContextInit;
-
-import static org.junit.Assert.*;
 
 /**
  * This class contains tests for {@link ImporterActionExecuter}.
@@ -362,7 +362,7 @@ public class ImporterActionExecuterTest
                 {
                     importerActionExecuter.setUncompressedBytesLimit("100000");
                     importerActionExecuter.execute(action, zipFileNodeRef);
-                    //unzip again to duplicate node
+                    // unzip again to duplicate node
                     importerActionExecuter.execute(action, zipFileNodeRef);
                 }
                 catch (FileExistsException e)


### PR DESCRIPTION
[ACS-9572] When unzipping, if a file/folder is already there with same name, then throw proper exception and show valid message to user.

[ACS-9572]: https://hyland.atlassian.net/browse/ACS-9572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ