### PR TITLE
Fix for "MNT-24776 : Category Picker Error when a User does not have Read Permissions to a Category"

### DIFF
--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/forms/pickerresults.lib.ftl
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/forms/pickerresults.lib.ftl
@@ -40,6 +40,7 @@
 		"items":
 		[
 		<#list results as row>
+			<#if row.item.hasPermission("Read")>
 			{
 				"type": "${row.item.typeShort}",
 				"parentType": "${row.item.parentTypeShort!""}",
@@ -75,6 +76,7 @@
 				"nodeRef": "${row.item.nodeRef}"<#if row.selectable?exists>,
 				"selectable" : ${row.selectable?string}</#if>
 			}<#if row_has_next>,</#if>
+			</#if>
 		</#list>
 		]
 	}


### PR DESCRIPTION
Fix for "MNT-24776 : Category Picker Error when a User does not have Read Permissions to a Category"