### PR TITLE
PRODSEC-10332 updated commons-fileupload2-jakarta to address cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency.jackson.version>2.17.2</dependency.jackson.version>
         <dependency.cxf.version>4.1.0</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0-jakarta-1</dependency.opencmis.version>
-        <dependency.webscripts.version>10.1</dependency.webscripts.version>
+        <dependency.webscripts.version>10.2</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.79</dependency.bouncycastle.version>
         <dependency.mockito-core.version>5.14.1</dependency.mockito-core.version>
         <dependency.assertj.version>3.27.3</dependency.assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency.jackson.version>2.17.2</dependency.jackson.version>
         <dependency.cxf.version>4.1.0</dependency.cxf.version>
         <dependency.opencmis.version>1.0.0-jakarta-1</dependency.opencmis.version>
-        <dependency.webscripts.version>10.0</dependency.webscripts.version>
+        <dependency.webscripts.version>10.1</dependency.webscripts.version>
         <dependency.bouncycastle.version>1.79</dependency.bouncycastle.version>
         <dependency.mockito-core.version>5.14.1</dependency.mockito-core.version>
         <dependency.assertj.version>3.27.3</dependency.assertj.version>

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/transfer/PostContentCommandProcessor.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/transfer/PostContentCommandProcessor.java
@@ -30,7 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
-import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.webscripts.Status;

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/transfer/PostSnapshotCommandProcessor.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/transfer/PostSnapshotCommandProcessor.java
@@ -31,7 +31,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
-import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.webscripts.Status;


### PR DESCRIPTION
Update 1

Because of new package and import path change I had to make the fix inside surf-webscripts. I have removed the not needed excludes and instead updated the surf-webscripts.

---

Original post:

I have missed some needed excludes. Initially I tracked the vulnerable dependency with
`mvn dependency:tree -Dincludes=\*:commons-fileupload2-core:\*` which gave me happy result with latest version (*-M4).

![image](https://github.com/user-attachments/assets/d5a85fd2-14a2-4340-b160-e27810821156)

But Veracode was still not happy, so I tried a different query `mvn dependency:tree -Dincludes=\*:\*:\*:2.0.0-M1` which lead me to this:
![image](https://github.com/user-attachments/assets/299199ac-f939-47d8-bf08-484cac2429ed)

Both repository and remote-api have the same dependency on spring-webscripts.
