### PR TITLE
MNT-24883 saving doc file with original filename 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>7.0.2</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.1.7</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.1.7</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.1.8-SNAPSHOT</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.1.8-SNAPSHOT</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.0.2</dependency.acs-event-model.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>7.0.2</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.1.8-SNAPSHOT</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.1.8-SNAPSHOT</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.1.7</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.1.7</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.0.2</dependency.acs-event-model.version>
 

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformImpl.java
@@ -33,14 +33,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.alfresco.httpclient.HttpClientConfig;
+import org.alfresco.model.ContentModel;
 import org.alfresco.repo.content.metadata.AsynchronousExtractor;
 import org.alfresco.repo.rendition2.RenditionDefinition2;
-import org.alfresco.service.cmr.repository.ContentReader;
-import org.alfresco.service.cmr.repository.ContentWriter;
-import org.alfresco.service.cmr.repository.MimetypeService;
-import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.*;
 import org.alfresco.transform.config.TransformOption;
 import org.alfresco.util.Pair;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * A local transformer using flat transform options.
@@ -50,6 +49,7 @@ import org.alfresco.util.Pair;
 public class LocalTransformImpl extends AbstractLocalTransform
 {
     private RemoteTransformerClient remoteTransformerClient;
+    TransformerDebug transformerDebug;
 
     private boolean available = false;
 
@@ -64,6 +64,7 @@ public class LocalTransformImpl extends AbstractLocalTransform
     {
         super(name, transformerDebug, mimetypeService, strictMimeTypeCheck, strictMimetypeExceptions,
                 retryTransformOnDifferentMimeType, transformsTransformOptions, localTransformServiceRegistry);
+        this.transformerDebug = transformerDebug;
         remoteTransformerClient = new RemoteTransformerClient(name, baseUrl, httpClientConfig);
         remoteTransformerClient.setStartupRetryPeriodSeconds(startupRetryPeriodSeconds);
 
@@ -190,7 +191,8 @@ public class LocalTransformImpl extends AbstractLocalTransform
         args[i++] = targetMimetype;
 
         targetExtension = AsynchronousExtractor.getExtension(targetMimetype, sourceExtension, targetExtension);
-        remoteTransformerClient.request(reader, writer, sourceMimetype, sourceExtension, targetExtension,
+        String fileName = transformerDebug.getFilename(sourceNodeRef,true);
+        remoteTransformerClient.request(reader, writer, fileName, sourceMimetype, sourceExtension, targetExtension,
                 timeoutMs, log, args);
     }
 }

--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformImpl.java
@@ -33,13 +33,11 @@ import java.util.Map;
 import java.util.Set;
 
 import org.alfresco.httpclient.HttpClientConfig;
-import org.alfresco.model.ContentModel;
 import org.alfresco.repo.content.metadata.AsynchronousExtractor;
 import org.alfresco.repo.rendition2.RenditionDefinition2;
 import org.alfresco.service.cmr.repository.*;
 import org.alfresco.transform.config.TransformOption;
 import org.alfresco.util.Pair;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * A local transformer using flat transform options.
@@ -191,7 +189,7 @@ public class LocalTransformImpl extends AbstractLocalTransform
         args[i++] = targetMimetype;
 
         targetExtension = AsynchronousExtractor.getExtension(targetMimetype, sourceExtension, targetExtension);
-        String fileName = transformerDebug.getFilename(sourceNodeRef,true);
+        String fileName = transformerDebug.getFilename(sourceNodeRef, true);
         remoteTransformerClient.request(reader, writer, fileName, sourceMimetype, sourceExtension, targetExtension,
                 timeoutMs, log, args);
     }

--- a/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
@@ -90,7 +90,7 @@ public class RemoteTransformerClient
         return baseUrl;
     }
 
-    public void request(ContentReader reader, ContentWriter writer, String fileName,String sourceMimetype, String sourceExtension,
+    public void request(ContentReader reader, ContentWriter writer, String fileName, String sourceMimetype, String sourceExtension,
             String targetExtension, long timeoutMs, Log logger, String... args)
     {
 
@@ -114,7 +114,7 @@ public class RemoteTransformerClient
         }
     }
 
