### PR TITLE
[ACS-9991] added logic to execute text extraction for content indexing even if thumbnails are disabled.

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -82,6 +82,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     public static final QName DEFAULT_RENDITION_CONTENT_PROP = ContentModel.PROP_CONTENT;
     public static final String DEFAULT_MIMETYPE = MimetypeMap.MIMETYPE_TEXT_PLAIN;
     public static final String MIMETYPE_METADATA_EXTRACT = "alfresco-metadata-extract";
+    public static final String MIMETYPE_METADATA_EMBED = "alfresco-metadata-embed";
     public static final String DEFAULT_ENCODING = "UTF-8";
 
     public static final int SOURCE_HAS_NO_CONTENT = -1;
@@ -969,11 +970,11 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         }
     }
 
-    // Checks if the given transform callback is a text extract transform for content indexing or metadata extract.
+    // Checks if the given transform callback is a text extract transform for content indexing or metadata extract/embed.
     private boolean isTextOrMetadataExtractTransform(RenderOrTransformCallBack renderOrTransform)
     {
         RenditionDefinition2 renditionDefinition = renderOrTransform.getRenditionDefinition();
-        return renditionDefinition != null && (MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(renditionDefinition.getTargetMimetype()) || MIMETYPE_METADATA_EXTRACT.equals(renditionDefinition.getTargetMimetype()));
+        return renditionDefinition != null && (MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(renditionDefinition.getTargetMimetype()) || MIMETYPE_METADATA_EXTRACT.equals(renditionDefinition.getTargetMimetype()) || MIMETYPE_METADATA_EMBED.equals(renditionDefinition.getTargetMimetype()));
     }
 
     private boolean isAsyncAllowed(RenderOrTransformCallBack renderOrTransform)
@@ -984,7 +985,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
             return false;
         }
 
