### PR TITLE
[ACS-9940] Bump spring security version to 6.4.11 (#3592)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
         <dependency.aspectj.version>1.9.22.1</dependency.aspectj.version>
         <dependency.spring.version>6.2.11</dependency.spring.version>
-        <dependency.spring-security.version>6.3.9</dependency.spring-security.version>
+        <dependency.spring-security.version>6.4.11</dependency.spring-security.version>
         <dependency.antlr.version>3.5.3</dependency.antlr.version>
         <dependency.jackson.version>2.17.2</dependency.jackson.version>
         <dependency.cxf.version>4.1.2</dependency.cxf.version>


### PR DESCRIPTION
(cherry picked from commit 109bdeee0f443c4106ac36db9fd41adab0d689b7)