-    HttpEntity getRequestEntity(ContentReader reader, String sourceMimetype,String fileName, String targetExtension,
+    HttpEntity getRequestEntity(ContentReader reader, String sourceMimetype, String fileName, String targetExtension,
             long timeoutMs, String[] args, StringJoiner sj)
     {
         return getRequestEntity(reader.getContentInputStream(), sourceMimetype, fileName, targetExtension, timeoutMs, args, sj);

--- a/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
@@ -340,7 +340,7 @@ public class RemoteTransformerClient
         ContentType contentType = ContentType.create(sourceMimetype);
         if (StringUtils.isEmpty(filename))
         {
-            builder.addBinaryBody("file", contentStream, contentType, "tmp" + sourceExtension);
+            builder.addBinaryBody("file", contentStream, contentType, "tmp." + sourceExtension);
         }
         else
         {

--- a/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
@@ -90,6 +90,7 @@ public class RemoteTransformerClient
         return baseUrl;
     }
 
+    @SuppressWarnings("PMD.UseObjectForClearerAPI")
     public void request(ContentReader reader, ContentWriter writer, String fileName, String sourceMimetype, String sourceExtension,
             String targetExtension, long timeoutMs, Log logger, String... args)
     {

--- a/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/RemoteTransformerClient.java
@@ -90,7 +90,7 @@ public class RemoteTransformerClient
         return baseUrl;
     }
 
-    public void request(ContentReader reader, ContentWriter writer, String sourceMimetype, String sourceExtension,
+    public void request(ContentReader reader, ContentWriter writer, String fileName,String sourceMimetype, String sourceExtension,
             String targetExtension, long timeoutMs, Log logger, String... args)
     {
 
@@ -103,7 +103,7 @@ public class RemoteTransformerClient
 
         try (InputStream contentStream = reader.getContentInputStream())
         {
-            HttpEntity reqEntity = getRequestEntity(contentStream, sourceMimetype, sourceExtension, targetExtension, timeoutMs,
+            HttpEntity reqEntity = getRequestEntity(contentStream, sourceMimetype, fileName, targetExtension, timeoutMs,
                     args, sj);
 
             request(logger, sourceExtension, targetExtension, reqEntity, writer, sj.toString());
@@ -114,10 +114,10 @@ public class RemoteTransformerClient
         }
     }
 
-    HttpEntity getRequestEntity(ContentReader reader, String sourceMimetype, String sourceExtension, String targetExtension,
+    HttpEntity getRequestEntity(ContentReader reader, String sourceMimetype,String fileName, String targetExtension,
             long timeoutMs, String[] args, StringJoiner sj)
     {
-        return getRequestEntity(reader.getContentInputStream(), sourceMimetype, sourceExtension, targetExtension, timeoutMs, args, sj);
+        return getRequestEntity(reader.getContentInputStream(), sourceMimetype, fileName, targetExtension, timeoutMs, args, sj);
     }
 
     void request(Log logger, String sourceExtension, String targetExtension, HttpEntity reqEntity, ContentWriter writer, String args)
@@ -331,12 +331,12 @@ public class RemoteTransformerClient
         return httpclient.execute(httpGet);
     }
 
-    private HttpEntity getRequestEntity(InputStream contentStream, String sourceMimetype, String sourceExtension,
+    private HttpEntity getRequestEntity(InputStream contentStream, String sourceMimetype, String filename,
             String targetExtension, long timeoutMs, String[] args, StringJoiner sj)
     {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         ContentType contentType = ContentType.create(sourceMimetype);
-        builder.addBinaryBody("file", contentStream, contentType, "tmp." + sourceExtension);
+        builder.addBinaryBody("file", contentStream, contentType, filename);
         builder.addTextBody("targetExtension", targetExtension);
         sj.add("targetExtension" + '=' + targetExtension);
         for (int i = 0; i < args.length; i += 2)

--- a/repository/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
@@ -110,7 +110,7 @@ public class RemoteTransformerClientTest
         doReturn(mockHttpResponse).when(remoteTransformerClient).execute(any(), any(HttpGet.class));
         doReturn(mockHttpResponse).when(remoteTransformerClient).execute(any(), any(HttpPost.class));
         doReturn(mockRequestEntity).when(remoteTransformerClient).getRequestEntity(any(), any(),
-                any(), any(), anyLong(), any(), any());// ,
+                any(), any(), any(), anyLong(), any(), any());// ,
 
         when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
         when(mockHttpResponse.getEntity()).thenReturn(mockResponseEntity);

--- a/repository/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
@@ -94,6 +94,7 @@ public class RemoteTransformerClientTest
     @Spy
     private RemoteTransformerClient remoteTransformerClient = new RemoteTransformerClient("TRANSFORMER", "http://localhost:1234/test", new HttpClientConfig());
 
+    private String fileName="test.doc";
     private String sourceMimetype = "application/msword";
     private String sourceExtension = "doc";
     private String targetExtension = "pdf";
@@ -141,7 +142,7 @@ public class RemoteTransformerClientTest
 
     private void requestTransform() throws IllegalAccessException
     {
-        remoteTransformerClient.request(mockReader, mockWriter, sourceMimetype, sourceExtension, targetExtension,
+        remoteTransformerClient.request(mockReader, mockWriter, fileName, sourceMimetype, sourceExtension, targetExtension,
                 timeoutMs, mockLogger);
     }
 

--- a/repository/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
+++ b/repository/src/test/java/org/alfresco/repo/content/transform/RemoteTransformerClientTest.java
@@ -94,7 +94,7 @@ public class RemoteTransformerClientTest
     @Spy
     private RemoteTransformerClient remoteTransformerClient = new RemoteTransformerClient("TRANSFORMER", "http://localhost:1234/test", new HttpClientConfig());
 
-    private String fileName="test.doc";
+    private String fileName = "test.doc";
     private String sourceMimetype = "application/msword";
     private String sourceExtension = "doc";
     private String targetExtension = "pdf";


### PR DESCRIPTION
Check https://github.com/Alfresco/alfresco-transform-core/pull/1080

In transformation payload sending webstore original filename instead of **tmp.+extenstion** 

pr depends on: 
https://github.com/Alfresco/alfresco-transform-core/pull/1080
https://github.com/Alfresco/alfresco-transform-service/pull/1019