-        // If thumbnails are disabled, allow only text extract or metadata extract transforms
+        // If thumbnails are disabled, allow only text extract or metadata extract/embed transforms
         return thumbnailsEnabled || isTextOrMetadataExtractTransform(renderOrTransform);
     }
 

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -290,8 +290,22 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         {
             if (!isEnabled())
             {
-                throw new RenditionService2Exception("Async transforms and renditions are disabled " +
-                        "(system.thumbnail.generate=false or renditionService2.enabled=false).");
+                TransformDefinition transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
+
+                // Check if flow is text extraction for content indexing.
+                boolean ifTextExtract = false;
+                if (transformDefinition != null)
+                {
+                     String replyQueue = transformDefinition.getReplyQueue();
+                     String targetMimetype = transformDefinition.getTargetMimetype();
+                     ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
+                             && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
+                }
+                if(!ifTextExtract)
+                {
+                    throw new RenditionService2Exception("Async transforms and renditions are disabled " +
+                            "(system.thumbnail.generate=false or renditionService2.enabled=false).");
+                }
             }
 
             if (!nodeService.exists(sourceNodeRef))

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -296,12 +296,12 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                 boolean ifTextExtract = false;
                 if (transformDefinition != null)
                 {
-                     String replyQueue = transformDefinition.getReplyQueue();
-                     String targetMimetype = transformDefinition.getTargetMimetype();
-                     ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
-                             && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
+                    String replyQueue = transformDefinition.getReplyQueue();
+                    String targetMimetype = transformDefinition.getTargetMimetype();
+                    ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
+                            && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
                 }
-                if(!ifTextExtract)
+                if (!ifTextExtract)
                 {
                     throw new RenditionService2Exception("Async transforms and renditions are disabled " +
                             "(system.thumbnail.generate=false or renditionService2.enabled=false).");

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -88,6 +88,12 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     public static final int SOURCE_HAS_NO_CONTENT = -1;
     public static final int RENDITION2_DOES_NOT_EXIST = -2;
 
+    // Allowed mimetypes to support text or metadata extract transforms when thumbnails are disabled.
+    private static final Set<String> ALLOWED_TEXT_OR_METADATA_MIMETYPES = Set.of(
+            MimetypeMap.MIMETYPE_TEXT_PLAIN,
+            MIMETYPE_METADATA_EXTRACT,
+            MIMETYPE_METADATA_EMBED);
+
     private static Log logger = LogFactory.getLog(RenditionService2Impl.class);
 
     // As Async transforms and renditions are so similar, this class provides a way to provide the code that is different.
@@ -974,7 +980,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     private boolean isTextOrMetadataExtractTransform(RenderOrTransformCallBack renderOrTransform)
     {
         RenditionDefinition2 renditionDefinition = renderOrTransform.getRenditionDefinition();
-        return renditionDefinition != null && (MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(renditionDefinition.getTargetMimetype()) || MIMETYPE_METADATA_EXTRACT.equals(renditionDefinition.getTargetMimetype()) || MIMETYPE_METADATA_EMBED.equals(renditionDefinition.getTargetMimetype()));
+        return renditionDefinition != null && ALLOWED_TEXT_OR_METADATA_MIMETYPES.contains(renditionDefinition.getTargetMimetype());
     }
 
     private boolean isAsyncAllowed(RenderOrTransformCallBack renderOrTransform)

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -292,7 +292,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
             {
                 // Check if flow is text extraction for content indexing.
                 boolean ifTextExtract = false;
-                if(renderOrTransform.getRenditionDefinition() instanceof TransformDefinition)
+                if (renderOrTransform.getRenditionDefinition() instanceof TransformDefinition)
                 {
                     TransformDefinition transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
                     if (transformDefinition != null)

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -288,22 +288,10 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     {
         try
         {
-            // If enabled is false, all async transforms/renditions must be blocked
-            if (!enabled)
+            if (!isAsyncAllowed(renderOrTransform))
             {
                 throw new RenditionService2Exception("Async transforms and renditions are disabled " +
                         "(system.thumbnail.generate=false or renditionService2.enabled=false).");
-            }
-
-            // If thumbnailsEnabled is false, only text extract transforms are allowed for content indexing.
-            if (!thumbnailsEnabled)
-            {
-                boolean isTextExtract = isTextExtractTransform(renderOrTransform);
-                if (!isTextExtract)
-                {
-                    throw new RenditionService2Exception("Async transforms and renditions are disabled " +
-                            "(system.thumbnail.generate=false or renditionService2.enabled=false).");
-                }
             }
 
             if (!nodeService.exists(sourceNodeRef))
@@ -990,4 +978,22 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         TransformDefinition def = (TransformDefinition) renderOrTransform.getRenditionDefinition();
         return MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(def.getTargetMimetype());
     }
+
+    private boolean isAsyncAllowed(RenderOrTransformCallBack renderOrTransform)
+    {
+        // If enabled is false, all async transforms/renditions must be blocked
+        if (!enabled)
+        {
+            return false;
+        }
+
+        // If thumbnails are not enabled, only text extract transforms are allowed for content indexing
+        if (!thumbnailsEnabled)
+        {
+            return isTextExtractTransform(renderOrTransform);
+        }
+
+        return true;
+    }
+
 }

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -987,7 +987,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
             return false;
         }
 
-        // If thumbnails are disabled, allow only text extract transforms are allowed for content indexing
+        // If thumbnails are disabled, allow only text extract transforms for content indexing
         return thumbnailsEnabled || isTextExtractTransform(renderOrTransform);
     }
 

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -987,13 +987,8 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
             return false;
         }
 
-        // If thumbnails are not enabled, only text extract transforms are allowed for content indexing
-        if (!thumbnailsEnabled)
-        {
-            return isTextExtractTransform(renderOrTransform);
-        }
-
-        return true;
+        // If thumbnails are disabled, allow only text extract transforms are allowed for content indexing
+        return thumbnailsEnabled || isTextExtractTransform(renderOrTransform);
     }
 
 }

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -89,7 +89,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     public static final int RENDITION2_DOES_NOT_EXIST = -2;
 
     // Allowed mimetypes to support text or metadata extract transforms when thumbnails are disabled.
