### PR TITLE
MNT-24975 - Repeated IPR groups due to casing inconsistencies

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
@@ -119,6 +119,11 @@ rm.patch.v35.holdNewChildAssocPatch.batchSize=1000
 rm.haspermissionmap.read=Read
 rm.haspermissionmap.write=WriteProperties,AddChildren,ReadContent
 
+# Extended Permissions
+# Enable matching the given username with the correct casing username when retrieving an IPR group.
+# Only needs to be used if there are owners that don't have the username in the correct casing.
+rm.extendedSecurity.enableUsernameNormalization=false
+
 #
 # Extended auto-version behaviour.  If true and other auto-version properties are satisfied, then
 # a document will be auto-versioned when its type is changed.

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-service-context.xml
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-service-context.xml
@@ -611,6 +611,7 @@
         <property name="authorityService" ref="authorityService"/>
         <property name="permissionService" ref="permissionService"/>
         <property name="transactionService" ref="transactionService"/>
+        <property name="enableUsernameNormalization" value="${rm.extendedSecurity.enableUsernameNormalization}" />
     </bean>
 
     <bean id="ExtendedSecurityService" class="org.springframework.aop.framework.ProxyFactoryBean">

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java
@@ -404,11 +404,13 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
         boolean hasMoreItems = true;
         int pageCount = 0;
 
-        // Normalize authorities to match the usernames if they exists
-        Set<String> authoritiesNormalized = normalizeAuthorities(authorities);
+        // If enabled, the authorities are forced to match the correct casing of the usernames in case they were set with the incorrect casing.
+        // If not, it will just use the authorities as they are.
+        // In normal circumstances, the authorities are in the correct casing, so this is disabled by default.
+        Set<String> authoritySet = normalizeAuthorities(authorities);
 
         // determine the short name prefix
-        String groupShortNamePrefix = getIPRGroupPrefixShortName(groupPrefix, authoritiesNormalized);
+        String groupShortNamePrefix = getIPRGroupPrefixShortName(groupPrefix, authoritySet);
 
         // iterate over the authorities to find a match
         while (hasMoreItems == true)
