### PR TITLE
ACS-9784 Fix Solr transform content request

### DIFF
--- a/repository/src/main/resources/alfresco/rendition-services2-context.xml
+++ b/repository/src/main/resources/alfresco/rendition-services2-context.xml
@@ -128,7 +128,7 @@
         <property name="retryTransformOnDifferentMimeType" value="${content.transformer.retryOn.different.mimetype}"/>
         <property name="shutdownIndicator" ref="shutdownIndicator" />
         <property name="httpClientConfig" ref="httpClientConfigTransform" />
-        <property name="nodeService" ref="NodeService" />
+        <property name="nodeService" ref="nodeService" />
     </bean>
 
     <bean id="localTransformServiceRegistryJsonObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper" />

--- a/repository/src/test/resources/test/alfresco/test-renditions-context.xml
+++ b/repository/src/test/resources/test/alfresco/test-renditions-context.xml
@@ -28,7 +28,7 @@
       <property name="strictMimeTypeCheck" value="${transformer.strict.mimetype.check}"/>
       <property name="retryTransformOnDifferentMimeType" value="false"/>
       <property name="httpClientConfig" ref="httpClientConfigTransform" />
-      <property name="nodeService" ref="NodeService" />
+      <property name="nodeService" ref="nodeService" />
    </bean>
 
 </beans>


### PR DESCRIPTION
Requests from Search Services without security context requires nodeService to get the source filename.