-    private static final Set<String> ALLOWED_TEXT_OR_METADATA_MIMETYPES = Set.of(
+    private static final Set<String> ALLOWED_MIMETYPES = Set.of(
             MimetypeMap.MIMETYPE_TEXT_PLAIN,
             MIMETYPE_METADATA_EXTRACT,
             MIMETYPE_METADATA_EMBED);
@@ -980,7 +980,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     private boolean isTextOrMetadataExtractTransform(RenderOrTransformCallBack renderOrTransform)
     {
         RenditionDefinition2 renditionDefinition = renderOrTransform.getRenditionDefinition();
-        return renditionDefinition != null && ALLOWED_TEXT_OR_METADATA_MIMETYPES.contains(renditionDefinition.getTargetMimetype());
+        return renditionDefinition != null && ALLOWED_MIMETYPES.contains(renditionDefinition.getTargetMimetype());
     }
 
     private boolean isAsyncAllowed(RenderOrTransformCallBack renderOrTransform)

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -971,12 +971,8 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
     // Checks if the given transform callback is a text extract transform for content indexing.
     private boolean isTextExtractTransform(RenderOrTransformCallBack renderOrTransform)
     {
-        if (!(renderOrTransform.getRenditionDefinition() instanceof TransformDefinition))
-        {
-            return false;
-        }
-        TransformDefinition def = (TransformDefinition) renderOrTransform.getRenditionDefinition();
-        return MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(def.getTargetMimetype());
+        RenditionDefinition2 renditionDefinition = renderOrTransform.getRenditionDefinition();
+        return renditionDefinition != null && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(renditionDefinition.getTargetMimetype());
     }
 
     private boolean isAsyncAllowed(RenderOrTransformCallBack renderOrTransform)

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -290,17 +290,20 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         {
             if (!isEnabled())
             {
-                TransformDefinition transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
-
                 // Check if flow is text extraction for content indexing.
                 boolean ifTextExtract = false;
-                if (transformDefinition != null)
+                if(renderOrTransform.getRenditionDefinition() instanceof TransformDefinition)
                 {
-                    String replyQueue = transformDefinition.getReplyQueue();
-                    String targetMimetype = transformDefinition.getTargetMimetype();
-                    ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
-                            && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
+                    TransformDefinition transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
+                    if (transformDefinition != null)
+                    {
+                        String replyQueue = transformDefinition.getReplyQueue();
+                        String targetMimetype = transformDefinition.getTargetMimetype();
+                        ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
+                                && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
+                    }
                 }
+
                 if (!ifTextExtract)
                 {
                     throw new RenditionService2Exception("Async transforms and renditions are disabled " +

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -81,6 +81,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
 
     public static final QName DEFAULT_RENDITION_CONTENT_PROP = ContentModel.PROP_CONTENT;
     public static final String DEFAULT_MIMETYPE = MimetypeMap.MIMETYPE_TEXT_PLAIN;
+    public static final String MIMETYPE_METADATA_EXTRACT = "alfresco-metadata-extract";
     public static final String DEFAULT_ENCODING = "UTF-8";
 
     public static final int SOURCE_HAS_NO_CONTENT = -1;
@@ -968,11 +969,11 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         }
     }
 
-    // Checks if the given transform callback is a text extract transform for content indexing.
-    private boolean isTextExtractTransform(RenderOrTransformCallBack renderOrTransform)
+    // Checks if the given transform callback is a text extract transform for content indexing or metadata extract.
+    private boolean isTextOrMetadataExtractTransform(RenderOrTransformCallBack renderOrTransform)
     {
         RenditionDefinition2 renditionDefinition = renderOrTransform.getRenditionDefinition();
-        return renditionDefinition != null && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(renditionDefinition.getTargetMimetype());
+        return renditionDefinition != null && (MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(renditionDefinition.getTargetMimetype()) || MIMETYPE_METADATA_EXTRACT.equals(renditionDefinition.getTargetMimetype()));
     }
 
     private boolean isAsyncAllowed(RenderOrTransformCallBack renderOrTransform)
@@ -983,8 +984,8 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
             return false;
         }
 
-        // If thumbnails are disabled, allow only text extract transforms for content indexing
-        return thumbnailsEnabled || isTextExtractTransform(renderOrTransform);
+        // If thumbnails are disabled, allow only text extract or metadata extract transforms
+        return thumbnailsEnabled || isTextOrMetadataExtractTransform(renderOrTransform);
     }
 
 }

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -290,18 +290,20 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
         {
             if (!isEnabled())
             {
-                // Check if flow is text extraction for content indexing.
+                // Check if flow is text extraction for content indexing and allow it.
                 boolean ifTextExtract = false;
+                TransformDefinition transformDefinition = null;
                 if (renderOrTransform.getRenditionDefinition() instanceof TransformDefinition)
                 {
-                    TransformDefinition transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
-                    if (transformDefinition != null)
-                    {
-                        String replyQueue = transformDefinition.getReplyQueue();
-                        String targetMimetype = transformDefinition.getTargetMimetype();
-                        ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
-                                && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
-                    }
+                    transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
+                }
+
+                if (transformDefinition != null) 
+                {
+                    String replyQueue = transformDefinition.getReplyQueue();
+                    String targetMimetype = transformDefinition.getTargetMimetype();
+                    ifTextExtract = "org.alfresco.search.contentstore.event".equals(replyQueue)
+                            && MimetypeMap.MIMETYPE_TEXT_PLAIN.equals(targetMimetype);
                 }
 
                 if (!ifTextExtract)

--- a/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
+++ b/repository/src/main/java/org/alfresco/repo/rendition2/RenditionService2Impl.java
@@ -298,7 +298,7 @@ public class RenditionService2Impl implements RenditionService2, InitializingBea
                     transformDefinition = (TransformDefinition) renderOrTransform.getRenditionDefinition();
                 }
 
-                if (transformDefinition != null) 
+                if (transformDefinition != null)
                 {
                     String replyQueue = transformDefinition.getReplyQueue();
                     String targetMimetype = transformDefinition.getTargetMimetype();

--- a/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -781,7 +781,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     @Test
     public void testTextExtractTransformAllowedWhenThumbnailDisabled()
     {
-        //create a source node
+        // create a source node
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.txt");
         assertNotNull("Node not generated", sourceNodeRef);
         String replyQueue = "org.alfresco.search.contentstore.event";

--- a/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -806,7 +806,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
         }
         finally
         {
-            renditionService2.setEnabled(true);
+            renditionService2.setThumbnailsEnabled(true);
         }
     }
 
@@ -834,7 +834,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
         }
         finally
         {
-            renditionService2.setEnabled(true);
+            renditionService2.setThumbnailsEnabled(true);
         }
     }
 

