### PR TITLE
ACS-9923 Removing an aspect needs to invoke onUpdateProperties

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
@@ -865,12 +865,15 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
             Map<QName, Serializable> propsBefore = nodeDAO.getNodeProperties(nodeId);
             Map<QName, PropertyDefinition> propertyDefs = aspectDef.getProperties();
             Set<QName> propertyToRemoveQNames = propertyDefs.keySet();
-            nodeDAO.removeNodeProperties(nodeId, propertyToRemoveQNames);
+            boolean propertiesRemoved = nodeDAO.removeNodeProperties(nodeId, propertyToRemoveQNames);
 
-            invokeOnUpdateProperties(
-                    nodeRef,
-                    propsBefore, // before
-                    nodeDAO.getNodeProperties(nodeId)); // after
+            if (propertiesRemoved)
+            {
+                invokeOnUpdateProperties(
+                        nodeRef,
+                        propsBefore, // before
+                        nodeDAO.getNodeProperties(nodeId)); // after
+            }
 
             // Remove child associations
             // We have to iterate over the associations and remove all those between the parent and child

--- a/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
@@ -862,9 +862,15 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
         if (aspectDef != null)
         {
             // Remove default properties
+            Map<QName, Serializable> propsBefore = nodeDAO.getNodeProperties(nodeId);
             Map<QName, PropertyDefinition> propertyDefs = aspectDef.getProperties();
             Set<QName> propertyToRemoveQNames = propertyDefs.keySet();
             nodeDAO.removeNodeProperties(nodeId, propertyToRemoveQNames);
+
+            invokeOnUpdateProperties(
+                    nodeRef,
+                    propsBefore, // before
+                    nodeDAO.getNodeProperties(nodeId)); // after
 
             // Remove child associations
             // We have to iterate over the associations and remove all those between the parent and child


### PR DESCRIPTION
Removing an aspect also removes the properties from that aspect from the node however the onUpdateProperties policies were not being triggered - particularly the event did not contain the information that properties were removed.