### PR TITLE
ACS-9646 removed extra space that broke the escaping logic

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/site/SiteServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/site/SiteServiceImpl.java
@@ -914,7 +914,7 @@ public class SiteServiceImpl extends AbstractLifecycleBean implements SiteServic
                 String[] tokenizedFilter = SearchLanguageConversion.tokenizeString(escNameFilter);
 
                 // cm:name
-                query.append(" cm:name:\" ");
+                query.append(" cm:name:\"");
                 for (int i = 0; i < tokenizedFilter.length; i++)
                 {
                     if (i != 0) // Not first element


### PR DESCRIPTION
This change fixes a broken behavior of `live-search-sites` web script when input contains elastic search reserved character.
![image](https://github.com/user-attachments/assets/2566e847-a0fe-4c6d-b4cc-071d984ed490)

The web script calls `org.alfresco.repo.site.SiteServiceImpl#findSites(java.lang.String, int)` to do a query, which eventually looks like:
```{"from":0,"query":{"bool":{"filter":[{"bool":{}}],"must":[{"bool":{"boost":1.0,"must":[{"bool":{"boost":1.0,"should":[{"query_string":{"query":"TYPE:st\\:site"}}]}},{"bool":{"boost":1.0,"should":[{"query_string":{"boost":1.0,"query":"cm%3Aname:-chu*"}},{"query_string":{"boost":1.0,"query":"cm%3Atitle:\\-chu*"}},{"query_string":{"boost":1.0,"query":"cm%3Adescription:\\-chu"}}]}}]}}]}},"size":5,"track_scores":true,"track_total_hits":10000}```

Notice the `-chu` is present 3 times, but the first occurrence is not escaped properly and results with following elastic search API error:
`**"Failed to parse query [cm%3Aname:-chu*]"**`

Fix is simply removing the extra ` ` so that all 3 occurrences are properly escaped.