--- a/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -781,7 +781,9 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     @Test
     public void testTextExtractTransformAllowedWhenThumbnailDisabled()
     {
+        //create a source node
         NodeRef sourceNodeRef = createSource(ADMIN, "quick.txt");
+        assertNotNull("Node not generated", sourceNodeRef);
         String replyQueue = "org.alfresco.search.contentstore.event";
         String targetMimetype = MimetypeMap.MIMETYPE_TEXT_PLAIN;
 
@@ -801,34 +803,6 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                     renditionService2.transform(sourceNodeRef, textExtractTransform);
                     return null;
                 });
-                return null;
-            }, ADMIN);
-        }
-        finally
-        {
-            renditionService2.setThumbnailsEnabled(true);
-        }
-    }
-
-    @Test(expected = RenditionService2Exception.class)
-    public void testNonTextExtractTransformThrowsWhenThumbnailDisabled()
-    {
-        NodeRef sourceNodeRef = createSource(ADMIN, "quick.txt");
-        String replyQueue = "some.other.queue";
-        String targetMimetype = MimetypeMap.MIMETYPE_PDF;
-
-        TransformDefinition nonTextExtractTransform = new TransformDefinition(
-                targetMimetype,
-                java.util.Collections.emptyMap(),
-                "clientData",
-                replyQueue,
-                "requestId");
-
-        renditionService2.setThumbnailsEnabled(false);
-        try
-        {
-            AuthenticationUtil.runAs(() -> {
-                renditionService2.transform(sourceNodeRef, nonTextExtractTransform);
                 return null;
             }, ADMIN);
         }

--- a/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -34,12 +34,12 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.alfresco.repo.content.MimetypeMap;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.model.RenditionModel;
+import org.alfresco.repo.content.MimetypeMap;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.security.permissions.AccessDeniedException;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
@@ -790,8 +790,7 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                 java.util.Collections.emptyMap(),
                 "clientData",
                 replyQueue,
-                "requestId"
-        );
+                "requestId");
 
         renditionService2.setThumbnailsEnabled(false);
         try