@@ -429,7 +431,7 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
             for (String group : results.getPage())
             {
                 // if exists and matches we have found our group
-                if (isIPRGroupTrueMatch(group, authoritiesNormalized))
+                if (isIPRGroupTrueMatch(group, authoritySet))
                 {
                     return new Pair<String, Integer>(group, nextGroupIndex);
                 }
@@ -451,6 +453,7 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
      */
     private Set<String> normalizeAuthorities(Set<String> authNames)
     {
+        // If disabled or no authorities, return as is
         if (!enableUsernameNormalization || authNames == null || authNames.isEmpty())
         {
             return authNames;
@@ -465,7 +468,7 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
     }
 
     /**
-     * Usernames are case insensitive but affect the IPR group matching when set with different casing. For a given authority of type user, this method normalizes the authority name. if group, it returns the name as-is.
+     * Usernames are case insensitive but affect the IPR group matching when set with different casing. For a given authority of type user, this method normalizes the authority name. If group, it returns the name as-is.
      *
      * @param authorityName
      *            the authority name to normalize
@@ -492,7 +495,7 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
             }
             catch (Exception e)
             {
-                // If anything goes wrong, fall back to the original name
+                // If anything goes wrong, fallback to the original name
             }
         }
 

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImpl.java
@@ -38,6 +38,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.extensions.webscripts.ui.common.StringUtils;
 
+import org.alfresco.model.ContentModel;
 import org.alfresco.model.RenditionModel;
 import org.alfresco.module.org_alfresco_module_rm.capability.RMPermissionModel;
 import org.alfresco.module.org_alfresco_module_rm.fileplan.FilePlanService;
@@ -96,6 +97,8 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
     /** transaction service */
     private TransactionService transactionService;
 
+    private boolean enableUsernameNormalization = false;
+
     /**
      * @param filePlanService
      *            file plan service
@@ -139,6 +142,15 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
     public void setTransactionService(TransactionService transactionService)
     {
         this.transactionService = transactionService;
+    }
+
+    /**
+     * @param enableUsernameNormalization
+     *            enable username normalization to ensure correct casing
+     */
+    public void setEnableUsernameNormalization(boolean enableUsernameNormalization)
+    {
+        this.enableUsernameNormalization = enableUsernameNormalization;
     }
 
     /**
@@ -392,14 +404,18 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
         boolean hasMoreItems = true;
         int pageCount = 0;
 
+        // Normalize authorities to match the usernames if they exists
+        Set<String> authoritiesNormalized = normalizeAuthorities(authorities);
+
         // determine the short name prefix
-        String groupShortNamePrefix = getIPRGroupPrefixShortName(groupPrefix, authorities);
+        String groupShortNamePrefix = getIPRGroupPrefixShortName(groupPrefix, authoritiesNormalized);
 
         // iterate over the authorities to find a match
         while (hasMoreItems == true)
         {
             // get matching authorities
-            PagingResults<String> results = authorityService.getAuthorities(AuthorityType.GROUP,
+            PagingResults<String> results = authorityService.getAuthorities(
+                    AuthorityType.GROUP,
                     RMAuthority.ZONE_APP_RM,
                     groupShortNamePrefix,
                     false,
@@ -413,7 +429,7 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
             for (String group : results.getPage())
             {
                 // if exists and matches we have found our group
-                if (isIPRGroupTrueMatch(group, authorities))
+                if (isIPRGroupTrueMatch(group, authoritiesNormalized))
                 {
                     return new Pair<String, Integer>(group, nextGroupIndex);
                 }
@@ -425,6 +441,62 @@ public class ExtendedSecurityServiceImpl extends ServiceBaseImpl
         }
 
         return new Pair<>(iprGroup, nextGroupIndex);
+    }
+
+    /**
+     * Given a set of authorities, normalizes the authority names to ensure correct casing.
+     * 
+     * @param authNames
+     * @return
+     */
+    private Set<String> normalizeAuthorities(Set<String> authNames)
+    {
+        if (!enableUsernameNormalization || authNames == null || authNames.isEmpty())
+        {
+            return authNames;
+        }
+
+        Set<String> normalizedAuthorities = new HashSet<>();
+        for (String authorityName : authNames)
+        {
+            normalizedAuthorities.add(normalizeAuthorityName(authorityName));
+        }
+        return normalizedAuthorities;
+    }
+
+    /**
+     * Usernames are case insensitive but affect the IPR group matching when set with different casing. For a given authority of type user, this method normalizes the authority name. if group, it returns the name as-is.
+     *
+     * @param authorityName
+     *            the authority name to normalize
+     * @return the normalized authority name
+     */
+    private String normalizeAuthorityName(String authorityName)
+    {
+        if (authorityName == null || authorityName.startsWith(GROUP_PREFIX))
+        {
+            return authorityName;
+        }
+
+        // For users, attempt to get the correct casing from the username property of the user node
+        if (authorityService.authorityExists(authorityName))
+        {
+            try
+            {
+                NodeRef authorityNodeRef = authorityService.getAuthorityNodeRef(authorityName);
+                if (authorityNodeRef != null)
+                {
+                    String username = (String) nodeService.getProperty(authorityNodeRef, ContentModel.PROP_USERNAME);
+                    return username != null ? username : authorityName;
+                }
+            }
+            catch (Exception e)
+            {
+                // If anything goes wrong, fall back to the original name
+            }
+        }
+
+        return authorityName;
     }
 
     /**

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImplUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/security/ExtendedSecurityServiceImplUnitTest.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.alfresco.model.ContentModel;
 import org.alfresco.model.RenditionModel;
 import org.alfresco.module.org_alfresco_module_rm.capability.RMPermissionModel;
 import org.alfresco.module.org_alfresco_module_rm.fileplan.FilePlanService;
@@ -67,6 +68,7 @@ import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransacti
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.cmr.security.AccessPermission;
 import org.alfresco.service.cmr.security.AccessStatus;
 import org.alfresco.service.cmr.security.AuthorityService;
@@ -522,6 +524,104 @@ public class ExtendedSecurityServiceImplUnitTest
         verify(mockedPermissionService).setPermission(nodeRef, writeGroup, RMPermissionModel.FILING, true);
         
     }
+
+    /**
+     * Given a node with no previous IPR groups assigned
+     * And having pre-existing IPR groups matching the ones we need
+     * When I add some read and write authorities but with a different casing
+     * Then the existing IPR groups are used
+     */
+    @SuppressWarnings("unchecked")
+    @Test public void addExtendedSecurityWithMixedCasingUsernames()
+    {
+        // Have the usernames in the node as the correct usernames but with incorrect casing
+        String user1 = "UseR";
+        String user2 = "UseR_w";
+
+        // Incorrect IPR Group names
+        Set<String> diffCasingReaders = Stream.of(user1, GROUP).collect(Collectors.toSet());
+        Set<String> diffCasingWriters = Stream.of(user2, GROUP_W).collect(Collectors.toSet());
+        String wrongReadGroupPrefix = extendedSecurityService.getIPRGroupPrefixShortName(READER_GROUP_PREFIX, diffCasingReaders);
+        String wrongWriteGroupPrefix = extendedSecurityService.getIPRGroupPrefixShortName(WRITER_GROUP_PREFIX, diffCasingWriters);
+        String wrongReadGroup = wrongReadGroupPrefix + "0";
+        String wrongWriteGroup = wrongWriteGroupPrefix + "0";
+
+        // Correct Group names
+        String correctReadGroup = readGroupPrefix + "0";
+        String correctWriteGroup = writeGroupPrefix + "0";
+
+        // If queried for the correct groups, return the results
+        PagingResults<String> mockedCorrectReadPResults = mock(PagingResults.class);
+        PagingResults<String> mockedCorrectWritePResults = mock(PagingResults.class);
+        when(mockedCorrectReadPResults.getPage())
+            .thenReturn(Stream.of(GROUP_PREFIX + correctReadGroup).collect(Collectors.toList()));
+        when(mockedAuthorityService.getAuthorities(
+                eq(AuthorityType.GROUP), 
+                eq(RMAuthority.ZONE_APP_RM), 
+                eq(readGroupPrefix),
+                eq(false), 
+                eq(false), 
+                any(PagingRequest.class)))
+            .thenReturn(mockedCorrectReadPResults);
+        
+        when(mockedCorrectWritePResults.getPage())
+            .thenReturn(Stream.of(GROUP_PREFIX + correctWriteGroup).collect(Collectors.toList()));
+        when(mockedAuthorityService.getAuthorities(
+                eq(AuthorityType.GROUP), 
+                eq(RMAuthority.ZONE_APP_RM), 
+                eq(writeGroupPrefix),
+                eq(false), 
+                eq(false), 
+                any(PagingRequest.class)))
+            .thenReturn(mockedCorrectWritePResults);
+
+        // Don't return results for the incorrect groups
+        PagingResults<String> mockedWrongReadPResults = mock(PagingResults.class);
+        PagingResults<String> mockedWrongWritePResults = mock(PagingResults.class);
+        when(mockedWrongReadPResults.getPage())
+            .thenReturn(Collections.emptyList());
+        when(mockedAuthorityService.getAuthorities(
+                eq(AuthorityType.GROUP), 
+                eq(RMAuthority.ZONE_APP_RM), 
+                eq(wrongReadGroupPrefix),
+                eq(false), 
+                eq(false), 
+                any(PagingRequest.class)))
+            .thenReturn(mockedWrongReadPResults);
+        
+        when(mockedWrongWritePResults.getPage())
+            .thenReturn(Collections.emptyList());
+        when(mockedAuthorityService.getAuthorities(
+                eq(AuthorityType.GROUP), 
+                eq(RMAuthority.ZONE_APP_RM), 
+                eq(wrongWriteGroupPrefix),
+                eq(false), 
+                eq(false), 
+                any(PagingRequest.class)))
+            .thenReturn(mockedWrongWritePResults);
+
+        // The users do exist, despite being in a different casing and are able to be retrieved
+        NodeRef noderefUser1 = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, USER);
+        when(mockedAuthorityService.authorityExists(user1)).thenReturn(true);
+        when(mockedAuthorityService.getAuthorityNodeRef(user1)).thenReturn(noderefUser1);
+        when(mockedNodeService.getProperty(noderefUser1, ContentModel.PROP_USERNAME)).thenReturn(USER);
+
+        NodeRef noderefUser2 = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, USER_W);
+        when(mockedAuthorityService.authorityExists(user2)).thenReturn(true);
+        when(mockedAuthorityService.getAuthorityNodeRef(user2)).thenReturn(noderefUser2);
+        when(mockedNodeService.getProperty(noderefUser2, ContentModel.PROP_USERNAME)).thenReturn(USER_W);
+
+        // Set the extended security service to normalize usernames
+        extendedSecurityService.setEnableUsernameNormalization(true);
+        extendedSecurityService.set(nodeRef, diffCasingReaders, diffCasingWriters);
+
+        // Verify that the incorrect read group is not created
+        verify(mockedAuthorityService, never()).createAuthority(AuthorityType.GROUP, wrongReadGroup, wrongReadGroup, Collections.singleton(RMAuthority.ZONE_APP_RM));
+
+        // Verify that the incorrect write group is not created
+        verify(mockedAuthorityService, never()).createAuthority(AuthorityType.GROUP, wrongWriteGroup, wrongWriteGroup, Collections.singleton(RMAuthority.ZONE_APP_RM));
+
+    }
     
     /**
      * Given a node with no previous IPR groups assigned
@@ -571,7 +671,7 @@ public class ExtendedSecurityServiceImplUnitTest
             .thenReturn(Stream
                 .of(USER_W, AlfMock.generateText())
                 .collect(Collectors.toSet()));
-        
+
         // add extended security
         extendedSecurityService.set(nodeRef, READERS, WRITERS);
         
@@ -895,7 +995,7 @@ public class ExtendedSecurityServiceImplUnitTest
         // group names
         String readGroup = extendedSecurityService.getIPRGroupShortName(READER_GROUP_FULL_PREFIX, READERS, 0);
         String writeGroup = extendedSecurityService.getIPRGroupShortName(WRITER_GROUP_FULL_PREFIX, WRITERS, 0);
-        
+
         // setup renditions
         NodeRef renditionNodeRef = AlfMock.generateNodeRef(mockedNodeService);
         when(mockedNodeService.hasAspect(nodeRef, RecordsManagementModel.ASPECT_RECORD))
@@ -904,7 +1004,7 @@ public class ExtendedSecurityServiceImplUnitTest
             .thenReturn(renditionNodeRef);
         when(mockedNodeService.getChildAssocs(nodeRef, RenditionModel.ASSOC_RENDITION, RegexQNamePattern.MATCH_ALL))
             .thenReturn(Collections.singletonList(mockedChildAssociationRef));        
-        
+
         // setup permissions
         Set<AccessPermission> permissions = Stream
             .of(new AccessPermissionImpl(AlfMock.generateText(), AccessStatus.ALLOWED, readGroup, 0),
@@ -913,17 +1013,17 @@ public class ExtendedSecurityServiceImplUnitTest
             .collect(Collectors.toSet());        
         when(mockedPermissionService.getAllSetPermissions(nodeRef))
             .thenReturn(permissions);      
-        
+
         // remove extended security
         extendedSecurityService.remove(nodeRef);
-        
+
         // verify that the groups permissions have been removed
         verify(mockedPermissionService).clearPermission(nodeRef, readGroup);
         verify(mockedPermissionService).clearPermission(nodeRef, writeGroup);
-        
+
         // verify that the groups permissions have been removed from the rendition
         verify(mockedPermissionService).clearPermission(renditionNodeRef, readGroup);
         verify(mockedPermissionService).clearPermission(renditionNodeRef, writeGroup);
-        
+
     }
 }


### PR DESCRIPTION
* When the owner is set with the incorrect casing (custom code, bulk import), the authority set is composed with the usernames with the incorrect casing and therefore the hash is different from the correct IPR group. This leads to the IPR groups being repeatedly created.
* Added configuration to force retrieving the correct casing for the usernames when finding the IPR groups so it behaves as if the casing was correct. This is disabled by default because its an extra check that is not needed in most of the environments. It is only needed if nodes have owner usernames set with the incorrect casing.
* To enable, set rm.extendedSecurity.enableUsernameNormalization=true
* Added unit test to test.