### PR TITLE
[PRODSEC-10096]-Bump-poi-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency.groovy.version>3.0.22</dependency.groovy.version>
         <dependency.tika.version>2.9.2</dependency.tika.version>
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
-        <dependency.poi.version>5.3.0</dependency.poi.version>
+        <dependency.poi.version>5.4.1</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
         <dependency.camel.version>4.10.2</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
         <dependency.netty.version>4.1.118.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->


### PR DESCRIPTION
[PRODSEC-10096]-Bump-poi-version to 5.4.1

[PRODSEC-10096]: https://hyland.atlassian.net/browse/PRODSEC-10096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