### PR TITLE
PRODSEC-10332 updated commons-fileupload2-jakarta to address cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,8 +444,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
-                <artifactId>commons-fileupload2-jakarta</artifactId>
-                <version>2.0.0-M1</version>
+                <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+                <version>2.0.0-M4</version>
             </dependency>
             <dependency>
                 <groupId>commons-net</groupId>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-fileupload2-jakarta</artifactId>
+            <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Update 1:
We should be using servlet 6 API.

----
`org.apache.commons:commons-fileupload2-jakarta:2.0.0-M1` has a CVE in `commons-fileupload2-core-2.0.0-M1.jar`. Instead of adding explicit updated dependency for core I've updated the dependency it comes with. There is a tiny problem though, because `commons-fileupload2-jakarta` is no longer maintained and instead there are 2 other versions depending on servlet API we're using. Here I have used the servlet5 one, with `commons-fileupload2-jakarta-servlet5`.