### PR TITLE
MNT-24883 sourcefile name added in transform options

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/content/transform/LocalTransformImpl.java
@@ -25,8 +25,7 @@
  */
 package org.alfresco.repo.content.transform;
 
-import static org.alfresco.repo.rendition2.RenditionDefinition2.SOURCE_ENCODING;
-import static org.alfresco.repo.rendition2.RenditionDefinition2.SOURCE_NODE_REF;
+import static org.alfresco.repo.rendition2.RenditionDefinition2.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -154,6 +153,7 @@ public class LocalTransformImpl extends AbstractLocalTransform
         {
             transformOptions.put(SOURCE_NODE_REF, sourceNodeRef.toString());
         }
+        transformOptions.put(SOURCE_FILENAME, transformerDebug.getFilename(sourceNodeRef, true));
 
         // Build an array of option names and values and extract the timeout.
         long timeoutMs = 0;

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionDefinition2.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionDefinition2.java
@@ -107,6 +107,11 @@ public interface RenditionDefinition2
     public static final String SOURCE_NODE_REF = "sourceNodeRef";
 
     /**
+     * The Source File Name is automatically added to the Transform Options if not specified and the transformer knows about it.
+     */
+    public static final String SOURCE_FILENAME = "sourceFileName";
+
+    /**
      * The encoding of a Target Node is automatically added to the Transform Options if not specified and the transformer knows about it.
      */
     public static final String TARGET_ENCODING = "targetEncoding";


### PR DESCRIPTION
Sending source file name in transform options. 

core pr:  https://github.com/Alfresco/alfresco-transform-core/pull/1081