### PR TITLE
ACS-9981 removed invalid T function import in Parameters

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/framework/resource/parameters/Parameters.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/resource/parameters/Parameters.java
@@ -27,7 +27,6 @@ package org.alfresco.rest.framework.resource.parameters;
 
 import java.util.List;
 
-import org.apache.poi.ss.formula.functions.T;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 
 import org.alfresco.rest.framework.core.exceptions.InvalidArgumentException;
@@ -69,7 +68,7 @@ public interface Parameters
      * @return The Parameter value
      * @throws InvalidArgumentException
      */
-    T getParameter(String parameterName, Class<T> clazz) throws InvalidArgumentException;
+    <T> T getParameter(String parameterName, Class<T> clazz) throws InvalidArgumentException;
 
     /**
      * Returns a representation of the Paging of collections of resources, with skip count and max items. See {@link Paging} Specified by the "skipCount" and "maxItems" request parameters.

--- a/remote-api/src/main/java/org/alfresco/rest/framework/resource/parameters/Params.java
+++ b/remote-api/src/main/java/org/alfresco/rest/framework/resource/parameters/Params.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.beanutils.ConvertUtils;
-import org.apache.poi.ss.formula.functions.T;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 
 import org.alfresco.repo.content.MimetypeMap;
@@ -231,7 +230,7 @@ public class Params implements Parameters
     }
 
     @Override
-    public T getParameter(String parameterName, Class<T> clazz) throws InvalidArgumentException
+    public <T> T getParameter(String parameterName, Class<T> clazz) throws InvalidArgumentException
     {
         String param = getParameter(parameterName);
         if (param == null)
@@ -239,7 +238,7 @@ public class Params implements Parameters
         Object obj = ConvertUtils.convert(param, clazz);
         if (obj != null && obj.getClass().equals(clazz))
         {
-            return (T) obj;
+            return clazz.cast(obj);
         }
         throw new InvalidArgumentException(InvalidArgumentException.DEFAULT_MESSAGE_ID, new Object[]{parameterName});
     }


### PR DESCRIPTION
This PR removed invalid T function wrapper import in Parameters interface (and usages of it). The method was supposed to be parametrized and return generic type instead, by coincidence also named T.