### PR TITLE
ACS-6928 handling restricted nodes in queries API

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/QueriesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/QueriesImpl.java
@@ -2,23 +2,23 @@
  * #%L
  * Alfresco Remote API
  * %%
- * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * Copyright (C) 2005 - 2025 Alfresco Software Limited
  * %%
- * This file is part of the Alfresco software. 
- * If the software was purchased under a paid Alfresco license, the terms of 
- * the paid license agreement will prevail.  Otherwise, the software is 
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
  * provided under the following open source license terms:
- * 
+ *
  * Alfresco is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Alfresco is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
@@ -31,7 +31,17 @@ import static org.alfresco.rest.api.impl.QueriesImpl.AbstractQuery.Sort.POST_QUE
 
 import java.io.Serializable;
 import java.text.Collator;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/remote-api/src/test/java/org/alfresco/rest/api/tests/QueriesSitesApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/tests/QueriesSitesApiTest.java
@@ -30,7 +30,10 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Queries API is using following steps to return response:

- call search engine with given parameters
- sort the results
- materialize results into response object

The assumption here is that search engine will return node references to which user has access to, which is not guaranteed. This behavior was only built in Solr based search engine. This causes a bug, when Queries API is attempting to sort the results, because in the context of some user it tries to access restricted node attributes, which eventually are returned as 403 HTTP response.

The fix is to materialize search results and ignore any result to which we don't have access and then sort it.