@@ -804,7 +803,8 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                 });
                 return null;
             }, ADMIN);
-        } finally
+        }
+        finally
         {
             renditionService2.setEnabled(true);
         }
@@ -822,18 +822,17 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                 java.util.Collections.emptyMap(),
                 "clientData",
                 replyQueue,
-                "requestId"
-        );
+                "requestId");
 
         renditionService2.setThumbnailsEnabled(false);
         try
         {
-            AuthenticationUtil.runAs(() ->
-            {
+            AuthenticationUtil.runAs(() -> {
                 renditionService2.transform(sourceNodeRef, nonTextExtractTransform);
                 return null;
             }, ADMIN);
-        } finally
+        }
+        finally
         {
             renditionService2.setEnabled(true);
         }

--- a/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
+++ b/repository/src/test/java/org/alfresco/repo/rendition2/RenditionService2IntegrationTest.java
@@ -782,9 +782,9 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
     public void testTextExtractTransformAllowedWhenThumbnailDisabled()
     {
         // create a source node
-        NodeRef sourceNodeRef = createSource(ADMIN, "quick.txt");
+        NodeRef sourceNodeRef = createSource(ADMIN, "quick.pdf");
         assertNotNull("Node not generated", sourceNodeRef);
-        String replyQueue = "org.alfresco.search.contentstore.event";
+        String replyQueue = "org.test.queue";
         String targetMimetype = MimetypeMap.MIMETYPE_TEXT_PLAIN;
 
         TransformDefinition textExtractTransform = new TransformDefinition(
@@ -805,6 +805,25 @@ public class RenditionService2IntegrationTest extends AbstractRenditionIntegrati
                 });
                 return null;
             }, ADMIN);
+        }
+        finally
+        {
+            renditionService2.setThumbnailsEnabled(true);
+        }
+    }
+
+    @Test
+    public void testMetadataExtractTransformAllowedWhenThumbnailDisabled()
+    {
+        // create a source node
+        NodeRef sourceNodeRef = createSource(ADMIN, "quick.pdf");
+        assertNotNull("Node not generated", sourceNodeRef);
+        renditionService2.setThumbnailsEnabled(false);
+        try
+        {
+            // Should NOT throw, as this is a metadata extract transform
+            extract(ADMIN, sourceNodeRef);
+            waitForExtract(ADMIN, sourceNodeRef, true);
         }
         finally
         {


### PR DESCRIPTION
Whenever thumbnails were disabled, content indexing and metadata extract/embed was skipped (exception being thrown). Added logic to check if the given transform callback is a text extract transform for content indexing or metadata extract/embed and allow it. Remaining callbacks will result in exception being throw, if thumbnails are disabled.