### PR TITLE
ACS-9635 bumped httpclien5 to 5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,9 @@
         <dependency.guava.version>33.3.1-jre</dependency.guava.version>
         <dependency.httpclient.version>4.5.14</dependency.httpclient.version>
         <dependency.httpcore.version>4.4.16</dependency.httpcore.version>
-        <dependency.httpcomponents-httpclient5.version>5.4.1</dependency.httpcomponents-httpclient5.version>
-        <dependency.httpcomponents-httpcore5.version>5.3.3</dependency.httpcomponents-httpcore5.version>
+        <dependency.httpcomponents-httpclient5.version>5.5</dependency.httpcomponents-httpclient5.version>
+        <dependency.httpcomponents-httpcore5.version>5.3.4</dependency.httpcomponents-httpcore5.version>
+        <dependency.httpcomponents-httpcore5-h2.version>5.3.4</dependency.httpcomponents-httpcore5-h2.version>
         <dependency.commons-httpclient.version>3.1-HTTPCLIENT-1265</dependency.commons-httpclient.version>
         <dependency.xercesImpl.version>2.12.2</dependency.xercesImpl.version>
         <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
@@ -399,6 +400,11 @@
                 <groupId>org.apache.httpcomponents.core5</groupId>
                 <artifactId>httpcore5</artifactId>
                 <version>${dependency.httpcomponents-httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${dependency.httpcomponents-httpcore5-h2.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>


### PR DESCRIPTION
Updated httpclient5 to version 5.5 in order to address https://nvd.nist.gov/vuln/detail/CVE-2025-27820 

Initially the update was causing issue, because two different versions of httpclient5 & core5 were included in the build which was picked by CI tests - the updated client was trying to invoke a non existing method of old core. Source of the old dependency was addressed in https://github.com/Alfresco/alfresco-elasticsearch-connector/pull/927.

There is a matching change in enterprise to verify the CI with updated httpclient5 and core5 https://github.com/Alfresco/alfresco-enterprise-repo/pull/2466