### PR TITLE
ACS-9429 Fix AGS Roles API

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-public-rest-context.xml
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-public-rest-context.xml
@@ -81,6 +81,7 @@
     <bean class="org.alfresco.rm.rest.api.fileplans.FilePlanRolesRelation">
         <property name="apiUtils" ref="apiUtils" />
         <property name="rmRoles" ref="rm.roles" />
+        <property name="filePlanService" ref="FilePlanService" />
     </bean>
 
    <bean class="org.alfresco.rm.rest.api.holds.HoldsEntityResource" >

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/rm/rest/api/fileplans/FilePlanRolesRelation.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/rm/rest/api/fileplans/FilePlanRolesRelation.java
@@ -74,7 +74,7 @@ public class FilePlanRolesRelation implements RelationshipResourceAction.Read<Ro
         NodeRef filePlanNodeRef = apiUtils.lookupAndValidateNodeType(filePlanId, RecordsManagementModel.TYPE_FILE_PLAN);
         if (!FilePlanComponentsApiUtils.FILE_PLAN_ALIAS.equals(filePlanId))
         {
-            filePlanNodeRef = filePlanService.getFilePlanBySiteId(filePlanId);
+            filePlanNodeRef = filePlanService.getFilePlan(filePlanNodeRef);
         }
         return filePlanNodeRef;
     }


### PR DESCRIPTION
This PR is to fix roles access for non-rm users when the file plan ID is used instead of a file plan alias.