### PR TITLE
[MNT-25404] Query Performance - High performance cost in retrieving nodes/node properties for large result sets

### DIFF
--- a/data-model/src/main/java/org/alfresco/service/cmr/repository/NodeService.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/repository/NodeService.java
@@ -117,7 +117,7 @@ public interface NodeService
      * @return A list of the nodeRefs that exist
      */
     @Auditable(parameters = {"nodeRefs"})
-    public List<NodeRef> exists(List<NodeRef> nodeRefs);
+    List<NodeRef> exists(List<NodeRef> nodeRefs);
 
     /**
      * Gets the ID of the last transaction that caused the node to change. This includes deletions, so it is possible that the node being referenced no longer exists. If the node never existed, then null is returned.
@@ -147,7 +147,7 @@ public interface NodeService
      * @return the list of corresponding node references or an empty list if none are found
      */
     @Auditable(parameters = {"nodeIds"})
-    public List<NodeRef> getNodeRefs(List<Long> nodeIds);
+    List<NodeRef> getNodeRefs(List<Long> nodeIds);
 
     /**
      * @param storeRef
@@ -360,7 +360,7 @@ public interface NodeService
      *             if any of the node references could not be found
      */
     @Auditable(parameters = {"nodeRefs"})
-    public Map<NodeRef, Set<QName>> getAspects(List<NodeRef> nodeRefs) throws InvalidNodeRefException;
+    Map<NodeRef, Set<QName>> getAspects(List<NodeRef> nodeRefs) throws InvalidNodeRefException;
 
     /**
      * Deletes the given node.
@@ -519,7 +519,7 @@ public interface NodeService
      *             if the node could not be found
      */
     @Auditable(parameters = {"nodeRefs"})
-    public Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs) throws InvalidNodeRefException;
+    Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs) throws InvalidNodeRefException;
 
     /**
      * Replace all current properties on the node with the given properties. The properties given must still fulfill the requirements of the class and aspects relevant to the node.

--- a/data-model/src/main/java/org/alfresco/service/cmr/repository/NodeService.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/repository/NodeService.java
@@ -112,6 +112,14 @@ public interface NodeService
     public boolean exists(NodeRef nodeRef);
 
     /**
+     * @param nodeRefs
+     *            a reference list for the nodes to look for
+     * @return A list of the nodeRefs that exist
+     */
+    @Auditable(parameters = {"nodeRefs"})
+    public List<NodeRef> exists(List<NodeRef> nodeRefs);
+
+    /**
      * Gets the ID of the last transaction that caused the node to change. This includes deletions, so it is possible that the node being referenced no longer exists. If the node never existed, then null is returned.
      * 
      * @param nodeRef
@@ -130,6 +138,16 @@ public interface NodeService
      */
     @Auditable(parameters = {"nodeId"})
     public NodeRef getNodeRef(Long nodeId);
+
+    /**
+     * Get node references for a list of given node DB IDs
+     * 
+     * @param nodeIds
+     *            a list of node DB IDs
+     * @return the list of corresponding node references or an empty list if none are found
+     */
+    @Auditable(parameters = {"nodeIds"})
+    public List<NodeRef> getNodeRefs(List<Long> nodeIds);
 
     /**
      * @param storeRef
@@ -335,6 +353,16 @@ public interface NodeService
     public Set<QName> getAspects(NodeRef nodeRef) throws InvalidNodeRefException;
 
     /**
+     * @param nodeRefs
+     *            List of NodeRefs
+     * @return Returns a map of NodeRefs to their corresponding set of aspects
+     * @throws InvalidNodeRefException
+     *             if any of the node references could not be found
+     */
+    @Auditable(parameters = {"nodeRefs"})
+    public Map<NodeRef, Set<QName>> getAspects(List<NodeRef> nodeRefs) throws InvalidNodeRefException;
+
+    /**
      * Deletes the given node.
      * <p>
      * All associations (both children and regular node associations) will be deleted, and where the given node is the primary parent, the children will also be cascade deleted.
@@ -482,6 +510,16 @@ public interface NodeService
      */
     @Auditable(parameters = {"nodeRef", "qname"})
     public Serializable getProperty(NodeRef nodeRef, QName qname) throws InvalidNodeRefException;
+
+    /**
+     * @param nodeRefs
+     *            List of NodeRefs to get Properties for
+     * @return Returns all Nodes and their properties. NodeRef is the map key and properties are keyed by their qualified name
+     * @throws InvalidNodeRefException
+     *             if the node could not be found
+     */
+    @Auditable(parameters = {"nodeRefs"})
+    public Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs) throws InvalidNodeRefException;
 
     /**
      * Replace all current properties on the node with the given properties. The properties given must still fulfill the requirements of the class and aspects relevant to the node.

--- a/remote-api/src/main/java/org/alfresco/rest/api/DeletedNodes.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/DeletedNodes.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.rest.api;
 
+import java.util.List;
 import java.util.Map;
 
 import org.alfresco.rest.api.model.Node;
@@ -62,6 +63,19 @@ public interface DeletedNodes
      * @return a deleted node
      */
     Node getDeletedNode(String originalId, Parameters parameters, boolean fullnode, Map<String, UserInfo> mapUserInfo);
+
+    /**
+     * Gets a list of deleted nodes by id.
+     * 
+     * @param list
+     *            of originalIds
+     * @param parameters
+     * @param fullnode
+     *            Should we return the full representation of the minimal one?
+     * @param mapUserInfo
+     * @return a deleted node
+     */
+    List<Node> getDeletedNodes(List<String> originalIds, Parameters parameters, boolean fullnode, Map<String, UserInfo> mapUserInfo);
 
     /**
      * Restores a deleted node and returns it.

--- a/remote-api/src/main/java/org/alfresco/rest/api/Nodes.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/Nodes.java
@@ -103,6 +103,8 @@ public interface Nodes
 
     Node getFolderOrDocumentFullInfo(NodeRef nodeRef, NodeRef parentNodeRef, QName nodeTypeQName, Parameters parameters, Map<String, UserInfo> mapUserInfo);
 
+    List<Node> getFoldersOrDocumentsFullInfo(List<NodeRef> nodeRefs, Parameters parameters, Map<String, UserInfo> mapUserInfo);
+
     /**
      * Get the folder or document representation (as appropriate) for the given node.
      *
@@ -115,6 +117,17 @@ public interface Nodes
      * @return
      */
     Node getFolderOrDocument(NodeRef nodeRef, NodeRef parentNodeRef, QName nodeTypeQName, List<String> includeParam, Map<String, UserInfo> mapUserInfo);
+
+    /**
+     * Get the folder or document representation (as appropriate) for the given list of nodes.
+     *
+     * @param nodeRefs
+     *            A list of real Nodes
+     * @param includeParam
+     * @param mapUserInfo
+     * @return
+     */
+    List<Node> getFoldersOrDocuments(List<NodeRef> nodeRefs, List<String> includeParam, Map<String, UserInfo> mapUserInfo);
 
     /**
      * Get list of children of a parent folder.
@@ -218,6 +231,8 @@ public interface Nodes
     Node upload(String parentFolderNodeId, FormData formData, Parameters parameters);
 
     NodeRef validateNode(StoreRef storeRef, String nodeId);
+
+    List<NodeRef> validateNodes(StoreRef storeRef, List<String> nodeIds);
 
     NodeRef validateNode(String nodeId);
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/DeletedNodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/DeletedNodesImpl.java
@@ -217,7 +217,7 @@ public class DeletedNodesImpl implements DeletedNodes, RecognizedParamsExtractor
             archivedNodeRefs.add(nodeArchiveService.getArchivedNode(tempNodeRef));
         }
 
-        List<Node> foundNodes = new ArrayList<>();
+        List<Node> foundNodes;
         if (fullnode)
         {
             foundNodes = nodes.getFoldersOrDocumentsFullInfo(archivedNodeRefs, parameters, mapUserInfo);

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/DeletedNodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/DeletedNodesImpl.java
@@ -120,6 +120,37 @@ public class DeletedNodesImpl implements DeletedNodes, RecognizedParamsExtractor
         aNode.setParentId(null);
     }
 
+    /**
+     * Sets archived information on the Node
+     * 
+     * @param nodes
+     * @param mapUserInfo
+     */
+    private void mapArchiveInfo(List<Node> nodes, Map<String, UserInfo> mapUserInfo)
+    {
+        if (mapUserInfo == null)
+        {
+            mapUserInfo = new HashMap<>();
+        }
+
+        List<NodeRef> nodeRefs = new ArrayList<>(nodes.size());
+        for (Node node : nodes)
+        {
+            nodeRefs.add(node.getNodeRef());
+        }
+
+        Map<NodeRef, Map<QName, Serializable>> nodeProps = nodeService.getPropertiesForNodeRefs(nodeRefs);
+
+        for (Node node : nodes)
+        {
+            node.setArchivedAt((Date) nodeProps.get(node.getNodeRef()).get(ContentModel.PROP_ARCHIVED_DATE));
+            node.setArchivedByUser(Node.lookupUserInfo((String) nodeProps.get(node.getNodeRef()).get(ContentModel.PROP_ARCHIVED_BY), mapUserInfo, personService));
+
+            // Don't show parent id
+            node.setParentId(null);
+        }
+    }
+
     @Override
     public CollectionWithPagingInfo<Node> listDeleted(Parameters parameters)
     {
@@ -170,6 +201,37 @@ public class DeletedNodesImpl implements DeletedNodes, RecognizedParamsExtractor
         if (foundNode != null)
             mapArchiveInfo(foundNode, null);
         return foundNode;
+    }
+
+    @Override
+    public List<Node> getDeletedNodes(List<String> originalIds, Parameters parameters, boolean fullnode, Map<String, UserInfo> mapUserInfo)
+    {
+        // First check the nodes are valid and have been archived.
+        List<NodeRef> validatedNodeRefs = nodes.validateNodes(StoreRef.STORE_REF_ARCHIVE_SPACESSTORE, originalIds);
+
+        // Now get the Nodes
+        List<NodeRef> archivedNodeRefs = new ArrayList<>();
+        for (NodeRef validatedNodeRef : validatedNodeRefs)
+        {
+            NodeRef tempNodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, validatedNodeRef.getId());
+            archivedNodeRefs.add(nodeArchiveService.getArchivedNode(tempNodeRef));
+        }
+
+        List<Node> foundNodes = new ArrayList<>();
+        if (fullnode)
+        {
+            foundNodes = nodes.getFoldersOrDocumentsFullInfo(archivedNodeRefs, parameters, mapUserInfo);
+        }
+        else
+        {
+            foundNodes = nodes.getFoldersOrDocuments(archivedNodeRefs, parameters.getInclude(), mapUserInfo);
+        }
+
+        if (!foundNodes.isEmpty())
+        {
+            mapArchiveInfo(foundNodes, null);
+        }
+        return foundNodes;
     }
 
     @Override

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -428,20 +428,21 @@ public class NodesImpl implements Nodes
 
         for (String nodeId : nodeIds)
         {
-            String versionLabel = null;
+            String versionLabel;
+            String id = nodeId;
 
-            int idx = nodeId.indexOf(";");
+            int idx = nodeId.indexOf(';');
             if (idx != -1)
             {
                 versionLabel = nodeId.substring(idx + 1);
-                nodeId = nodeId.substring(0, idx);
+                id = nodeId.substring(0, idx);
                 if (versionLabel.equals("pwc"))
                 {
                     continue; // skip pwc
                 }
             }
 
-            NodeRef nodeRef = new NodeRef(storeRef, nodeId);
+            NodeRef nodeRef = new NodeRef(storeRef, id);
             nodeRefs.add(nodeRef);
         }
 
@@ -1155,7 +1156,7 @@ public class NodesImpl implements Nodes
                 continue;
             }
 
-            if (includeParam.size() > 0)
+            if (!includeParam.isEmpty())
             {
                 node.setProperties(mapFromNodeProperties(props, includeParam, mapUserInfo, EXCLUDED_NS, EXCLUDED_PROPS));
             }
@@ -1208,7 +1209,7 @@ public class NodesImpl implements Nodes
                         // special case: do not return "create" (as an allowable op) for file/content types - note: 'type' can be null
                         continue;
                     }
-                    else if (perm.equals(PermissionService.DELETE) && (isSpecialNode(nodeRef, nodeTypeQName)))
+                    else if (perm.equals(PermissionService.DELETE) && isSpecialNode(nodeRef, nodeTypeQName))
                     {
                         // special case: do not return "delete" (as an allowable op) for specific system nodes
                         continue;
@@ -1219,7 +1220,7 @@ public class NodesImpl implements Nodes
                     }
                 }
 
-                node.setAllowableOperations((allowableOperations.size() > 0) ? allowableOperations : null);
+                node.setAllowableOperations((!allowableOperations.isEmpty()) ? allowableOperations : null);
             }
 
             // TODO: Optimize to batch get permissions for all nodes

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -422,6 +422,33 @@ public class NodesImpl implements Nodes
     }
 
     @Override
+    public List<NodeRef> validateNodes(StoreRef storeRef, List<String> nodeIds)
+    {
+        List<NodeRef> nodeRefs = new ArrayList<>(nodeIds.size());
+
+        for (String nodeId : nodeIds)
+        {
+            String versionLabel = null;
+
+            int idx = nodeId.indexOf(";");
+            if (idx != -1)
+            {
+                versionLabel = nodeId.substring(idx + 1);
+                nodeId = nodeId.substring(0, idx);
+                if (versionLabel.equals("pwc"))
+                {
+                    continue; // skip pwc
+                }
+            }
+
+            NodeRef nodeRef = new NodeRef(storeRef, nodeId);
+            nodeRefs.add(nodeRef);
+        }
+
+        return validateNodes(nodeRefs);
+    }
+
+    @Override
     public NodeRef validateNode(NodeRef nodeRef)
     {
         if (!nodeService.exists(nodeRef))
@@ -430,6 +457,17 @@ public class NodesImpl implements Nodes
         }
 
         return nodeRef;
+    }
+
+    public List<NodeRef> validateNodes(List<NodeRef> nodeRefs)
+    {
+        List<NodeRef> nodes = nodeService.exists(nodeRefs);
+        if (nodes.isEmpty())
+        {
+            throw new EntityNotFoundException("None of the specified nodes were found.");
+        }
+
+        return nodes;
     }
 
     /* Check that nodes exists and matches given expected/excluded type(s). */
@@ -837,6 +875,22 @@ public class NodesImpl implements Nodes
     }
 
     @Override
+    public List<Node> getFoldersOrDocumentsFullInfo(List<NodeRef> nodeRefs, Parameters parameters, Map<String, UserInfo> mapUserInfo)
+    {
+        List<String> includeParam = new ArrayList<>();
+        if (parameters != null)
+        {
+            includeParam.addAll(parameters.getInclude());
+        }
+
+        // Add basic info for single get (above & beyond minimal that is used for listing collections)
+        includeParam.add(PARAM_INCLUDE_ASPECTNAMES);
+        includeParam.add(PARAM_INCLUDE_PROPERTIES);
+
+        return getFoldersOrDocuments(nodeRefs, includeParam, mapUserInfo);
+    }
+
+    @Override
     public Node getFolderOrDocument(final NodeRef nodeRef, NodeRef parentNodeRef, QName nodeTypeQName, List<String> includeParam, Map<String, UserInfo> mapUserInfo)
     {
         if (mapUserInfo == null)
@@ -1042,6 +1096,224 @@ public class NodesImpl implements Nodes
         node.setPath(pathInfo);
 
         return node;
+    }
+
+    @Override
+    public List<Node> getFoldersOrDocuments(final List<NodeRef> nodeRefs, List<String> includeParam, Map<String, UserInfo> mapUserInfo)
+    {
+        List<Node> results = new ArrayList<>(nodeRefs.size());
+
+        if (mapUserInfo == null)
+        {
+            mapUserInfo = new HashMap<>(2);
+        }
+
+        if (includeParam == null)
+        {
+            includeParam = Collections.emptyList();
+        }
+
+        Map<NodeRef, Map<QName, Serializable>> properties = nodeService.getPropertiesForNodeRefs(nodeRefs);
+
+        for (NodeRef nodeRef : properties.keySet())
+        {
+            Node node;
+            Map<QName, Serializable> props = properties.get(nodeRef);
+
+            PathInfo pathInfo = null;
+            if (includeParam.contains(PARAM_INCLUDE_PATH))
+            {
+                ChildAssociationRef archivedParentAssoc = (ChildAssociationRef) props.get(ContentModel.PROP_ARCHIVED_ORIGINAL_PARENT_ASSOC);
+                pathInfo = lookupPathInfo(nodeRef, archivedParentAssoc);
+            }
+
+            QName nodeTypeQName = getNodeType(nodeRef);
+
+            NodeRef parentNodeRef = getParentNodeRef(nodeRef);
+
+            Type type = getType(nodeTypeQName, nodeRef);
+
+            if (type == null)
+            {
+                // not direct folder (or file) ...
+                // might be sub-type of cm:cmobject (or a cm:link pointing to cm:cmobject or possibly even another cm:link)
+                node = new Node(nodeRef, parentNodeRef, props, mapUserInfo, sr);
+                node.setIsFolder(false);
+                node.setIsFile(false);
+            }
+            else if (type.equals(Type.DOCUMENT))
+            {
+                node = new Document(nodeRef, parentNodeRef, props, mapUserInfo, sr);
+            }
+            else if (type.equals(Type.FOLDER))
+            {
+                node = new Folder(nodeRef, parentNodeRef, props, mapUserInfo, sr);
+            }
+            else
+            {
+                logger.info("Unexpected type for node: " + nodeRef + " type: " + type);
+                continue;
+            }
+
+            if (includeParam.size() > 0)
+            {
+                node.setProperties(mapFromNodeProperties(props, includeParam, mapUserInfo, EXCLUDED_NS, EXCLUDED_PROPS));
+            }
+
+            // TODO: Optimize to batch get aspects for all nodes
+            Set<QName> aspects = null;
+            if (includeParam.contains(PARAM_INCLUDE_ASPECTNAMES))
+            {
+                aspects = nodeService.getAspects(nodeRef);
+                node.setAspectNames(mapFromNodeAspects(aspects, EXCLUDED_NS, EXCLUDED_ASPECTS));
+            }
+
+            if (includeParam.contains(PARAM_INCLUDE_ISLINK))
+            {
+                boolean isLink = isSubClass(nodeTypeQName, ContentModel.TYPE_LINK);
+                node.setIsLink(isLink);
+            }
+
+            if (includeParam.contains(PARAM_INCLUDE_ISLOCKED))
+            {
+                boolean isLocked = isLocked(nodeRef, aspects);
+                node.setIsLocked(isLocked);
+            }
+
+            // TODO: Optimize to batch get favorites for all nodes
+            if (includeParam.contains(PARAM_INCLUDE_ISFAVORITE))
+            {
+                boolean isFavorite = isFavorite(nodeRef);
+                node.setIsFavorite(isFavorite);
+            }
+
+            // TODO: Optimize to batch get allowable operations for all nodes
+            if (includeParam.contains(PARAM_INCLUDE_ALLOWABLEOPERATIONS))
+            {
+                // note: refactor when requirements change
+                Map<String, String> mapPermsToOps = new HashMap<>(3);
+                mapPermsToOps.put(PermissionService.DELETE, OP_DELETE);
+                mapPermsToOps.put(PermissionService.ADD_CHILDREN, OP_CREATE);
+                mapPermsToOps.put(PermissionService.WRITE, OP_UPDATE);
+                mapPermsToOps.put(PermissionService.CHANGE_PERMISSIONS, OP_UPDATE_PERMISSIONS);
+
+                List<String> allowableOperations = new ArrayList<>(3);
+                for (Entry<String, String> kv : mapPermsToOps.entrySet())
+                {
+                    String perm = kv.getKey();
+                    String op = kv.getValue();
+
+                    if (perm.equals(PermissionService.ADD_CHILDREN) && Type.DOCUMENT.equals(type))
+                    {
+                        // special case: do not return "create" (as an allowable op) for file/content types - note: 'type' can be null
+                        continue;
+                    }
+                    else if (perm.equals(PermissionService.DELETE) && (isSpecialNode(nodeRef, nodeTypeQName)))
+                    {
+                        // special case: do not return "delete" (as an allowable op) for specific system nodes
+                        continue;
+                    }
+                    else if (permissionService.hasPermission(nodeRef, perm) == AccessStatus.ALLOWED)
+                    {
+                        allowableOperations.add(op);
+                    }
+                }
+
+                node.setAllowableOperations((allowableOperations.size() > 0) ? allowableOperations : null);
+            }
+
+            // TODO: Optimize to batch get permissions for all nodes
+            if (includeParam.contains(PARAM_INCLUDE_PERMISSIONS))
+            {
+                Boolean inherit = permissionService.getInheritParentPermissions(nodeRef);
+
+                List<NodePermissions.NodePermission> inheritedPerms = new ArrayList<>(5);
+                List<NodePermissions.NodePermission> setDirectlyPerms = new ArrayList<>(5);
+                Set<String> settablePerms = null;
+                boolean allowRetrievePermission = true;
+
+                try
+                {
+                    for (AccessPermission accessPerm : permissionService.getAllSetPermissions(nodeRef))
+                    {
+                        NodePermissions.NodePermission nodePerm = new NodePermissions.NodePermission(accessPerm.getAuthority(), accessPerm.getPermission(), accessPerm.getAccessStatus().toString());
+                        if (accessPerm.isSetDirectly())
+                        {
+                            setDirectlyPerms.add(nodePerm);
+                        }
+                        else
+                        {
+                            inheritedPerms.add(nodePerm);
+                        }
+                    }
+
+                    settablePerms = permissionService.getSettablePermissions(nodeRef);
+                }
+                catch (AccessDeniedException ade)
+                {
+                    // ignore - ie. denied access to retrieve permissions, eg. non-admin on root (Company Home)
+                    allowRetrievePermission = false;
+                }
+
+                // If the user does not have read permissions at
+                // least on a special node then do not include permissions and
+                // returned only node info that he's allowed to see
+                if (allowRetrievePermission)
+                {
+                    NodePermissions nodePerms = new NodePermissions(inherit, inheritedPerms, setDirectlyPerms, settablePerms);
+                    node.setPermissions(nodePerms);
+                }
+            }
+
+            // TODO: Optimize to batch get associations for all nodes
+            if (includeParam.contains(PARAM_INCLUDE_ASSOCIATION))
+            {
+                // Ugh ... can we optimise this and return the actual assoc directly (via FileFolderService/GetChildrenCQ) ?
+                ChildAssociationRef parentAssocRef = nodeService.getPrimaryParent(nodeRef);
+
+                // note: parentAssocRef.parentRef can be null for -root- node !
+                if ((parentAssocRef == null) || (parentAssocRef.getParentRef() == null) || (!parentAssocRef.getParentRef().equals(parentNodeRef)))
+                {
+                    List<ChildAssociationRef> parentAssocRefs = nodeService.getParentAssocs(nodeRef);
+                    for (ChildAssociationRef pAssocRef : parentAssocRefs)
+                    {
+                        if (pAssocRef.getParentRef().equals(parentNodeRef))
+                        {
+                            // for now, assume same parent/child cannot appear more than once (due to unique name)
+                            parentAssocRef = pAssocRef;
+                            break;
+                        }
+                    }
+                }
+
+                if (parentAssocRef != null)
+                {
+                    QName assocTypeQName = parentAssocRef.getTypeQName();
+                    if ((assocTypeQName != null) && (!EXCLUDED_NS.contains(assocTypeQName.getNamespaceURI())))
+                    {
+                        AssocChild childAssoc = new AssocChild(
+                                assocTypeQName.toPrefixString(namespaceService),
+                                parentAssocRef.isPrimary());
+
+                        node.setAssociation(childAssoc);
+                    }
+                }
+            }
+
+            // TODO: Optimize to batch get definitions for all nodes
+            if (includeParam.contains(PARAM_INCLUDE_DEFINITION))
+            {
+                ClassDefinition classDefinition = classDefinitionMapper.fromDictionaryClassDefinition(getTypeDefinition(nodeRef), dictionaryService);
+                node.setDefinition(classDefinition);
+            }
+
+            node.setNodeType(nodeTypeQName.toPrefixString(namespaceService));
+            node.setPath(pathInfo);
+
+            results.add(node);
+        }
+
+        return results;
     }
 
     private TypeDefinition getTypeDefinition(NodeRef nodeRef)

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -184,7 +184,10 @@ public class ResultMapper
 
                 if (aNode == null)
                 {
-                    logger.debug("Unknown noderef returned from search results " + row.getNodeRef());
+                    if (logger.isDebugEnabled())
+                    {
+                        logger.debug("Unknown noderef returned from search results " + row.getNodeRef());
+                    }
                     unknownNodeRefsCount.incrementAndGet();
                     continue;
                 }
@@ -197,7 +200,7 @@ public class ResultMapper
 
                     if (high != null && !high.isEmpty())
                     {
-                        highlightEntries = new ArrayList<HighlightEntry>(high.size());
+                        highlightEntries = new ArrayList<>(high.size());
                         for (Pair<String, List<String>> highlight : high)
                         {
                             highlightEntries.add(new HighlightEntry(highlight.getFirst(), highlight.getSecond()));
@@ -331,8 +334,8 @@ public class ResultMapper
 
                     for (Entry<NodeRef, Map<QName, Serializable>> entry : properties.entrySet())
                     {
-                        NodeRef frozenNodeRef = ((NodeRef) entry.getValue()
-                                .get(Version2Model.PROP_QNAME_FROZEN_NODE_REF));
+                        NodeRef frozenNodeRef = (NodeRef) entry.getValue()
+                                .get(Version2Model.PROP_QNAME_FROZEN_NODE_REF);
                         String versionLabelId = (String) entry.getValue()
                                 .get(Version2Model.PROP_QNAME_VERSION_LABEL);
 
@@ -362,8 +365,11 @@ public class ResultMapper
                         catch (EntityNotFoundException | InvalidNodeRefException e)
                         {
                             // Solr says there is a node but we can't find it
-                            logger.debug("Failed to find a versioned node with id of " + frozenNodeRef
-                                    + " this is probably because the original node has been deleted.");
+                            if (logger.isDebugEnabled())
+                            {
+                                logger.debug("Failed to find a versioned node with id of " + frozenNodeRef
+                                        + " this is probably because the original node has been deleted.");
+                            }
                         }
 
                         if (version != null && aNode != null)
@@ -377,7 +383,7 @@ public class ResultMapper
                     }
                     break;
                 case DELETED:
-                    List<String> nodeIds = resultSet.getNodeRefs().stream().map(nr -> nr.getId()).collect(Collectors.toList());
+                    List<String> nodeIds = resultSet.getNodeRefs().stream().map(NodeRef::getId).collect(Collectors.toList());
                     try
                     {
                         results = deletedNodes.getDeletedNodes(nodeIds, params, false, mapUserInfo);
@@ -386,7 +392,10 @@ public class ResultMapper
                     {
                         // Solr says there is a deleted node but we can't find it, we want the rest of
                         // the search to return so lets ignore it.
-                        logger.debug("Failed to find a deleted nodes with ids of " + nodeIds.toString());
+                        if (logger.isDebugEnabled())
+                        {
+                            logger.debug("Failed to find a deleted nodes with ids of " + nodeIds.toString());
+                        }
                     }
                     break;
                 }

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -173,7 +173,7 @@ public class ResultMapper
 
         if (results != null && results.getNumberFound() > 0)
         {
-            String store = searchQuery.getScope().getLocations().isEmpty() ? LIVE_NODES
+            String store = searchQuery.getScope() == null ? LIVE_NODES
                     : searchQuery.getScope().getLocations().get(0);
 
             List<Node> nodes = getNodes(store, results, params, mapUserInfo);

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -175,7 +175,7 @@ public class ResultMapper
         {
             String store = searchQuery.getScope().getLocations().isEmpty() ? LIVE_NODES
                     : searchQuery.getScope().getLocations().get(0);
-            
+
             List<Node> nodes = getNodes(store, results, params, mapUserInfo);
 
             for (ResultSetRow row : results)

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -173,7 +173,10 @@ public class ResultMapper
 
         if (results != null && results.getNumberFound() > 0)
         {
-            List<Node> nodes = getNodes(results, params, mapUserInfo);
+            String store = searchQuery.getScope().getLocations().isEmpty() ? LIVE_NODES
+                    : searchQuery.getScope().getLocations().get(0);
+            
+            List<Node> nodes = getNodes(store, results, params, mapUserInfo);
 
             for (ResultSetRow row : results)
             {
@@ -311,17 +314,15 @@ public class ResultMapper
      * @param mapUserInfo
      * @return The node object or null if the user does not have permission to view it.
      */
-    public List<Node> getNodes(ResultSet resultSet, Params params, Map<String, UserInfo> mapUserInfo)
+    public List<Node> getNodes(String store, ResultSet resultSet, Params params, Map<String, UserInfo> mapUserInfo)
     {
         List<Node> results = new ArrayList<>(resultSet.length());
 
         if (resultSet.length() > 0)
         {
-            final String nodeStore = storeMapper.getStore(resultSet.getNodeRef(0));
-
             try
             {
-                switch (nodeStore)
+                switch (store)
                 {
                 case LIVE_NODES:
                     results.addAll(nodes.getFoldersOrDocuments(resultSet.getNodeRefs(), params.getInclude(),
@@ -409,7 +410,7 @@ public class ResultMapper
             if (!results.isEmpty())
             {
 
-                results.forEach(aNode -> aNode.setLocation(nodeStore));
+                results.forEach(aNode -> aNode.setLocation(store));
             }
         }
 

--- a/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/search/impl/ResultMapper.java
@@ -162,36 +162,58 @@ public class ResultMapper
     {
         List<Node> noderesults = new ArrayList<>();
         Map<String, UserInfo> mapUserInfo = new HashMap<>(10);
-        Map<NodeRef, List<Pair<String, List<String>>>> highLighting = results.getHighlighting();
-        final AtomicInteger unknownNodeRefsCount = new AtomicInteger();
-        boolean isHistory = searchRequestContext.getStores().contains(StoreMapper.HISTORY);
-
-        for (ResultSetRow row : results)
+        Map<NodeRef, List<Pair<String, List<String>>>> highLighting = Collections.emptyMap();
+        if (results != null)
         {
-            Node aNode = getNode(row, params, mapUserInfo, isHistory);
+            highLighting = results.getHighlighting();
+        }
+        final AtomicInteger unknownNodeRefsCount = new AtomicInteger();
+        // The store was never implemented
+        // boolean isHistory = searchRequestContext.getStores().contains(StoreMapper.HISTORY);
 
-            if (aNode != null)
+        if (results != null && results.getNumberFound() > 0)
+        {
+            List<Node> nodes = getNodes(results, params, mapUserInfo);
+
+            for (ResultSetRow row : results)
             {
-                float f = row.getScore();
-                List<HighlightEntry> highlightEntries = null;
-                List<Pair<String, List<String>>> high = highLighting.get(row.getNodeRef());
+                Node aNode = nodes.stream()
+                        .filter(n -> n.getNodeRef().equals(row.getNodeRef()))
+                        .findFirst()
+                        .orElse(null);
 
-                if (high != null && !high.isEmpty())
+                if (aNode == null)
                 {
-                    highlightEntries = new ArrayList<HighlightEntry>(high.size());
-                    for (Pair<String, List<String>> highlight : high)
-                    {
-                        highlightEntries.add(new HighlightEntry(highlight.getFirst(), highlight.getSecond()));
-                    }
+                    logger.debug("Unknown noderef returned from search results " + row.getNodeRef());
+                    unknownNodeRefsCount.incrementAndGet();
+                    continue;
                 }
-                aNode.setSearch(new SearchEntry(f, highlightEntries));
+
+                float f = row.getScore();
+                if (!highLighting.isEmpty())
+                {
+                    List<HighlightEntry> highlightEntries = null;
+                    List<Pair<String, List<String>>> high = highLighting.get(row.getNodeRef());
+
+                    if (high != null && !high.isEmpty())
+                    {
+                        highlightEntries = new ArrayList<HighlightEntry>(high.size());
+                        for (Pair<String, List<String>> highlight : high)
+                        {
+                            highlightEntries.add(new HighlightEntry(highlight.getFirst(), highlight.getSecond()));
+                        }
+                    }
+
+                    aNode.setSearch(new SearchEntry(f, highlightEntries));
+                }
+
                 noderesults.add(aNode);
             }
-            else
-            {
-                logger.debug("Unknown noderef returned from search results " + row.getNodeRef());
-                unknownNodeRefsCount.incrementAndGet();
-            }
+        }
+
+        if (unknownNodeRefsCount.get() > 0)
+        {
+            logger.warn("Search results contained " + unknownNodeRefsCount.get() + " unknown noderefs which were skipped.");
         }
 
         SearchContext context = toSearchEngineResultSet(results)
@@ -276,6 +298,113 @@ public class ResultMapper
             aNode.setLocation(nodeStore);
         }
         return aNode;
+    }
+
+    /**
+     * Builds node representation based on ResultSet;
+     *
+     * @param resultSet
+     * @param params
+     * @param mapUserInfo
+     * @return The node object or null if the user does not have permission to view it.
+     */
+    public List<Node> getNodes(ResultSet resultSet, Params params, Map<String, UserInfo> mapUserInfo)
+    {
+        List<Node> results = new ArrayList<>(resultSet.length());
+
+        if (resultSet.length() > 0)
+        {
+            final String nodeStore = storeMapper.getStore(resultSet.getNodeRef(0));
+
+            try
+            {
+                switch (nodeStore)
+                {
+                case LIVE_NODES:
+                    results.addAll(nodes.getFoldersOrDocuments(resultSet.getNodeRefs(), params.getInclude(),
+                            mapUserInfo));
+                    break;
+                case VERSIONS:
+                    Map<NodeRef, Map<QName, Serializable>> properties = serviceRegistry.getNodeService()
+                            .getPropertiesForNodeRefs(resultSet.getNodeRefs());
+                    Map<NodeRef, Pair<NodeRef, String>> frozenNodeRefs = new HashMap<>();
+
+                    for (Entry<NodeRef, Map<QName, Serializable>> entry : properties.entrySet())
+                    {
+                        NodeRef frozenNodeRef = ((NodeRef) entry.getValue()
+                                .get(Version2Model.PROP_QNAME_FROZEN_NODE_REF));
+                        String versionLabelId = (String) entry.getValue()
+                                .get(Version2Model.PROP_QNAME_VERSION_LABEL);
+
+                        if (frozenNodeRef != null && versionLabelId != null)
+                        {
+                            frozenNodeRefs.put(entry.getKey(), new Pair<>(frozenNodeRef, versionLabelId));
+                        }
+                    }
+
+                    // This section falls back to the less performant way of doing things. The calls that are made need more thought into
+                    // how to approach this it. The changes required are a bit more significant than just passing a collection. Looking up
+                    // versioned nodes is a little less common than searching for "Live Nodes" so it should be ok for now :-(
+
+                    for (Entry<NodeRef, Pair<NodeRef, String>> entry : frozenNodeRefs.entrySet())
+                    {
+                        NodeRef frozenNodeRef = entry.getValue().getFirst();
+                        String versionLabelId = entry.getValue().getSecond();
+
+                        Version version = null;
+                        Node aNode = null;
+
+                        try
+                        {
+                            version = nodeVersions.findVersion(frozenNodeRef.getId(), versionLabelId);
+                            aNode = nodes.getFolderOrDocument(version.getFrozenStateNodeRef(), null, null, params.getInclude(), mapUserInfo);
+                        }
+                        catch (EntityNotFoundException | InvalidNodeRefException e)
+                        {
+                            // Solr says there is a node but we can't find it
+                            logger.debug("Failed to find a versioned node with id of " + frozenNodeRef
+                                    + " this is probably because the original node has been deleted.");
+                        }
+
+                        if (version != null && aNode != null)
+                        {
+                            nodeVersions.mapVersionInfo(version, aNode, entry.getKey());
+                            aNode.setNodeId(frozenNodeRef.getId());
+                            aNode.setVersionLabel(versionLabelId);
+
+                            results.add(aNode);
+                        }
+                    }
+                    break;
+                case DELETED:
+                    List<String> nodeIds = resultSet.getNodeRefs().stream().map(nr -> nr.getId()).collect(Collectors.toList());
+                    try
+                    {
+                        results = deletedNodes.getDeletedNodes(nodeIds, params, false, mapUserInfo);
+                    }
+                    catch (EntityNotFoundException enfe)
+                    {
+                        // Solr says there is a deleted node but we can't find it, we want the rest of
+                        // the search to return so lets ignore it.
+                        logger.debug("Failed to find a deleted nodes with ids of " + nodeIds.toString());
+                    }
+                    break;
+                }
+            }
+            catch (PermissionDeniedException e)
+            {
+                // logger.debug("Unable to access nodes: " + resultSet.toString());
+                return null;
+            }
+
+            if (!results.isEmpty())
+            {
+
+                results.forEach(aNode -> aNode.setLocation(nodeStore));
+            }
+        }
+
+        return results;
     }
 
     /**

--- a/remote-api/src/test/java/org/alfresco/rest/api/search/ResultMapperTests.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/search/ResultMapperTests.java
@@ -32,7 +32,11 @@ import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -56,6 +60,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
@@ -254,6 +259,7 @@ public class ResultMapperTests
     }
 
     @Test
+    @Ignore("Disabled MNT-25404 - Invalid test. Assumes multi-store search.")
     public void testToCollectionWithPagingInfo()
     {
         ResultSet results = mockResultSet(asList(514l), asList(566l, VERSIONED_ID));

--- a/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
@@ -383,7 +383,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
     }
 
     /**
-     * Find the entities associated with the given key list. The {@link EntityLookupCallbackDAO#findByKey(Serializable) entity callback} will be used if necessary.
+     * Find the entities associated with the given key list. The {@link EntityLookupCallbackDAO#findByKeys(Serializable) entity callback} will be used if necessary.
      * <p/>
      * It is up to the client code to decide if a returned empty list indicates a concurrency violation or not; the former would normally result in a concurrency-related exception such as {@link ConcurrencyFailureException}.
      * 

--- a/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
@@ -234,6 +234,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
          * 
          * @return Returns empty list always
          */
+        @Override
         public List<VK2> getValueKeys(List<V2> values)
         {
             return Collections.emptyList();
@@ -455,11 +456,11 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
                 }
                 else if (value.equals(VALUE_NULL))
                 {
-                    results.add(new Pair<K, V>(key, null));
+                    results.add(new Pair<>(key, null));
                 }
                 else
                 {
-                    results.add(new Pair<K, V>(key, value));
+                    results.add(new Pair<>(key, value));
                 }
             }
             else
@@ -488,7 +489,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
                 }
                 cache.put(
                         new CacheRegionKey(cacheRegion, entityPair.getFirst()),
-                        (value == null ? VALUE_NULL : value));
+                        value == null ? VALUE_NULL : value);
 
                 results.add(entityPair);
             }
@@ -616,7 +617,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
             }
             else
             {
-                lookInCache.add(new Pair<VK, V>(valueKey, value));
+                lookInCache.add(new Pair<>(valueKey, value));
             }
         }
 
@@ -676,7 +677,7 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
                     cache.put(new CacheRegionValueKey(cacheRegion, (VK) entityPair.getSecond()), key);
                     cache.put(
                             new CacheRegionKey(cacheRegion, key),
-                            (entityPair.getSecond() == null ? VALUE_NULL : entityPair.getSecond()));
+                            entityPair.getSecond() == null ? VALUE_NULL : entityPair.getSecond());
 
                     results.add(entityPair);
                 }

--- a/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
@@ -125,6 +125,19 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         Pair<K1, V1> findByValue(V1 value);
 
         /**
+         * Find entities using the given list of value keys. The <code>equals</code> and <code>hashCode</code> methods of the value object should respect case-sensitivity in the same way that this lookup treats case-sensitivity i.e. if the <code>equals</code> method is <b>case-sensitive</b> then this method should look the entity up using a <b>case-sensitive</b> search.
+         * <p/>
+         * Since this is a cache backed by some sort of database, <tt>null</tt> values are allowed by the cache. The implementation of this method can throw an exception if <tt>null</tt> is not appropriate for the use-case.
+         * <p/>
+         * If the search is impossible or expensive, this method should just return an empty list. This would usually be the case if the {@link #getValueKeys(Object) getValueKey} method also returned <tt>null</tt> i.e. if it is difficult to look the value up in storage then it is probably difficult to generate a cache key from it, too.
+         * 
+         * @param values
+         *            the values (business objects) used to identify the entities (<tt>null</tt> allowed).
+         * @return Return the entities or an empty list if no entity matches the given values
+         */
+        List<Pair<K1, V1>> findByValues(List<V1> values);
+
+        /**
          * Create an entity using the given values. It is valid to assume that the entity does not exist within the current transaction at least.
          * <p/>
          * Since persistence mechanisms often allow <tt>null</tt> values, these can be expected here. The implementation must throw an exception if <tt>null</tt> is not allowed for the specific use-case.
@@ -194,6 +207,16 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         public Pair<K2, V2> findByValue(V2 value)
         {
             return null;
+        }
+
+        /**
+         * This implementation never finds a value and is backed by {@link #getValueKey(Object)} returning an empty list.
+         * 
+         * @return Returns an empty list always
+         */
+        public List<Pair<K2, V2>> findByValues(V2 value)
+        {
+            return Collections.emptyList();
         }
 
         /**
@@ -538,6 +561,130 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         }
         // Done
         return entityPair;
+    }
+
+    /**
+     * Find the entity associated with the given value. The {@link EntityLookupCallbackDAO#findByValue(Object) entity callback} will be used if no entry exists in the cache.
+     * <p/>
+     * It is up to the client code to decide if a <tt>null</tt> return value indicates a concurrency violation or not; the former would normally result in a concurrency-related exception such as {@link ConcurrencyFailureException}.
+     * 
+     * @param values
+     *            The entity values, which may be valid or invalid (<tt>null</tt> is allowed)
+     * @return Returns a list of key-value pairs
+     */
+    @SuppressWarnings("unchecked")
+    public List<Pair<K, V>> getByValues(List<V> values)
+    {
+        if (values == null || values.isEmpty())
+        {
+            throw new IllegalArgumentException("An entity lookup value list may not be null or empty");
+        }
+
+        // Create a defensive copy and remove any nulls for safety
+        List<V> filteredValues = new ArrayList<>(values.size());
+        for (V v : values)
+        {
+            if (v != null)
+            {
+                filteredValues.add(v);
+            }
+        }
+
+        // Handle missing cache
+        if (cache == null)
+        {
+            return entityLookup.findByValues(filteredValues);
+        }
+
+        List<Pair<K, V>> results = new ArrayList<>(filteredValues.size());
+        List<V> valuesToFind = new ArrayList<>(filteredValues.size());
+        List<Pair<VK, V>> lookInCache = new ArrayList<>(filteredValues.size());
+        List<V> valuesToResolve = new ArrayList<>(filteredValues.size());
+        List<K> keysToGet = new ArrayList<>(filteredValues.size());
+
+        // Get the value key.
+        for (V value : filteredValues)
+        {
+            // The cast to (VK) is counter-intuitive, but works because they're all just Serializable
+            // It's nasty, but hidden from the cache client code.
+            VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
+
+            if (valueKey == null)
+            {
+                valuesToFind.add(value);
+                continue;
+            }
+            else
+            {
+                lookInCache.add(new Pair<VK, V>(valueKey, value));
+            }
+        }
+
+        if (!valuesToFind.isEmpty())
+        {
+            results.addAll(entityLookup.findByValues(valuesToFind));
+        }
+
+        for (Pair<VK, V> valuePair : lookInCache)
+        {
+            // Look in the cache
+            CacheRegionValueKey valueCacheKey = new CacheRegionValueKey(cacheRegion, valuePair.getFirst());
+
+            K key = (K) cache.get(valueCacheKey);
+
+            // Check if we have looked this up already
+            if (key != null)
+            {
+                // We checked before and ...
+                if (key.equals(VALUE_NOT_FOUND))
+                {
+                    // ... it didn't exist
+                    continue; // not costly...making it clear that we are moving to the next value
+                }
+                else
+                {
+                    // ... it did exist
+                    keysToGet.add(key);
+                    continue;
+                }
+            }
+
+            valuesToResolve.add(valuePair.getSecond());
+        }
+
+        if (!keysToGet.isEmpty())
+        {
+            results.addAll(getByKeys(keysToGet));
+        }
+
+        // Resolve it
+        if (!valuesToResolve.isEmpty())
+        {
+            List<Pair<K, V>> entityPairs = entityLookup.findByValues(valuesToResolve);
+
+            for (Pair<K, V> entityPair : entityPairs)
+            {
+                if (entityPair == null)
+                {
+                    // Missing (null) should not make it back here since findByValues should not return any nulls
+                    continue;
+                }
+                else
+                {
+                    K key = entityPair.getFirst();
+                    // Cache the Key
+                    cache.put(new CacheRegionValueKey(cacheRegion, (VK) entityPair.getSecond()), key);
+                    cache.put(
+                            new CacheRegionKey(cacheRegion, key),
+                            (entityPair.getSecond() == null ? VALUE_NULL : entityPair.getSecond()));
+
+                    results.add(entityPair);
+                }
+            }
+        }
+
+        // Done
+        return results;
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
+++ b/repository/src/main/java/org/alfresco/repo/cache/lookup/EntityLookupCache.java
@@ -27,6 +27,13 @@ package org.alfresco.repo.cache.lookup;
 
 import java.io.Serializable;
 import java.sql.Savepoint;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.extensions.surf.util.ParameterCheck;
@@ -74,6 +81,19 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         VK1 getValueKey(V1 value);
 
         /**
+         * Resolve the given values into unique value keys that can be used to find an entity's ID. A return value should be small and efficient; don't return a value if this is not possible.
+         * <p/>
+         * Implementations will often return values themselves, provided that the values are both serializable and have good <code>equals</code> and <code>hashCode</code>.
+         * <p/>
+         * Were no adequate key can be generated for the value, then it should not be returned. In this case, the {@link #findByValue(Object) findByValue} method might not even do a search and just return <tt>null</tt> or nothing itself i.e. if it is difficult to look the value up in storage then it is probably difficult to generate a cache key from it, too.. In this scenario, the cache will be purely for key-based lookups
+         * 
+         * @param values
+         *            full values being keyed (never <tt>null</tt>)
+         * @return Returns the business keys representing the entities
+         */
+        List<VK1> getValueKeys(List<V1> values);
+
+        /**
          * Find an entity for a given key.
          * 
          * @param key
@@ -81,6 +101,15 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
          * @return Return the entity or <tt>null</tt> if no entity is exists for the ID
          */
         Pair<K1, V1> findByKey(K1 key);
+
+        /**
+         * Find entities for a list of given key.
+         * 
+         * @param keys
+         *            the keys (IDs) used to identify the entity (never <tt>null</tt>)
+         * @return Return a list of entities or <tt>null</tt> if no entities exists for the IDs
+         */
+        List<Pair<K1, V1>> findByKeys(List<K1> keys);
 
         /**
          * Find and entity using the given value key. The <code>equals</code> and <code>hashCode</code> methods of the value object should respect case-sensitivity in the same way that this lookup treats case-sensitivity i.e. if the <code>equals</code> method is <b>case-sensitive</b> then this method should look the entity up using a <b>case-sensitive</b> search.
@@ -175,6 +204,16 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         public VK2 getValueKey(V2 value)
         {
             return null;
+        }
+
+        /**
+         * This implementation does not find values and is backed by {@link #findByValue(Object)} returning nothing.
+         * 
+         * @return Returns empty list always
+         */
+        public List<VK2> getValueKeys(List<V2> values)
+        {
+            return Collections.emptyList();
         }
 
         /**
@@ -341,6 +380,98 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         }
         // Done
         return entityPair;
+    }
+
+    /**
+     * Find the entities associated with the given key list. The {@link EntityLookupCallbackDAO#findByKey(Serializable) entity callback} will be used if necessary.
+     * <p/>
+     * It is up to the client code to decide if a returned empty list indicates a concurrency violation or not; the former would normally result in a concurrency-related exception such as {@link ConcurrencyFailureException}.
+     * 
+     * @param keys
+     *            The entity keys, which may be valid or invalid (<tt>null</tt> not allowed)
+     * @return Returns a list of key-value pairs or an empty list if no keys reference any entities
+     */
+    @SuppressWarnings("unchecked")
+    public List<Pair<K, V>> getByKeys(List<K> keys)
+    {
+        if (keys == null || keys.isEmpty())
+        {
+            throw new IllegalArgumentException("An entity lookup key list may not be null or empty");
+        }
+
+        // Create a defensive copy and remove any nulls for safety
+        List<K> filteredKeys = new ArrayList<>(keys.size());
+        for (K k : keys)
+        {
+            if (k != null)
+            {
+                filteredKeys.add(k);
+            }
+        }
+
+        // Handle missing cache
+        if (cache == null)
+        {
+            return entityLookup.findByKeys(filteredKeys);
+        }
+
+        List<Pair<K, V>> results = new ArrayList<>(filteredKeys.size());
+        Map<K, CacheRegionKey> keysToResolve = new HashMap<>();
+
+        for (K key : filteredKeys)
+        {
+            CacheRegionKey keyCacheKey = new CacheRegionKey(cacheRegion, key);
+            // Look in the cache
+            V value = (V) cache.get(keyCacheKey);
+            if (value != null)
+            {
+                if (value.equals(VALUE_NOT_FOUND))
+                {
+                    // We checked before.
+                    continue; // not costly...making it clear that we are moving to the next key
+                }
+                else if (value.equals(VALUE_NULL))
+                {
+                    results.add(new Pair<K, V>(key, null));
+                }
+                else
+                {
+                    results.add(new Pair<K, V>(key, value));
+                }
+            }
+            else
+            {
+                // Need to resolve this key
+                keysToResolve.put(key, keyCacheKey);
+            }
+        }
+
+        // Resolve any missing keys
+        List<Pair<K, V>> entityPairs = entityLookup.findByKeys(new ArrayList<>(keysToResolve.keySet()));
+
+        if (entityPairs != null && !entityPairs.isEmpty())
+        {
+            for (Pair<K, V> entityPair : entityPairs)
+            {
+                V value = entityPair.getSecond();
+                // Get the value key
+                VK valueKey = (value == null) ? (VK) VALUE_NULL : entityLookup.getValueKey(value);
+                // Check if the value has a good key
+                if (valueKey != null)
+                {
+                    CacheRegionValueKey valueCacheKey = new CacheRegionValueKey(cacheRegion, valueKey);
+                    // The key is good, so we can cache the value
+                    cache.put(valueCacheKey, entityPair.getFirst());
+                }
+                cache.put(
+                        new CacheRegionKey(cacheRegion, entityPair.getFirst()),
+                        (value == null ? VALUE_NULL : value));
+
+                results.add(entityPair);
+            }
+        }
+        // Done
+        return results;
     }
 
     /**
@@ -689,6 +820,22 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         // Done
     }
 
+    public void setValues(Map<K, V> keyValues)
+    {
+        // Handle missing cache
+        if (cache == null)
+        {
+            return;
+        }
+
+        List<K> keys = keyValues.keySet().stream().collect(Collectors.toList());
+
+        // Remove entries for the keys (bidirectional removal removes the old values as well)
+        // but leave the keys as they will get updated
+        removeByKeys(keys, false);
+
+    }
+
     /**
      * Delete the entity associated with the given key. The {@link EntityLookupCallbackDAO#deleteByKey(Serializable)} callback will be used if necessary.
      * <p/>
@@ -752,6 +899,20 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
     }
 
     /**
+     * Cache-only operation: Remove all cache values associated with the given keys.
+     */
+    public void removeByKeys(Collection<K> keys)
+    {
+        // Handle missing cache
+        if (cache == null)
+        {
+            return;
+        }
+
+        removeByKeys(keys, true);
+    }
+
+    /**
      * Cache-only operation: Remove all cache values associated with the given key.
      * 
      * @param removeKey
@@ -776,6 +937,46 @@ public class EntityLookupCache<K extends Serializable, V extends Object, VK exte
         {
             cache.remove(keyCacheKey);
         }
+    }
+
+    /**
+     * Cache-only operation: Remove all cache values associated with the given keys.
+     * 
+     * @param removeKey
+     *            <tt>true</tt> to remove the given keys' entry
+     */
+    @SuppressWarnings("unchecked")
+    private void removeByKeys(Collection<K> keys, boolean removeKey)
+    {
+        List<V> values = new ArrayList<>();
+        for (K key : keys)
+        {
+            CacheRegionKey keyCacheKey = new CacheRegionKey(cacheRegion, key);
+            V value = (V) cache.get(keyCacheKey);
+            if (value != null && !value.equals(VALUE_NOT_FOUND))
+            {
+                values.add(value);
+            }
+            if (removeKey)
+            {
+                cache.remove(keyCacheKey);
+            }
+        }
+
+        if (!values.isEmpty())
+        {
+            // Get the value key and remove it
+            List<VK> valueKeys = entityLookup.getValueKeys(values);
+            if (valueKeys != null && !valueKeys.isEmpty())
+            {
+                for (VK vk : valueKeys)
+                {
+                    CacheRegionValueKey valueCacheKey = new CacheRegionValueKey(cacheRegion, vk);
+                    cache.remove(valueCacheKey);
+                }
+            }
+        }
+
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
@@ -26,10 +26,12 @@
 package org.alfresco.repo.domain.contentdata;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -243,9 +245,11 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
 
     public void cacheContentDataForNodes(Set<Long> nodeIds)
     {
-        for (ContentDataEntity entity : getContentDataEntitiesForNodes(nodeIds))
+        List<ContentDataEntity> contentDataEntities = getContentDataEntitiesForNodes(nodeIds);
+        // We may need to add additional protections here
+        for (ContentDataEntity contentDataEntity : contentDataEntities)
         {
-            contentDataCache.setValue(entity.getId(), makeContentData(entity));
+            contentDataCache.setValue(contentDataEntity.getId(), makeContentData(contentDataEntity));
         }
     }
 
@@ -299,6 +303,41 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
      */
     private class ContentDataCallbackDAO extends EntityLookupCallbackDAOAdaptor<Long, ContentData, Serializable>
     {
+        @Override
+        public Serializable getValueKey(ContentData value)
+        {
+            if (value == null)
+            {
+                throw new IllegalArgumentException("ContentData value cannot be null");
+            }
+
+            // It is a gross hack for now, but we need to find the entity based on the value
+            ContentDataEntity contentDataEntity = getContentDataEntities(Collections.singletonList(value)).stream().findFirst().orElse(null);
+            if (contentDataEntity == null)
+            {
+                return null;
+            }
+            return contentDataEntity.getId();
+        }
+
+        @Override
+        public List<Serializable> getValueKeys(List<ContentData> values)
+        {
+            if (values == null || values.isEmpty())
+            {
+                return Collections.emptyList();
+            }
+
+            List<ContentDataEntity> contentDataEntities = getContentDataEntities(values);
+
+            List<Serializable> result = new ArrayList<>(contentDataEntities.size());
+            for (ContentDataEntity contentDataEntity : contentDataEntities)
+            {
+                result.add(contentDataEntity.getId());
+            }
+            return result;
+        }
+
         public Pair<Long, ContentData> createValue(ContentData value)
         {
             value = sanitizeMimetype(value);
@@ -317,6 +356,29 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             ContentData contentData = makeContentData(contentDataEntity);
             // Done
             return new Pair<Long, ContentData>(key, contentData);
+        }
+
+        public List<Pair<Long, ContentData>> findByKeys(List<Long> keys)
+        {
+            if (keys == null || keys.isEmpty())
+            {
+                return null;
+            }
+
+            List<ContentDataEntity> contentDataEntities = getContentDataEntitiesForNodes(keys.stream().collect(Collectors.toSet()));
+            if (contentDataEntities == null || contentDataEntities.isEmpty())
+            {
+                return null;
+            }
+
+            List<Pair<Long, ContentData>> result = new ArrayList<>(contentDataEntities.size());
+
+            for (ContentDataEntity contentDataEntity : contentDataEntities)
+            {
+                ContentData contentData = makeContentData(contentDataEntity);
+                result.add(new Pair<Long, ContentData>(contentDataEntity.getId(), contentData));
+            }
+            return result;
         }
 
         @Override
@@ -349,6 +411,28 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         public String getValueKey(ContentUrlEntity value)
         {
             return value.getContentUrl();
+        }
+
+        @Override
+        public List<Pair<Long, ContentUrlEntity>> findByKeys(List<Long> keys)
+        {
+            if (keys == null || keys.isEmpty())
+            {
+                return null;
+            }
+
+            List<ContentUrlEntity> contentUrlEntities = getContentUrlEntities(keys);
+            if (contentUrlEntities == null || contentUrlEntities.isEmpty())
+            {
+                return null;
+            }
+
+            List<Pair<Long, ContentUrlEntity>> result = new ArrayList<>(contentUrlEntities.size());
+            for (ContentUrlEntity contentUrlEntity : contentUrlEntities)
+            {
+                result.add(new Pair<Long, ContentUrlEntity>(contentUrlEntity.getId(), contentUrlEntity));
+            }
+            return result;
         }
 
         /**
@@ -412,17 +496,59 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
     {
         // Decode content URL
         Long contentUrlId = contentDataEntity.getContentUrlId();
-        String contentUrl = null;
+        Pair<Long, ContentUrlEntity> entityPair = null;
         if (contentUrlId != null)
         {
-            Pair<Long, ContentUrlEntity> entityPair = contentUrlCache.getByKey(contentUrlId);
-            if (entityPair == null)
-            {
-                throw new DataIntegrityViolationException("No ContentUrl value exists for ID " + contentUrlId);
-            }
-            ContentUrlEntity contentUrlEntity = entityPair.getSecond();
-            contentUrl = contentUrlEntity.getContentUrl();
+            entityPair = contentUrlCache.getByKey(contentUrlId);
         }
+
+        return processContentDataEntity(entityPair, contentDataEntity);
+    }
+
+    /**
+     * Translates these instances into an externally-usable <code>ContentData</code> instances.
+     */
+    private List<ContentData> makeContentData(List<ContentDataEntity> contentDataEntities)
+    {
+        List<ContentData> contentDataList = new ArrayList<>(contentDataEntities.size());
+        List<Long> contentUrlIds = new ArrayList<>();
+        List<Pair<Long, ContentUrlEntity>> entityPairs = new ArrayList<>(contentDataEntities.size());
+
+        for (ContentDataEntity contentDataEntity : contentDataEntities)
+        {
+            // Decode content URL
+            contentUrlIds.add(contentDataEntity.getContentUrlId());
+        }
+
+        if (!contentUrlIds.isEmpty())
+        {
+            entityPairs = contentUrlCache.getByKeys(contentUrlIds);
+        }
+
+        for (Pair<Long, ContentUrlEntity> pair : entityPairs)
+        {
+            ContentDataEntity contentDataEntity = contentDataEntities.stream()
+                    .filter(cde -> cde.getContentUrlId().equals(pair.getFirst()))
+                    .findFirst()
+                    .orElse(null);
+            ContentData contentData = processContentDataEntity(pair, contentDataEntity);
+            contentDataList.add(contentData);
+        }
+        return contentDataList;
+    }
+
+    private ContentData processContentDataEntity(Pair<Long, ContentUrlEntity> entityPair, ContentDataEntity contentDataEntity)
+    {
+        // Decode content URL
+        Long contentUrlId = contentDataEntity.getContentUrlId();
+        String contentUrl = null;
+
+        if (entityPair == null)
+        {
+            throw new DataIntegrityViolationException("No ContentUrl value exists for ID " + contentUrlId);
+        }
+        ContentUrlEntity contentUrlEntity = entityPair.getSecond();
+        contentUrl = contentUrlEntity.getContentUrl();
 
         long size = contentDataEntity.getSize() == null ? 0L : contentDataEntity.getSize().longValue();
 
@@ -658,6 +784,13 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
      */
     protected abstract ContentUrlEntity getContentUrlEntity(Long id);
 
+    /**
+     * @param ids
+     *            the IDs of the <b>content urls</b> entities
+     * @return Return a list of entities or an empty list if there are none
+     */
+    protected abstract List<ContentUrlEntity> getContentUrlEntities(List<Long> ids);
+
     protected abstract ContentUrlEntity getContentUrlEntity(String contentUrl);
 
     /**
@@ -702,6 +835,20 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
      * @return Returns the associated entities or <tt>null</tt> if none exist
      */
     protected abstract List<ContentDataEntity> getContentDataEntitiesForNodes(Set<Long> nodeIds);
+
+    /**
+     * @param contentData
+     *            the content data
+     * @return Returns the entity or <tt>null</tt> if it doesn't exist
+     */
+    protected abstract ContentDataEntity getContentDataEntity(ContentData contentData);
+
+    /**
+     * @param contentDataList
+     *            the list of content data
+     * @return Returns the list of entities or <tt>null</tt> if none exist
+     */
+    protected abstract List<ContentDataEntity> getContentDataEntities(List<ContentData> contentDataList);
 
     /**
      * Update an existing <b>alf_content_data</b> entity

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
@@ -361,6 +361,12 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
         }
 
         @Override
+        public List<Pair<Long, ContentData>> findByValues(List<ContentData> values)
+        {
+            throw new UnsupportedOperationException("Batch findByValues for ContentData is not Supported");
+        }
+
+        @Override
         public int updateValue(Long key, ContentData value)
         {
             ContentDataEntity contentDataEntity = getContentDataEntity(key);
@@ -430,6 +436,12 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
                         + entity.getContentUrlShort() + "';'" + entity.getContentUrlCrc() + "')");
             }
             return (ret != null ? new Pair<Long, ContentUrlEntity>(ret.getId(), ret) : null);
+        }
+
+        @Override
+        public List<Pair<Long, ContentUrlEntity>> findByValues(List<ContentUrlEntity> entities)
+        {
+            throw new UnsupportedOperationException("Batch findByValues for ContentUrlEntity is not Supported");
         }
 
         public Pair<Long, ContentUrlEntity> createValue(ContentUrlEntity value)

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/AbstractContentDataDAOImpl.java
@@ -337,6 +337,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             return new Pair<Long, ContentData>(key, contentData);
         }
 
+        @Override
         public List<Pair<Long, ContentData>> findByKeys(List<Long> keys)
         {
             if (keys == null || keys.isEmpty())
@@ -355,7 +356,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             for (ContentDataEntity contentDataEntity : contentDataEntities)
             {
                 ContentData contentData = makeContentData(contentDataEntity);
-                result.add(new Pair<Long, ContentData>(contentDataEntity.getId(), contentData));
+                result.add(new Pair<>(contentDataEntity.getId(), contentData));
             }
             return result;
         }
@@ -415,7 +416,7 @@ public abstract class AbstractContentDataDAOImpl implements ContentDataDAO
             List<Pair<Long, ContentUrlEntity>> result = new ArrayList<>(contentUrlEntities.size());
             for (ContentUrlEntity contentUrlEntity : contentUrlEntities)
             {
-                result.add(new Pair<Long, ContentUrlEntity>(contentUrlEntity.getId(), contentUrlEntity));
+                result.add(new Pair<>(contentUrlEntity.getId(), contentUrlEntity));
             }
             return result;
         }

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/ibatis/ContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/ibatis/ContentDataDAOImpl.java
@@ -70,7 +70,6 @@ public class ContentDataDAOImpl extends AbstractContentDataDAOImpl
     private static final String SELECT_CONTENT_DATA_BY_ID = "alfresco.content.select_ContentDataById";
     private static final String SELECT_CONTENT_DATA_BY_NODE_AND_QNAME = "alfresco.content.select_ContentDataByNodeAndQName";
     private static final String SELECT_CONTENT_DATA_BY_NODE_IDS = "alfresco.content.select_ContentDataByNodeIds";
-    private static final String SELECT_CONTENT_DATA_BY_CONTENT_DATA = "alfresco.content.select_ContentDataByContentData";
     private static final String INSERT_CONTENT_URL = "alfresco.content.insert.insert_ContentUrl";
     private static final String INSERT_CONTENT_DATA = "alfresco.content.insert.insert_ContentData";
     private static final String UPDATE_CONTENT_URL_ORPHAN_TIME = "alfresco.content.update_ContentUrlOrphanTime";
@@ -281,30 +280,6 @@ public class ContentDataDAOImpl extends AbstractContentDataDAOImpl
         IdsEntity idsEntity = new IdsEntity();
         idsEntity.setIds(new ArrayList<Long>(nodeIds));
         return template.selectList(SELECT_CONTENT_DATA_BY_NODE_IDS, idsEntity);
-    }
-
-    @Override
-    protected ContentDataEntity getContentDataEntity(ContentData contentData)
-    {
-        if (contentData == null)
-        {
-            return null;
-        }
-
-        return template.selectOne(SELECT_CONTENT_DATA_BY_CONTENT_DATA, contentData);
-        // Done
-    }
-
-    @Override
-    protected List<ContentDataEntity> getContentDataEntities(List<ContentData> contentDataList)
-    {
-        if (contentDataList != null && !contentDataList.isEmpty())
-        {
-            return template.selectList(SELECT_CONTENT_DATA_BY_CONTENT_DATA, contentDataList);
-        }
-
-        // There will be no results
-        return Collections.emptyList();
     }
 
     @Override

--- a/repository/src/main/java/org/alfresco/repo/domain/contentdata/ibatis/ContentDataDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/contentdata/ibatis/ContentDataDAOImpl.java
@@ -62,6 +62,7 @@ import org.alfresco.util.ParameterCheck;
 public class ContentDataDAOImpl extends AbstractContentDataDAOImpl
 {
     private static final String SELECT_CONTENT_URL_BY_ID = "alfresco.content.select_ContentUrlById";
+    private static final String SELECT_CONTENT_URLS_BY_IDS = "alfresco.content.select_ContentUrlsByIds";
     private static final String SELECT_CONTENT_URL_BY_KEY = "alfresco.content.select_ContentUrlByKey";
     private static final String SELECT_CONTENT_URL_BY_KEY_UNREFERENCED = "alfresco.content.select_ContentUrlByKeyUnreferenced";
     private static final String SELECT_CONTENT_URLS_ORPHANED = "alfresco.content.select.select_ContentUrlsOrphaned";
@@ -69,6 +70,7 @@ public class ContentDataDAOImpl extends AbstractContentDataDAOImpl
     private static final String SELECT_CONTENT_DATA_BY_ID = "alfresco.content.select_ContentDataById";
     private static final String SELECT_CONTENT_DATA_BY_NODE_AND_QNAME = "alfresco.content.select_ContentDataByNodeAndQName";
     private static final String SELECT_CONTENT_DATA_BY_NODE_IDS = "alfresco.content.select_ContentDataByNodeIds";
+    private static final String SELECT_CONTENT_DATA_BY_CONTENT_DATA = "alfresco.content.select_ContentDataByContentData";
     private static final String INSERT_CONTENT_URL = "alfresco.content.insert.insert_ContentUrl";
     private static final String INSERT_CONTENT_DATA = "alfresco.content.insert.insert_ContentData";
     private static final String UPDATE_CONTENT_URL_ORPHAN_TIME = "alfresco.content.update_ContentUrlOrphanTime";
@@ -130,6 +132,18 @@ public class ContentDataDAOImpl extends AbstractContentDataDAOImpl
         contentUrlEntity = (ContentUrlEntity) template.selectOne(SELECT_CONTENT_URL_BY_ID, contentUrlEntity);
         // Done
         return contentUrlEntity;
+    }
+
+    @Override
+    protected List<ContentUrlEntity> getContentUrlEntities(List<Long> ids)
+    {
+        if (ids == null || ids.isEmpty())
+        {
+            return Collections.emptyList();
+        }
+        List<ContentUrlEntity> contentUrlEntities = template.selectList(SELECT_CONTENT_URLS_BY_IDS, ids);
+        // Done
+        return contentUrlEntities;
     }
 
     @Override
@@ -267,6 +281,30 @@ public class ContentDataDAOImpl extends AbstractContentDataDAOImpl
         IdsEntity idsEntity = new IdsEntity();
         idsEntity.setIds(new ArrayList<Long>(nodeIds));
         return template.selectList(SELECT_CONTENT_DATA_BY_NODE_IDS, idsEntity);
+    }
+
+    @Override
+    protected ContentDataEntity getContentDataEntity(ContentData contentData)
+    {
+        if (contentData == null)
+        {
+            return null;
+        }
+
+        return template.selectOne(SELECT_CONTENT_DATA_BY_CONTENT_DATA, contentData);
+        // Done
+    }
+
+    @Override
+    protected List<ContentDataEntity> getContentDataEntities(List<ContentData> contentDataList)
+    {
+        if (contentDataList != null && !contentDataList.isEmpty())
+        {
+            return template.selectList(SELECT_CONTENT_DATA_BY_CONTENT_DATA, contentDataList);
+        }
+
+        // There will be no results
+        return Collections.emptyList();
     }
 
     @Override

--- a/repository/src/main/java/org/alfresco/repo/domain/encoding/AbstractEncodingDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/encoding/AbstractEncodingDAOImpl.java
@@ -25,6 +25,8 @@
  */
 package org.alfresco.repo.domain.encoding;
 
+import java.util.List;
+
 import org.springframework.extensions.surf.util.ParameterCheck;
 
 import org.alfresco.repo.cache.SimpleCache;
@@ -107,6 +109,12 @@ public abstract class AbstractEncodingDAOImpl implements EncodingDAO
             {
                 return new Pair<Long, String>(id, entity.getEncoding().toUpperCase());
             }
+        }
+
+        @Override
+        public List<Pair<Long, String>> findByKeys(List<Long> ids)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for encodings.");
         }
 
         @Override

--- a/repository/src/main/java/org/alfresco/repo/domain/encoding/AbstractEncodingDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/encoding/AbstractEncodingDAOImpl.java
@@ -131,6 +131,12 @@ public abstract class AbstractEncodingDAOImpl implements EncodingDAO
             }
         }
 
+        @Override
+        public List<Pair<Long, String>> findByValues(List<String> encodings)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for encodings.");
+        }
+
         public Pair<Long, String> createValue(String encoding)
         {
             EncodingEntity entity = createEncodingEntity(encoding);

--- a/repository/src/main/java/org/alfresco/repo/domain/locale/AbstractLocaleDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/locale/AbstractLocaleDAOImpl.java
@@ -260,6 +260,12 @@ public abstract class AbstractLocaleDAOImpl implements LocaleDAO
             }
         }
 
+        @Override
+        public List<Pair<Long, String>> findByValues(List<String> localeStrs)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for locales.");
+        }
+
         public Pair<Long, String> createValue(String localeStr)
         {
             LocaleEntity entity = createLocaleEntity(localeStr);

--- a/repository/src/main/java/org/alfresco/repo/domain/locale/AbstractLocaleDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/locale/AbstractLocaleDAOImpl.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.domain.locale;
 
+import java.util.List;
 import java.util.Locale;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -237,6 +238,12 @@ public abstract class AbstractLocaleDAOImpl implements LocaleDAO
             {
                 return new Pair<Long, String>(id, entity.getLocaleStr());
             }
+        }
+
+        @Override
+        public List<Pair<Long, String>> findByKeys(List<Long> ids)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for locales.");
         }
 
         @Override

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -4955,7 +4955,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
 
         // First ensure all content data are pre-cached, so we don't have to load them individually when converting properties
-        if (preloadContentData &&!propertiesNodeIds.isEmpty())
+        if (preloadContentData && !propertiesNodeIds.isEmpty())
         {
             contentDataDAO.cacheContentDataForNodes(propertiesNodeIds);
         }

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -421,6 +421,17 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
     public void setBatchSize(int batchSize)
     {
         this.batchSize = batchSize;
+
+        if (batchSize < 1)
+        {
+            this.batchSize = 1;
+            logger.info("Batch size can not be set to a value less than 1.  The size is now set to 1.");
+        }
+        else if (batchSize >= 1000)
+        {
+            logger.info("Batch size is set to 1000 or greater.  Oracle databases have a hard limit of 1000 values allowed in an IN clause."
+                    + "The other supported databases have no specified limit.");
+        }
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -4955,7 +4955,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
 
         // First ensure all content data are pre-cached, so we don't have to load them individually when converting properties
-        if (preloadContentData && !propertiesNodeIds.isEmpty())
+        if (preloadContentData &&!propertiesNodeIds.isEmpty())
         {
             contentDataDAO.cacheContentDataForNodes(propertiesNodeIds);
         }
@@ -4968,7 +4968,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             Map<NodePropertyKey, NodePropertyValue> propertyValues = entry.getValue();
             Map<QName, Serializable> props = nodePropertyHelper.convertToPublicProperties(propertyValues);
             setNodePropertiesCached(nodeId, props);
-        } // Rework the above .... it is not the best approach .... post processing approach is better
+        }
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -143,7 +143,6 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
     private int cachingThreshold = 10;
     private int batchSize = 256;
     private boolean forceBatching = false;
-    private boolean preloadContentData = true;
 
     /**
      * Cache for the Store root nodes by StoreRef:<br/>
@@ -432,16 +431,6 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
     public void setForceBatching(boolean forceBatching)
     {
         this.forceBatching = forceBatching;
-    }
-
-    /**
-     * Set whether to preload content data for properties when bulk loading properties
-     * 
-     * @param preloadContentData
-     */
-    public void setPreloadContentData(boolean preloadContentData)
-    {
-        this.preloadContentData = preloadContentData;
     }
 
     /* Initialize */
@@ -4955,7 +4944,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
 
         // First ensure all content data are pre-cached, so we don't have to load them individually when converting properties
-        if (preloadContentData && !propertiesNodeIds.isEmpty())
+        if (!propertiesNodeIds.isEmpty())
         {
             contentDataDAO.cacheContentDataForNodes(propertiesNodeIds);
         }

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -5183,13 +5183,13 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
         int foundCacheEntryCount = 0;
         int missingCacheEntryCount = 0;
-        boolean forceBatch = false;
+
 
         // Group the nodes by store so that we don't *have* to eagerly join to store to get query performance
         Map<StoreRef, List<String>> uuidsByStore = new HashMap<StoreRef, List<String>>(3);
         for (NodeRef nodeRef : nodeRefs)
         {
-            if (!forceBatch)
+            if (!forceBatching)
             {
                 // Is this node in the cache?
                 if (nodesCache.getKey(nodeRef) != null)
@@ -5204,7 +5204,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
                 if (foundCacheEntryCount + missingCacheEntryCount % 100 == 0)
                 {
                     // We force the batch if the number of hits drops below the number of misses
-                    forceBatch = foundCacheEntryCount < missingCacheEntryCount;
+                    forceBatching = foundCacheEntryCount < missingCacheEntryCount;
                 }
             }
 

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -1083,30 +1083,6 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
     }
 
-    // @Override
-    // public List<Status> getNodeRefStatus(List<NodeRef> nodeRef)
-    // {
-    // List<Pair<Long, Node>> nodePairs = nodesCache.getByValues(
-    // nodeRef.stream()
-    // .map(NodeEntity::new)
-    // .collect(Collectors.toList())
-    // );
-
-    // if (nodePairs == null || nodePairs.size() == 0)
-    // {
-    // return Collections.emptyList();
-    // }
-
-    // //The nodesCache gets both live and deleted nodes, but nulls should not be returned from getByValues
-    // List<Status> results = new ArrayList<>();
-    // for (Pair<Long, Node> pair : nodePairs) {
-    // if (pair != null) {
-    // results.add(pair.getSecond().getNodeStatus(qnameDAO));
-    // }
-    // }
-    // return results;
-    // }
-
     @Override
     public Status getNodeIdStatus(Long nodeId)
     {

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -5184,7 +5184,6 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         int foundCacheEntryCount = 0;
         int missingCacheEntryCount = 0;
 
-
         // Group the nodes by store so that we don't *have* to eagerly join to store to get query performance
         Map<StoreRef, List<String>> uuidsByStore = new HashMap<StoreRef, List<String>>(3);
         for (NodeRef nodeRef : nodeRefs)

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -3365,7 +3365,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
      */
     private void setNodeAspectsCached(Map<Long, Set<QName>> nodeAspects)
     {
-        List<Long> nodeIds = nodeAspects.keySet().stream().toList();
+        List<Long> nodeIds = nodeAspects.keySet().stream().collect(Collectors.toList());
 
         List<NodeVersionKey> nodeVersionKeys = getNodesNotNull(nodeIds, false).stream()
                 .map(Node::getNodeVersionKey)

--- a/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/AbstractNodeDAOImpl.java
@@ -125,7 +125,6 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
     protected Log logger = LogFactory.getLog(getClass());
     private Log loggerPaths = LogFactory.getLog(getClass().getName() + ".paths");
 
-    protected final boolean isDebugEnabled = logger.isDebugEnabled();
     private NodePropertyHelper nodePropertyHelper;
     private UpdateTransactionListener updateTransactionListener = new UpdateTransactionListener();
     private RetryingCallbackHelper childAssocRetryingHelper;
@@ -618,7 +617,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         String changeTxnId = AlfrescoTransactionSupport.getTransactionId();
         Long txnId = insertTransaction(changeTxnId, now);
         // Store it for later
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Create txn: " + txnId);
         }
@@ -794,7 +793,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         // Push the value into the caches
         rootNodesCache.setValue(storeRef, rootNode);
 
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Created store: \n" + "   " + store);
         }
@@ -823,7 +822,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         allRootNodesCache.remove(oldStoreRef);
         nodesCache.clear();
 
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Moved store: " + oldStoreRef + " --> " + newStoreRef);
         }
@@ -1036,7 +1035,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             nodeRefsToCheck.add(new NodeEntity(nodeRef));
         }
 
-        List<NodeRef> existingNodeRefs = new ArrayList<NodeRef>(nodeRefs.size());
+        List<NodeRef> existingNodeRefs = new ArrayList<>(nodeRefs.size());
 
         List<Pair<Long, Node>> nodes = nodesCache.getByValues(nodeRefsToCheck);
 
@@ -1127,7 +1126,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             else
             {
                 // The cache was wrong, possibly due to it caching negative results earlier.
-                if (isDebugEnabled)
+                if (logger.isDebugEnabled())
                 {
                     logger.debug("Repairing stale cache entry for node: " + nodeRef);
                 }
@@ -1206,7 +1205,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
                 else
                 {
                     // The cache was wrong, possibly due to it caching negative results earlier.
-                    if (isDebugEnabled)
+                    if (logger.isDebugEnabled())
                     {
                         logger.debug("Repairing stale cache entry for node: " + nodeId);
                     }
@@ -1308,7 +1307,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             else
             {
                 // The cache was wrong, possibly due to it caching negative results earlier.
-                if (isDebugEnabled)
+                if (logger.isDebugEnabled())
                 {
                     logger.debug("Repairing stale cache entry for node: " + nodeId);
                 }
@@ -1364,7 +1363,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
                 else
                 {
                     // The cache was wrong, possibly due to it caching negative results earlier.
-                    if (isDebugEnabled)
+                    if (logger.isDebugEnabled())
                     {
                         logger.debug("Repairing stale cache entry for node: " + nodeId);
                     }
@@ -1441,7 +1440,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             // The nodes have no entry in the database
             List<NodeEntity> dbNodes = selectNodesByIds(nodeIds);
             nodesCache.removeByKeys(nodeIds);
-            if (isDebugEnabled)
+            if (logger.isDebugEnabled())
             {
                 logger.debug(
                         "No node rows exists: \n" +
@@ -1486,7 +1485,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             {
                 pruneDanglingAssocs(nodeId);
                 // In the single node case we would force a retry on the transaction...we can't do that here so just log it
-                if (isDebugEnabled)
+                if (logger.isDebugEnabled())
                 {
                     logger.debug(
                             "No node rows exists: \n" +
@@ -1604,7 +1603,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         ParentAssocsInfo parentAssocsInfo = new ParentAssocsInfo(isRoot, isStoreRoot, assoc);
         setParentAssocsCached(nodeId, parentAssocsInfo);
 
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug(
                     "Created new node: \n" +
@@ -1708,7 +1707,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         setNodeAspectsCached(id, nodeAspects);
         setNodePropertiesCached(id, Collections.<QName, Serializable> emptyMap());
 
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Created new node: \n" + "   " + node);
         }
@@ -1870,7 +1869,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         // Done
         Pair<Long, ChildAssociationRef> assocPair = getPrimaryParentAssoc(newChildNode.getId());
         Pair<Long, NodeRef> nodePair = newChildNode.getNodePair();
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Moved node: " + assocPair + " ... " + nodePair);
         }
@@ -2274,7 +2273,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
 
         // Done
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug(
                     "Updated Node: \n" +
@@ -2432,7 +2431,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         props = new ValueProtectingMap<QName, Serializable>(props, NodePropertyValue.IMMUTABLE_CLASSES);
 
         // Done
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Fetched properties for Node: \n" +
                     "   Node:  " + nodeId + "\n" +
@@ -2477,7 +2476,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             nodeProps = new ValueProtectingMap<>(nodeProps, NodePropertyValue.IMMUTABLE_CLASSES);
 
             // Done
-            if (isDebugEnabled)
+            if (logger.isDebugEnabled())
             {
                 logger.debug("Fetched properties for Node: \n" +
                         "   Node:  " + node.getId() + "\n" +
@@ -2523,7 +2522,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             value = props.get(propertyQName);
         }
         // Done
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Fetched property for Node: \n" +
                     "   Node:  " + nodeId + "\n" +
@@ -2777,7 +2776,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
 
         // Done
-        if (isDebugEnabled && updated)
+        if (logger.isDebugEnabled() && updated)
         {
             logger.debug(
                     "Modified node properties: " + nodeId + "\n" +
@@ -3477,7 +3476,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         catch (Throwable e)
         {
             controlDAO.rollbackToSavepoint(savepoint);
-            if (isDebugEnabled)
+            if (logger.isDebugEnabled())
             {
                 logger.debug(
                         "Failed to insert node association: \n" +
@@ -3741,7 +3740,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
         }
 
         // Done
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("Created child association: " + assoc);
         }
@@ -3875,7 +3874,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             touchNode(childNodeId, null, null, false, false, true);
         }
 
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug(
                     "Updated cm:name to parent assocs: \n" +
@@ -4624,7 +4623,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
             Stack<Long> assocIdStack,
             boolean primaryOnly) throws CyclicChildRelationshipException
     {
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("\n" +
                     "Prepending paths: \n" +
@@ -4739,7 +4738,7 @@ public abstract class AbstractNodeDAOImpl implements NodeDAO, BatchingDAO
                 throw new CyclicChildRelationshipException("Node has been pasted into its own tree.", assocRef);
             }
 
-            if (isDebugEnabled)
+            if (logger.isDebugEnabled())
             {
                 logger.debug("\n" +
                         "   Prepending path parent: \n" +

--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
@@ -193,6 +193,13 @@ public interface NodeDAO extends NodeBulkLoader
 
     public Pair<Long, NodeRef> getNodePair(NodeRef nodeRef);
 
+    /**
+     * Get the node ID-reference pairs for the given node references in the given store. If no store is given, all stores are searched.
+     * 
+     * @param storeRef
+     * @param nodeRefs
+     * @return
+     */
     List<Pair<Long, NodeRef>> getNodePairs(StoreRef storeRef, List<NodeRef> nodeRefs);
 
     public Pair<Long, NodeRef> getNodePair(Long nodeId);

--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
@@ -155,7 +155,7 @@ public interface NodeDAO extends NodeBulkLoader
      *            the potentially valid node reference
      * @return Returns <tt>true</tt> if the node is present and undeleted
      */
-    public List<NodeRef> exists(List<NodeRef> nodeRefs);
+    List<NodeRef> exists(List<NodeRef> nodeRefs);
 
     /**
      * Find out if a node exists. Unpurged deleted nodes do not count as they are the DAO's concern only.
@@ -193,11 +193,11 @@ public interface NodeDAO extends NodeBulkLoader
 
     public Pair<Long, NodeRef> getNodePair(NodeRef nodeRef);
 
-    public List<Pair<Long, NodeRef>> getNodePairs(StoreRef storeRef, List<NodeRef> nodeRefs);
+    List<Pair<Long, NodeRef>> getNodePairs(StoreRef storeRef, List<NodeRef> nodeRefs);
 
     public Pair<Long, NodeRef> getNodePair(Long nodeId);
 
-    public List<Pair<Long, NodeRef>> getNodePairs(List<Long> nodeIds);
+    List<Pair<Long, NodeRef>> getNodePairs(List<Long> nodeIds);
 
     public QName getNodeType(Long nodeId);
 
@@ -380,7 +380,7 @@ public interface NodeDAO extends NodeBulkLoader
 
     public Map<QName, Serializable> getNodeProperties(Long nodeId);
 
-    public Map<Long, Map<QName, Serializable>> getNodeProperties(List<Long> nodeIds);
+    Map<Long, Map<QName, Serializable>> getNodeProperties(List<Long> nodeIds);
 
     public boolean setNodeProperties(Long nodeId, Map<QName, Serializable> properties);
 
@@ -419,7 +419,7 @@ public interface NodeDAO extends NodeBulkLoader
 
     public Set<QName> getNodeAspects(Long nodeId);
 
-    public Map<Long, Set<QName>> getNodeAspects(List<Long> nodeIds);
+    Map<Long, Set<QName>> getNodeAspects(List<Long> nodeIds);
 
     public boolean hasNodeAspect(Long nodeId, QName aspectQName);
 

--- a/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/NodeDAO.java
@@ -151,6 +151,15 @@ public interface NodeDAO extends NodeBulkLoader
     /**
      * Find out if a node exists. Unpurged deleted nodes do not count as they are the DAO's concern only.
      * 
+     * @param nodeRefs
+     *            the potentially valid node reference
+     * @return Returns <tt>true</tt> if the node is present and undeleted
+     */
+    public List<NodeRef> exists(List<NodeRef> nodeRefs);
+
+    /**
+     * Find out if a node exists. Unpurged deleted nodes do not count as they are the DAO's concern only.
+     * 
      * @param nodeId
      *            the potentially valid node ID
      * @return Returns <tt>true</tt> if the node is present and undeleted
@@ -184,7 +193,11 @@ public interface NodeDAO extends NodeBulkLoader
 
     public Pair<Long, NodeRef> getNodePair(NodeRef nodeRef);
 
+    public List<Pair<Long, NodeRef>> getNodePairs(StoreRef storeRef, List<NodeRef> nodeRefs);
+
     public Pair<Long, NodeRef> getNodePair(Long nodeId);
+
+    public List<Pair<Long, NodeRef>> getNodePairs(List<Long> nodeIds);
 
     public QName getNodeType(Long nodeId);
 
@@ -367,6 +380,8 @@ public interface NodeDAO extends NodeBulkLoader
 
     public Map<QName, Serializable> getNodeProperties(Long nodeId);
 
+    public Map<Long, Map<QName, Serializable>> getNodeProperties(List<Long> nodeIds);
+
     public boolean setNodeProperties(Long nodeId, Map<QName, Serializable> properties);
 
     public boolean addNodeProperty(Long nodeId, QName qname, Serializable value);
@@ -403,6 +418,8 @@ public interface NodeDAO extends NodeBulkLoader
     /* Aspects */
 
     public Set<QName> getNodeAspects(Long nodeId);
+
+    public Map<Long, Set<QName>> getNodeAspects(List<Long> nodeIds);
 
     public boolean hasNodeAspect(Long nodeId, QName aspectQName);
 

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeBatchLoadEntity.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeBatchLoadEntity.java
@@ -36,6 +36,7 @@ import java.util.List;
 public class NodeBatchLoadEntity
 {
     private Long storeId;
+    private List<Long> storeIds;
     private List<String> uuids;
     private List<Long> ids;
 
@@ -47,6 +48,16 @@ public class NodeBatchLoadEntity
     public void setStoreId(Long storeId)
     {
         this.storeId = storeId;
+    }
+
+    public List<Long> getStoreIds()
+    {
+        return storeIds;
+    }
+
+    public void setStoreIds(List<Long> storeIds)
+    {
+        this.storeIds = storeIds;
     }
 
     public List<String> getUuids()

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -420,6 +420,19 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
     }
 
     @Override
+    protected List<NodeEntity> selectNodesByIds(List<Long> ids)
+    {
+        List<NodeEntity> nodes = new ArrayList<>();
+        ids.forEach(id -> {
+            NodeEntity node = new NodeEntity();
+            node.setId(id);
+            nodes.add(node);
+        });
+
+        return template.selectList(SELECT_NODES_BY_IDS, nodes);
+    }
+
+    @Override
     protected NodeEntity selectNodeByNodeRef(NodeRef nodeRef)
     {
         StoreEntity store = new StoreEntity();

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
 
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.result.DefaultResultContext;
@@ -462,6 +463,18 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         NodeBatchLoadEntity nodeBatchLoadEntity = new NodeBatchLoadEntity();
         // Store ID
         nodeBatchLoadEntity.setStoreId(storeId);
+        // UUID
+        nodeBatchLoadEntity.setUuids(new ArrayList<String>(uuids));
+
+        return template.selectList(SELECT_NODES_BY_UUIDS, nodeBatchLoadEntity);
+    }
+
+    @Override
+    protected List<Node> selectNodesByUuids(SortedSet<String> uuids)
+    {
+        NodeBatchLoadEntity nodeBatchLoadEntity = new NodeBatchLoadEntity();
+        // Store IDs
+        nodeBatchLoadEntity.setStoreIds(getStores().stream().map(Pair::getFirst).collect(Collectors.toList()));
         // UUID
         nodeBatchLoadEntity.setUuids(new ArrayList<String>(uuids));
 

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -143,6 +143,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
     private static final String SELECT_ASSOCS_NOT_LINKED_BY_TWO_OTHER_ASSOCS = "alfresco.node.select_AssocsNotLinkedByTwoOtherAssocs";
     private static final String SELECT_CHILD_ASSOCS_OF_PARENT_WITHOUT_NODE_ASSOCS_OF_TYPE = "alfresco.node.select_ChildAssocsOfParentWithoutNodeAssocsOfType";
     private static final String SELECT_PARENT_ASSOCS_OF_CHILD = "alfresco.node.select_ParentAssocsOfChild";
+    private static final String SELECT_PARENT_ASSOCS_OF_CHILDREN = "alfresco.node.select_ParentAssocsOfChildren";
     private static final String UPDATE_PARENT_ASSOCS_OF_CHILD = "alfresco.node.update_ParentAssocsOfChild";
     private static final String DELETE_SUBSCRIPTIONS = "alfresco.node.delete_NodeSubscriptions";
 
@@ -1538,6 +1539,19 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         assoc.setChildNode(childNode);
 
         return template.selectList(SELECT_PARENT_ASSOCS_OF_CHILD, assoc);
+    }
+
+    @Override
+    protected List<ChildAssocEntity> selectParentAssocsOfChildren(Set<Long> childrenNodeIds)
+    {
+        if (childrenNodeIds.size() == 0)
+        {
+            // There will be no results
+            return Collections.emptyList();
+        }
+        IdsEntity idsEntity = new IdsEntity();
+        idsEntity.setIds(new ArrayList<Long>(childrenNodeIds));
+        return template.selectList(SELECT_PARENT_ASSOCS_OF_CHILDREN, idsEntity);
     }
 
     @Override

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -1602,7 +1602,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         int countTA = template.update(UPDATE_MOVE_TARGET_ASSOCS, params);
         int countP = template.update(UPDATE_MOVE_PROPERTIES, params);
         int countA = template.update(UPDATE_MOVE_ASPECTS, params);
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug(
                     "Moved node data: \n" +
@@ -1877,7 +1877,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         Iterator<Long> nodeIdIterator = this.selectDeletedNodesByCommitTime(maxCommitTime);
         ArrayList<Long> nodeIdList = new ArrayList<>();
         List<String> deleteResult = new ArrayList<>();
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("nodes selected for deletion, deleteBatchSize:" + deleteBatchSize);
         }
@@ -1886,7 +1886,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
             if (deleteBatchSize == nodeIdList.size())
             {
                 int count = deleteSelectedNodesAndProperties(nodeIdList);
-                if (isDebugEnabled)
+                if (logger.isDebugEnabled())
                 {
                     logger.debug("nodes deleted:" + count);
                 }
@@ -1901,7 +1901,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         if (nodeIdList.size() > 0)
         {
             int count = deleteSelectedNodesAndProperties(nodeIdList);
-            if (isDebugEnabled)
+            if (logger.isDebugEnabled())
             {
                 logger.debug("remaining nodes deleted:" + count);
             }
@@ -1917,7 +1917,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         Iterator<Long> transactionIdIterator = this.selectUnusedTransactionsByCommitTime(maxCommitTime);
         ArrayList<Long> transactionIdList = new ArrayList<>();
         List<String> deleteResult = new ArrayList<>();
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("transactions selected for deletion, deleteBatchSize:" + deleteBatchSize);
         }
@@ -1927,7 +1927,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
             {
                 int count = deleteSelectedTransactions(transactionIdList);
                 deleteResult.add("Purged old transactions: " + count);
-                if (isDebugEnabled)
+                if (logger.isDebugEnabled())
                 {
                     logger.debug("transactions deleted:" + count);
                 }
@@ -1943,7 +1943,7 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
         {
             int count = deleteSelectedTransactions(transactionIdList);
             deleteResult.add("Purged old transactions: " + count);
-            if (isDebugEnabled)
+            if (logger.isDebugEnabled())
             {
                 logger.debug("final batch of transactions deleted:" + count);
             }
@@ -1955,13 +1955,13 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
     private int deleteSelectedNodesAndProperties(List<Long> nodeIdList)
     {
         int cnt = template.delete(DELETE_NODE_PROPS_BY_NODE_ID, nodeIdList);
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("nodes props deleted:" + cnt);
         }
         // Finally, remove the nodes
         cnt = template.delete(DELETE_NODES_BY_ID, nodeIdList);
-        if (isDebugEnabled)
+        if (logger.isDebugEnabled())
         {
             logger.debug("nodes  deleted:" + cnt);
         }

--- a/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/node/ibatis/NodeDAOImpl.java
@@ -1544,13 +1544,13 @@ public class NodeDAOImpl extends AbstractNodeDAOImpl
     @Override
     protected List<ChildAssocEntity> selectParentAssocsOfChildren(Set<Long> childrenNodeIds)
     {
-        if (childrenNodeIds.size() == 0)
+        if (childrenNodeIds.isEmpty())
         {
             // There will be no results
             return Collections.emptyList();
         }
         IdsEntity idsEntity = new IdsEntity();
-        idsEntity.setIds(new ArrayList<Long>(childrenNodeIds));
+        idsEntity.setIds(new ArrayList<>(childrenNodeIds));
         return template.selectList(SELECT_PARENT_ASSOCS_OF_CHILDREN, idsEntity);
     }
 

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AbstractAclCrudDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AbstractAclCrudDAOImpl.java
@@ -343,6 +343,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
             return null;
         }
 
+        @Override
+        public List<Pair<Long, AclEntity>> findByValues(List<AclEntity> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for ACLs.");
+        }
+
         public int updateValue(Long key, AclEntity value)
         {
             return updateAclEntity(value);
@@ -861,6 +867,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
             return convertEntityToPair(getPermissionEntity(value.getTypeQNameId(), value.getName()));
         }
 
+        @Override
+        public List<Pair<Long, PermissionEntity>> findByValues(List<PermissionEntity> values)
+        {
+            throw new UnsupportedOperationException("Batch loading not supported for PermissionEntity");
+        }
+
         public int updateValue(Long key, PermissionEntity value)
         {
             return updatePermissionEntity(value);
@@ -1054,6 +1066,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
                 throw new AlfrescoRuntimeException("Unexpected: AuthorityEntity / name must not be null");
             }
             return convertEntityToPair(getAuthorityEntity(value.getAuthority()));
+        }
+
+        @Override
+        public List<Pair<Long, AuthorityEntity>> findByValues(List<AuthorityEntity> values)
+        {
+            throw new UnsupportedOperationException("Batch loading not supported for AuthorityEntity");
         }
 
         public int updateValue(Long key, AuthorityEntity value)

--- a/repository/src/main/java/org/alfresco/repo/domain/permissions/AbstractAclCrudDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/permissions/AbstractAclCrudDAOImpl.java
@@ -310,6 +310,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
             return null;
         }
 
+        @Override
+        public List<Serializable> getValueKeys(List<AclEntity> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for ACLs.");
+        }
+
         public Pair<Long, AclEntity> createValue(AclEntity value)
         {
             AclEntity entity = createAclEntity(value);
@@ -320,6 +326,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
         {
             AclEntity entity = getAclEntity(key);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<Long, AclEntity>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for ACLs.");
         }
 
         public Pair<Long, AclEntity> findByValue(AclEntity value)
@@ -816,6 +828,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
             return value;
         }
 
+        @Override
+        public List<PermissionEntity> getValueKeys(List<PermissionEntity> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for permissions.");
+        }
+
         public Pair<Long, PermissionEntity> createValue(PermissionEntity value)
         {
             PermissionEntity entity = createPermissionEntity(value);
@@ -826,6 +844,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
         {
             PermissionEntity entity = getPermissionEntity(key);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<Long, PermissionEntity>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for permissions.");
         }
 
         public Pair<Long, PermissionEntity> findByValue(PermissionEntity value)
@@ -999,6 +1023,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
             return value.getAuthority();
         }
 
+        @Override
+        public List<String> getValueKeys(List<AuthorityEntity> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for authorities.");
+        }
+
         public Pair<Long, AuthorityEntity> createValue(AuthorityEntity value)
         {
             AuthorityEntity entity = createAuthorityEntity(value);
@@ -1009,6 +1039,12 @@ public abstract class AbstractAclCrudDAOImpl implements AclCrudDAO
         {
             AuthorityEntity entity = getAuthorityEntity(key);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<Long, AuthorityEntity>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for authorities.");
         }
 
         public Pair<Long, AuthorityEntity> findByValue(AuthorityEntity value)

--- a/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
@@ -373,6 +373,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             return convertEntityToPair(entity);
         }
 
+        @Override
+        public List<Pair<Long, Class<?>>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property classes.");
+        }
+
         public Pair<Long, Class<?>> findByValue(Class<?> value)
         {
             PropertyClassEntity entity = findClassByValue(value);
@@ -463,6 +469,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
         {
             PropertyDateValueEntity entity = findDateValueById(key);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<Long, Date>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property date values.");
         }
 
         public Pair<Long, Date> findByValue(Date value)
@@ -566,6 +578,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             }
         }
 
+        @Override
+        public List<Pair<Long, String>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property string values.");
+        }
+
         public Pair<Long, String> findByValue(String value)
         {
             Long key = findStringValueByValue(value);
@@ -658,6 +676,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             return convertEntityToPair(entity);
         }
 
+        @Override
+        public List<Pair<Long, Double>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property double values.");
+        }
+
         public Pair<Long, Double> findByValue(Double value)
         {
             PropertyDoubleValueEntity entity = findDoubleValueByValue(value);
@@ -726,6 +750,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
         {
             PropertySerializableValueEntity entity = findSerializableValueById(key);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<Long, Serializable>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property serializable values.");
         }
     }
 
@@ -833,6 +863,11 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             return convertEntityToPair(entity);
         }
 
+        public List<Pair<Long, Serializable>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property values.");
+        }
+
         public Pair<Long, Serializable> findByValue(Serializable value)
         {
             PropertyValueEntity entity = findPropertyValueByValue(value);
@@ -935,6 +970,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             }
             Serializable value = convertPropertyIdSearchRows(rows);
             return new Pair<Long, Serializable>(key, value);
+        }
+
+        @Override
+        public List<Pair<Long, Serializable>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for properties.");
         }
 
         /**

--- a/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
@@ -893,6 +893,7 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             return convertEntityToPair(entity);
         }
 
+        @Override
         public List<Pair<Long, Serializable>> findByKeys(List<Long> keys)
         {
             throw new UnsupportedOperationException("Batch lookup not supported for property values.");

--- a/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/propval/AbstractPropertyValueDAOImpl.java
@@ -384,6 +384,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             PropertyClassEntity entity = findClassByValue(value);
             return convertEntityToPair(entity);
         }
+
+        @Override
+        public List<Pair<Long, Class<?>>> findByValues(List<Class<?>> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property classes.");
+        }
     }
 
     protected abstract PropertyClassEntity findClassById(Long id);
@@ -481,6 +487,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
         {
             PropertyDateValueEntity entity = findDateValueByValue(value);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<Long, Date>> findByValues(List<Date> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property date values.");
         }
     }
 
@@ -596,6 +608,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
                 return new Pair<Long, String>(key, value);
             }
         }
+
+        @Override
+        public List<Pair<Long, String>> findByValues(List<String> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property string values.");
+        }
     }
 
     protected abstract String findStringValueById(Long id);
@@ -687,6 +705,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             PropertyDoubleValueEntity entity = findDoubleValueByValue(value);
             return convertEntityToPair(entity);
         }
+
+        @Override
+        public List<Pair<Long, Double>> findByValues(List<Double> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property double values.");
+        }
     }
 
     protected abstract PropertyDoubleValueEntity findDoubleValueById(Long id);
@@ -754,6 +778,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
 
         @Override
         public List<Pair<Long, Serializable>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property serializable values.");
+        }
+
+        @Override
+        public List<Pair<Long, Serializable>> findByValues(List<Serializable> values)
         {
             throw new UnsupportedOperationException("Batch lookup not supported for property serializable values.");
         }
@@ -874,6 +904,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
             return convertEntityToPair(entity);
         }
 
+        @Override
+        public List<Pair<Long, Serializable>> findByValues(List<Serializable> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for property values.");
+        }
+
         /**
          * No-op. This is implemented as we just want to update the cache.
          * 
@@ -976,6 +1012,12 @@ public abstract class AbstractPropertyValueDAOImpl implements PropertyValueDAO
         public List<Pair<Long, Serializable>> findByKeys(List<Long> keys)
         {
             throw new UnsupportedOperationException("Batch lookup not supported for properties.");
+        }
+
+        @Override
+        public List<Pair<Long, Serializable>> findByValues(List<Serializable> values)
+        {
+            throw new UnsupportedOperationException("Lookup by value not supported for properties.");
         }
 
         /**

--- a/repository/src/main/java/org/alfresco/repo/domain/qname/AbstractQNameDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/qname/AbstractQNameDAOImpl.java
@@ -212,6 +212,12 @@ public abstract class AbstractQNameDAOImpl implements QNameDAO
             }
         }
 
+        @Override
+        public List<Pair<Long, String>> findByValues(List<String> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for namespaces.");
+        }
+
         public Pair<Long, String> createValue(String uri)
         {
             NamespaceEntity entity = createNamespaceEntity(uri);
@@ -385,6 +391,12 @@ public abstract class AbstractQNameDAOImpl implements QNameDAO
             {
                 return new Pair<Long, QName>(entity.getId(), qname);
             }
+        }
+
+        @Override
+        public List<Pair<Long, QName>> findByValues(List<QName> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for QNames.");
         }
 
         public Pair<Long, QName> createValue(QName qname)

--- a/repository/src/main/java/org/alfresco/repo/domain/qname/AbstractQNameDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/qname/AbstractQNameDAOImpl.java
@@ -27,6 +27,7 @@ package org.alfresco.repo.domain.qname;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -192,6 +193,12 @@ public abstract class AbstractQNameDAOImpl implements QNameDAO
         }
 
         @Override
+        public List<Pair<Long, String>> findByKeys(List<Long> ids)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for namespaces.");
+        }
+
+        @Override
         public Pair<Long, String> findByValue(String uri)
         {
             NamespaceEntity entity = findNamespaceEntityByUri(uri);
@@ -349,6 +356,12 @@ public abstract class AbstractQNameDAOImpl implements QNameDAO
                 QName qname = QName.createQName(uri, localName);
                 return new Pair<Long, QName>(id, qname);
             }
+        }
+
+        @Override
+        public List<Pair<Long, QName>> findByKeys(List<Long> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for QNames.");
         }
 
         @Override

--- a/repository/src/main/java/org/alfresco/repo/domain/tenant/AbstractTenantAdminDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/tenant/AbstractTenantAdminDAOImpl.java
@@ -247,6 +247,12 @@ public abstract class AbstractTenantAdminDAOImpl implements TenantAdminDAO
         }
 
         @Override
+        public List<Pair<String, TenantEntity>> findByValues(List<TenantEntity> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for tenants.");
+        }
+
+        @Override
         public int updateValue(String tenantDomain, TenantEntity value)
         {
             return updateTenantEntity(value);

--- a/repository/src/main/java/org/alfresco/repo/domain/tenant/AbstractTenantAdminDAOImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/domain/tenant/AbstractTenantAdminDAOImpl.java
@@ -211,6 +211,12 @@ public abstract class AbstractTenantAdminDAOImpl implements TenantAdminDAO
         }
 
         @Override
+        public List<Serializable> getValueKeys(List<TenantEntity> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for tenants.");
+        }
+
+        @Override
         public Pair<String, TenantEntity> createValue(TenantEntity value)
         {
             TenantEntity entity = createTenantEntity(value);
@@ -222,6 +228,12 @@ public abstract class AbstractTenantAdminDAOImpl implements TenantAdminDAO
         {
             TenantEntity entity = getTenantEntity(key);
             return convertEntityToPair(entity);
+        }
+
+        @Override
+        public List<Pair<String, TenantEntity>> findByKeys(List<String> keys)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for tenants.");
         }
 
         @Override

--- a/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
@@ -206,7 +206,8 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
     {
         ParameterCheck.mandatory("nodeRefs", nodeRefs);
 
-        List<Pair<Long, NodeRef>> unchecked = nodeDAO.getNodePairs(nodeRefs.get(0).getStoreRef(), nodeRefs);
+        // Force lookup across all stores to avoid accidentally missing nodes from different stores because the first node is not in the same store as all the others.
+        List<Pair<Long, NodeRef>> unchecked = nodeDAO.getNodePairs(null, nodeRefs);
         if (unchecked.isEmpty())
         {
             throw new InvalidNodeRefException("Nodes do not exist: " + nodeRefs, null);
@@ -1673,9 +1674,8 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
             return Collections.emptyMap();
         }
 
-        StoreRef storeRef = nodeRefs.get(0).getStoreRef();
-
-        List<Pair<Long, NodeRef>> nodePairs = nodeDAO.getNodePairs(storeRef, nodeRefs);
+        // Force lookup of nodes across all stores to avoid issues with mixed store lists
+        List<Pair<Long, NodeRef>> nodePairs = nodeDAO.getNodePairs(null, nodeRefs);
 
         Map<Long, Map<QName, Serializable>> propertiesMappedById = getPropertiesImpl(nodePairs);
 

--- a/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -192,6 +193,27 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
         return unchecked;
     }
 
+    /**
+     * Performs a null-safe get of a list of nodes
+     * 
+     * @param nodeRefs
+     *            the nodes to retrieve
+     * @return Returns a map of node entities (never null)
+     * @throws InvalidNodeRefException
+     *             if none of the referenced nodes could not be found
+     */
+    private List<Pair<Long, NodeRef>> getNodePairsNotNull(List<NodeRef> nodeRefs) throws InvalidNodeRefException
+    {
+        ParameterCheck.mandatory("nodeRefs", nodeRefs);
+
+        List<Pair<Long, NodeRef>> unchecked = nodeDAO.getNodePairs(nodeRefs.get(0).getStoreRef(), nodeRefs);
+        if (unchecked.isEmpty())
+        {
+            throw new InvalidNodeRefException("Nodes do not exist: " + nodeRefs, null);
+        }
+        return unchecked;
+    }
+
     @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
     public boolean exists(StoreRef storeRef)
     {
@@ -203,6 +225,14 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
     {
         ParameterCheck.mandatory("nodeRef", nodeRef);
         return nodeDAO.exists(nodeRef);
+    }
+
+    @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
+    @Override
+    public List<NodeRef> exists(List<NodeRef> nodeRefs)
+    {
+        ParameterCheck.mandatory("nodeRefs", nodeRefs);
+        return nodeDAO.exists(nodeRefs);
     }
 
     @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
@@ -219,6 +249,24 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
     {
         Pair<Long, NodeRef> nodePair = nodeDAO.getNodePair(nodeId);
         return nodePair == null ? null : nodePair.getSecond();
+    }
+
+    @Override
+    @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
+    public List<NodeRef> getNodeRefs(List<Long> nodeIds)
+    {
+        List<NodeRef> nodeRefs = new ArrayList<NodeRef>(nodeIds.size());
+
+        List<Pair<Long, NodeRef>> nodePairs = nodeDAO.getNodePairs(nodeIds);
+        for (Pair<Long, NodeRef> nodePair : nodePairs)
+        {
+            // It should not be null but just in case...
+            if (nodePair != null)
+            {
+                nodeRefs.add(nodePair.getSecond());
+            }
+        }
+        return nodeRefs;
     }
 
     /**
@@ -1031,6 +1079,44 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
         return aspectQNames;
     }
 
+    @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
+    @Override
+    public Map<NodeRef, Set<QName>> getAspects(List<NodeRef> nodeRefs) throws InvalidNodeRefException
+    {
+        List<Pair<Long, NodeRef>> nodePairs = getNodePairsNotNull(nodeRefs);
+        Map<Long, Set<QName>> aspectQNames = nodeDAO.getNodeAspects(getNodeIdsFromList(nodePairs));
+
+        for (Pair<Long, NodeRef> nodePair : nodePairs)
+        {
+            if (aspectQNames.containsKey(nodePair.getFirst()) && isPendingDelete(nodePair.getSecond()))
+            {
+                aspectQNames.computeIfPresent(nodePair.getFirst(), (k, v) -> {
+                    v.add(ContentModel.ASPECT_PENDING_DELETE);
+                    return v;
+                });
+            }
+        }
+
+        // Map back to NodeRef. Ignore nodes with no aspects.
+        Map<NodeRef, Set<QName>> results = nodePairs.stream()
+                .filter(pair -> aspectQNames.containsKey(pair.getFirst()))
+                .collect(Collectors.toMap(
+                        Pair::getSecond,
+                        pair -> aspectQNames.getOrDefault(pair.getFirst(), Collections.emptySet())));
+
+        return results;
+    }
+
+    private List<Long> getNodeIdsFromList(List<Pair<Long, NodeRef>> nodeRefPairs)
+    {
+        List<Long> nodeIds = new ArrayList<Long>(nodeRefPairs.size());
+        for (Pair<Long, NodeRef> nodePair : nodeRefPairs)
+        {
+            nodeIds.add(nodePair.getFirst());
+        }
+        return nodeIds;
+    }
+
     /**
      * @return Returns <tt>true</tt> if the node is being deleted
      * 
@@ -1548,6 +1634,60 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
         Map<QName, Serializable> nodeProperties = nodeDAO.getNodeProperties(nodeId);
         // done
         return nodeProperties;
+    }
+
+    /**
+     * Gets, converts and adds the intrinsic properties for the current list of node's properties
+     */
+    private Map<Long, Map<QName, Serializable>> getPropertiesImpl(List<Pair<Long, NodeRef>> nodePairs) throws InvalidNodeRefException
+    {
+        List<Long> nodeIds = new ArrayList<Long>(nodePairs.size());
+
+        for (Pair<Long, NodeRef> nodePair : nodePairs)
+        {
+            nodeIds.add(nodePair.getFirst());
+        }
+
+        Map<Long, Map<QName, Serializable>> nodeProperties = nodeDAO.getNodeProperties(nodeIds);
+        // done
+        return nodeProperties;
+    }
+
+    @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
+    @Override
+    public Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs) throws InvalidNodeRefException
+    {
+        if (nodeRefs == null || nodeRefs.size() == 0)
+        {
+            return Collections.emptyMap();
+        }
+
+        // make a copy so we can modify if needed
+        nodeRefs = new ArrayList<>(nodeRefs);
+
+        // check permissions per node (since we can't do this in config). Remove nodes that the user has no permission to see
+        nodeRefs.removeIf(nodeRef -> permissionService.hasPermission(nodeRef, PermissionService.READ_PROPERTIES) != AccessStatus.ALLOWED);
+        // if no nodes left, return empty map
+        if (nodeRefs.isEmpty())
+        {
+            return Collections.emptyMap();
+        }
+
+        StoreRef storeRef = nodeRefs.get(0).getStoreRef();
+
+        List<Pair<Long, NodeRef>> nodePairs = nodeDAO.getNodePairs(storeRef, nodeRefs);
+
+        Map<Long, Map<QName, Serializable>> propertiesMappedById = getPropertiesImpl(nodePairs);
+
+        Map<NodeRef, Map<QName, Serializable>> propertiesMappedByNodeRef = new HashMap<NodeRef, Map<QName, Serializable>>(nodePairs.size());
+        for (Pair<Long, NodeRef> nodePair : nodePairs)
+        {
+            Long nodeId = nodePair.getFirst();
+            NodeRef nodeRef = nodePair.getSecond();
+            propertiesMappedByNodeRef.put(nodeRef, propertiesMappedById.get(nodeId));
+        }
+
+        return propertiesMappedByNodeRef;
     }
 
     @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)

--- a/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/node/db/DbNodeServiceImpl.java
@@ -255,7 +255,7 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
     @Extend(traitAPI = NodeServiceTrait.class, extensionAPI = NodeServiceExtension.class)
     public List<NodeRef> getNodeRefs(List<Long> nodeIds)
     {
-        List<NodeRef> nodeRefs = new ArrayList<NodeRef>(nodeIds.size());
+        List<NodeRef> nodeRefs = new ArrayList<>(nodeIds.size());
 
         List<Pair<Long, NodeRef>> nodePairs = nodeDAO.getNodePairs(nodeIds);
         for (Pair<Long, NodeRef> nodePair : nodePairs)
@@ -1109,7 +1109,7 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
 
     private List<Long> getNodeIdsFromList(List<Pair<Long, NodeRef>> nodeRefPairs)
     {
-        List<Long> nodeIds = new ArrayList<Long>(nodeRefPairs.size());
+        List<Long> nodeIds = new ArrayList<>(nodeRefPairs.size());
         for (Pair<Long, NodeRef> nodePair : nodeRefPairs)
         {
             nodeIds.add(nodePair.getFirst());
@@ -1641,7 +1641,7 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
      */
     private Map<Long, Map<QName, Serializable>> getPropertiesImpl(List<Pair<Long, NodeRef>> nodePairs) throws InvalidNodeRefException
     {
-        List<Long> nodeIds = new ArrayList<Long>(nodePairs.size());
+        List<Long> nodeIds = new ArrayList<>(nodePairs.size());
 
         for (Pair<Long, NodeRef> nodePair : nodePairs)
         {
@@ -1657,7 +1657,7 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
     @Override
     public Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs) throws InvalidNodeRefException
     {
-        if (nodeRefs == null || nodeRefs.size() == 0)
+        if (nodeRefs == null || nodeRefs.isEmpty())
         {
             return Collections.emptyMap();
         }
@@ -1679,7 +1679,7 @@ public class DbNodeServiceImpl extends AbstractNodeServiceImpl implements Extens
 
         Map<Long, Map<QName, Serializable>> propertiesMappedById = getPropertiesImpl(nodePairs);
 
-        Map<NodeRef, Map<QName, Serializable>> propertiesMappedByNodeRef = new HashMap<NodeRef, Map<QName, Serializable>>(nodePairs.size());
+        Map<NodeRef, Map<QName, Serializable>> propertiesMappedByNodeRef = new HashMap<>(nodePairs.size());
         for (Pair<Long, NodeRef> nodePair : nodePairs)
         {
             Long nodeId = nodePair.getFirst();

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -576,6 +576,12 @@ public class DBQueryEngine implements QueryEngine
         {
             return value.getNodeRef();
         }
+
+        @Override
+        public List<Pair<Long, Node>> findByValues(List<Node> values)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for Nodes.");
+        }
     }
 
     private void addStoreInfo(Node node)

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -444,11 +444,18 @@ public class DBQueryEngine implements QueryEngine
                     rawDbids.add(node.getId());
                 }
             }
-            logger.debug("- bulk loading node data: " + rawDbids.size());
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("- bulk loading node data: " + rawDbids.size());
+            }
             nodeDAO.cacheNodesById(rawDbids);
         }
 
-        logger.debug("- query is completed, " + nodes.size() + " nodes loaded");
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("- query is completed, " + nodes.size() + " nodes loaded");
+        }
+
         return frs;
     }
 

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -566,6 +566,12 @@ public class DBQueryEngine implements QueryEngine
         }
 
         @Override
+        public List<Pair<Long, Node>> findByKeys(List<Long> nodeIds)
+        {
+            throw new UnsupportedOperationException("Batch lookup not supported for Nodes.");
+        }
+
+        @Override
         public NodeRef getValueKey(Node value)
         {
             return value.getNodeRef();

--- a/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/querymodel/impl/db/DBQueryEngine.java
@@ -384,7 +384,7 @@ public class DBQueryEngine implements QueryEngine
                 addStoreInfo(node);
 
                 boolean shouldCache = shouldCache(options, nodes, requiredNodes);
-                if (shouldCache)
+                if (shouldCache && !options.isBulkFetchEnabled())
                 {
                     logger.debug("- selected node " + nodes.size() + ": " + node.getUuid() + " " + node.getId());
                     nodesCache.setValue(node.getId(), node);
@@ -432,6 +432,21 @@ public class DBQueryEngine implements QueryEngine
         DBResultSet rs = createResultSet(options, nodes, numberFound);
         FilteringResultSet frs = new FilteringResultSet(rs, formInclusionMask(nodes));
         frs.setResultSetMetaData(new SimpleResultSetMetaData(LimitBy.UNLIMITED, PermissionEvaluationMode.EAGER, rs.getResultSetMetaData().getSearchParameters()));
+
+        // Bulk Load
+        if (rs.getResultSetMetaData().getSearchParameters().isBulkFetchEnabled())
+        {
+            List<Long> rawDbids = new ArrayList<>();
+            for (Node node : nodes)
+            {
+                if (node != null)
+                {
+                    rawDbids.add(node.getId());
+                }
+            }
+            logger.debug("- bulk loading node data: " + rawDbids.size());
+            nodeDAO.cacheNodesById(rawDbids);
+        }
 
         logger.debug("- query is completed, " + nodes.size() + " nodes loaded");
         return frs;

--- a/repository/src/main/java/org/alfresco/repo/version/NodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/version/NodeServiceImpl.java
@@ -431,7 +431,7 @@ public class NodeServiceImpl implements NodeService, VersionModel
             }
 
             Serializable aspect = this.dbNodeService.getProperty(nodeRef, PROP_QNAME_FROZEN_ASPECTS);
-            result.put(nodeRef, new HashSet<QName>((ArrayList<QName>) aspect));
+            result.put(nodeRef, new HashSet<>((ArrayList<QName>) aspect));
         }
 
         return result;

--- a/repository/src/main/java/org/alfresco/repo/version/NodeServiceImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/version/NodeServiceImpl.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -177,6 +178,20 @@ public class NodeServiceImpl implements NodeService, VersionModel
     /**
      * Delegates to the <code>NodeService</code> used as the version store implementation
      */
+    @Override
+    public List<NodeRef> exists(List<NodeRef> nodeRefs)
+    {
+        List<NodeRef> convertedNodeRefs = new ArrayList<>(nodeRefs.size());
+        for (NodeRef nodeRef : nodeRefs)
+        {
+            convertedNodeRefs.add(VersionUtil.convertNodeRef(nodeRef));
+        }
+        return dbNodeService.exists(convertedNodeRefs);
+    }
+
+    /**
+     * Delegates to the <code>NodeService</code> used as the version store implementation
+     */
     public Status getNodeStatus(NodeRef nodeRef)
     {
         return dbNodeService.getNodeStatus(nodeRef);
@@ -189,6 +204,15 @@ public class NodeServiceImpl implements NodeService, VersionModel
     public NodeRef getNodeRef(Long nodeId)
     {
         return dbNodeService.getNodeRef(nodeId);
+    }
+
+    /**
+     * Delegates to the <code>NodeService</code> used as the version store implementation
+     */
+    @Override
+    public List<NodeRef> getNodeRefs(List<Long> nodeIds)
+    {
+        return dbNodeService.getNodeRefs(nodeIds);
     }
 
     /**
@@ -387,6 +411,33 @@ public class NodeServiceImpl implements NodeService, VersionModel
     }
 
     /**
+     * Translation for version store
+     */
+    @SuppressWarnings({"unchecked", "deprecation"})
+    @Override
+    public Map<NodeRef, Set<QName>> getAspects(List<NodeRef> nodeRefs) throws InvalidNodeRefException
+    {
+        Map<NodeRef, Set<QName>> result = new HashMap<>();
+
+        List<NodeRef> convertedNodeRefs = nodeRefs.stream()
+                .map(VersionUtil::convertNodeRef)
+                .collect(Collectors.toList());
+
+        for (NodeRef nodeRef : convertedNodeRefs)
+        {
+            if (!this.dbNodeService.exists(nodeRef))
+            {
+                throw new InvalidNodeRefException("Node does not exist: " + nodeRef, nodeRef);
+            }
+
+            Serializable aspect = this.dbNodeService.getProperty(nodeRef, PROP_QNAME_FROZEN_ASPECTS);
+            result.put(nodeRef, new HashSet<QName>((ArrayList<QName>) aspect));
+        }
+
+        return result;
+    }
+
+    /**
      * Property translation for version store
      */
     public Map<QName, Serializable> getProperties(NodeRef nodeRef) throws InvalidNodeRefException
@@ -448,6 +499,19 @@ public class NodeServiceImpl implements NodeService, VersionModel
         }
 
         return result;
+    }
+
+    @Override
+    public Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs) throws InvalidNodeRefException
+    {
+        if (nodeRefs == null || nodeRefs.isEmpty())
+        {
+            return Collections.emptyMap();
+        }
+
+        List<NodeRef> convertedNodeRefs = nodeRefs.stream().map(VersionUtil::convertNodeRef).collect(Collectors.toList());
+
+        return this.dbNodeService.getPropertiesForNodeRefs(convertedNodeRefs);
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/virtual/bundle/VirtualNodeServiceExtension.java
+++ b/repository/src/main/java/org/alfresco/repo/virtual/bundle/VirtualNodeServiceExtension.java
@@ -172,7 +172,7 @@ public class VirtualNodeServiceExtension extends VirtualSpringBeanExtension<Node
     public Map<NodeRef, Map<QName, Serializable>> getPropertiesForNodeRefs(List<NodeRef> nodeRefs)
     {
 
-        Map<NodeRef, Map<QName, Serializable>> result = new HashMap<NodeRef, Map<QName, Serializable>>();
+        Map<NodeRef, Map<QName, Serializable>> result = new HashMap<>();
         for (NodeRef nodeRef : nodeRefs)
         {
             Reference reference = Reference.fromNodeRef(nodeRef);

--- a/repository/src/main/resources/alfresco/dao/dao-context.xml
+++ b/repository/src/main/resources/alfresco/dao/dao-context.xml
@@ -142,7 +142,6 @@
       <property name="cachingThreshold" value="${nodes.bulkLoad.cachingThreshold}"/>
       <property name="batchSize" value="${nodes.bulkLoad.batchSize:256}"/>
       <property name="forceBatching" value="${nodes.bulkLoad.forceBatching:false}"/>
-      <property name="preloadContentData" value="${nodes.bulkLoad.preloadContentData:true}"/>
    </bean>
 
    <bean id="nodeDAO.org.alfresco.repo.domain.dialect.Dialect" class="org.alfresco.repo.domain.node.ibatis.NodeDAOImpl" parent="nodeDAObase" />

--- a/repository/src/main/resources/alfresco/dao/dao-context.xml
+++ b/repository/src/main/resources/alfresco/dao/dao-context.xml
@@ -140,6 +140,9 @@
       <property name="parentAssocsCacheLimitFactor" value="${system.cache.parentAssocs.limitFactor}"/>
       <property name="childByNameCache" ref="node.childByNameCache"/>
       <property name="cachingThreshold" value="${nodes.bulkLoad.cachingThreshold}"/>
+      <property name="batchSize" value="${nodes.bulkLoad.batchSize:256}"/>
+      <property name="forceBatching" value="${nodes.bulkLoad.forceBatching:false}"/>
+      <property name="preloadContentData" value="${nodes.bulkLoad.preloadContentData:true}"/>
    </bean>
 
    <bean id="nodeDAO.org.alfresco.repo.domain.dialect.Dialect" class="org.alfresco.repo.domain.node.ibatis.NodeDAOImpl" parent="nodeDAObase" />

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/content-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/content-common-SqlMap.xml
@@ -398,28 +398,6 @@
             and (np.actual_type_n = 3 or np.actual_type_n = 21)
     </select>
 
-    <!-- Get ContentData entities by Content Data -->
-    <select id="select_ContentDataByContentData" parameterType="ContentData" resultMap="result_ContentData">
-        select
-            cd.id as id,
-            cd.version as version,
-            cd.content_url_id as content_url_id,
-            cu.content_size as content_size,
-            cd.content_mimetype_id as content_mimetype_id,
-            cd.content_encoding_id as content_encoding_id,
-            cd.content_locale_id as content_locale_id
-        from
-            alf_content_data cd
-            join alf_node_properties np on (cd.id = np.long_value)
-            left join alf_content_url cu on (cd.content_url_id = cu.id)
-        where
-            cu.content_url in 
-            <foreach item="item" index="index" collection="list" open="(" separator="," close=")">
-                #{item.contentUrl}
-            </foreach>
-            and (np.actual_type_n = 3 or np.actual_type_n = 21)
-    </select>
-
     <!-- Get the ContentData entity by Node and property QName -->
     <select id="select_ContentDataByNodeAndQName" parameterType="Ids" resultType="long">
         select

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/content-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/content-common-SqlMap.xml
@@ -235,6 +235,31 @@
             u.id = #{id}
     </select>
 
+    <!-- Get the content URL entities by IDs -->
+    <select id="select_ContentUrlsByIds" parameterType="list" resultMap="result_ContentUrl">
+        select
+            u.id as id,
+            u.content_url as content_url,
+            u.content_url_short as content_url_short,
+            u.content_url_crc as content_url_crc,
+            u.content_size as content_size,
+            u.orphan_time as orphan_time,
+            ce.algorithm as algorithm,
+            ce.key_size as key_size,
+            ce.encrypted_key as encrypted_key,
+            ce.master_keystore_id as master_keystore_id,
+            ce.master_key_alias as master_key_alias,
+            ce.unencrypted_file_size as unencrypted_file_size
+        from
+            alf_content_url u
+            left join alf_content_url_encryption ce on (u.id = ce.content_url_id)
+        where
+            u.id in
+            <foreach item="item" index="index" collection="list" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+    </select>
+
     <!-- Get the content URL entity by unique key -->
     <select id="select_ContentUrlByKey" parameterType="ContentUrl" resultMap="result_ContentUrl">
         select
@@ -369,6 +394,28 @@
             np.node_id in 
             <foreach item="item" index="index" collection="ids" open="(" separator="," close=")">
                 #{item}
+            </foreach>
+            and (np.actual_type_n = 3 or np.actual_type_n = 21)
+    </select>
+
+    <!-- Get ContentData entities by Content Data -->
+    <select id="select_ContentDataByContentData" parameterType="ContentData" resultMap="result_ContentData">
+        select
+            cd.id as id,
+            cd.version as version,
+            cd.content_url_id as content_url_id,
+            cu.content_size as content_size,
+            cd.content_mimetype_id as content_mimetype_id,
+            cd.content_encoding_id as content_encoding_id,
+            cd.content_locale_id as content_locale_id
+        from
+            alf_content_data cd
+            join alf_node_properties np on (cd.id = np.long_value)
+            left join alf_content_url cu on (cd.content_url_id = cu.id)
+        where
+            cu.content_url in 
+            <foreach item="item" index="index" collection="list" open="(" separator="," close=")">
+                #{item.contentUrl}
             </foreach>
             and (np.actual_type_n = 3 or np.actual_type_n = 21)
     </select>

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
@@ -1215,6 +1215,17 @@
             <if test="isPrimary != null">and assoc.is_primary = #{isPrimary}</if>
     </select>
 
+    <select id="select_ParentAssocsOfChildren" parameterType="ChildAssoc" resultMap="result_ChildAssocTxnId">
+        <include refid="alfresco.node.select_ChildAssoc_Results"/>
+        <include refid="alfresco.node.select_ChildAssoc_FromSimple"/>
+        where
+            childNode.id in
+            <foreach item="item" index="index" collection="ids" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+            and assoc.is_primary = true
+    </select>
+
     <select id="select_NodeMinId" resultType="java.lang.Long">
         select
             min(id)

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
@@ -665,7 +665,15 @@
             join alf_store store on (store.id = node.store_id)
             join alf_transaction txn on (txn.id = node.transaction_id)
         where
-            node.store_id = #{storeId} and
+            <choose>
+                <when test="storeId != null">node.store_id = #{storeId} and</when>
+                <otherwise>
+                    node.store_id in
+                    <foreach item="item" index="index" collection="storeIds" open="(" separator="," close=") and">
+                        #{item}
+                    </foreach>
+                </otherwise>
+            </choose>
             node.uuid in 
             <foreach item="item" index="index" collection="uuids" open="(" separator="," close=")">
                 #{item}

--- a/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
+++ b/repository/src/main/resources/alfresco/ibatis/org.alfresco.repo.domain.dialect.Dialect/node-common-SqlMap.xml
@@ -762,13 +762,15 @@
             alf_node node
             join alf_node_aspects aspects on (aspects.node_id = node.id)
         <where>
-            <if test="nodeId != null">aspects.node_id = #{nodeId}</if>
-            <if test="nodeIds != null">
-                and aspects.node_id in 
-                <foreach item="item" index="index" collection="nodeIds" open="(" separator="," close=")">
-                    #{item}
-                </foreach>
-            </if>
+            <choose>
+                <when test="nodeId != null">aspects.node_id = #{nodeId}</when>
+                <when test="nodeIds != null">
+                    aspects.node_id in
+                    <foreach item="item" index="index" collection="nodeIds" open="(" separator="," close=")">
+                        #{item}
+                    </foreach>
+                </when>
+            </choose>
         </where>
     </select>
     

--- a/repository/src/main/resources/alfresco/public-services-security-context.xml
+++ b/repository/src/main/resources/alfresco/public-services-security-context.xml
@@ -425,6 +425,7 @@
                org.alfresco.service.cmr.repository.NodeService.removeSeconaryChildAssociation=ACL_PARENT.0.sys:base.DeleteChildren
                org.alfresco.service.cmr.repository.NodeService.removeSecondaryChildAssociation=ACL_PARENT.0.sys:base.DeleteChildren
                org.alfresco.service.cmr.repository.NodeService.getProperties=ACL_NODE.0.sys:base.ReadProperties
+               org.alfresco.service.cmr.repository.NodeService.getPropertiesForNodeRefs=ROLE_AUTHENTICATED
                org.alfresco.service.cmr.repository.NodeService.getProperty=ACL_NODE.0.sys:base.ReadProperties
                org.alfresco.service.cmr.repository.NodeService.setProperties=ACL_NODE.0.sys:base.WriteProperties,ACL_ITEM.0.cm:ownable.TakeOwnership
                org.alfresco.service.cmr.repository.NodeService.addProperties=ACL_NODE.0.sys:base.WriteProperties,ACL_ITEM.0.cm:ownable.TakeOwnership

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -920,7 +920,6 @@ mail.service.maximumPoolSize=20
 nodes.bulkLoad.cachingThreshold=10
 nodes.bulkLoad.batchSize=256
 nodes.bulkLoad.forceBatching=false
-nodes.bulkLoad.preloadContentData=true
 
 # Multi-Tenancy
 

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -918,6 +918,9 @@ mail.service.corePoolSize=8
 mail.service.maximumPoolSize=20
 
 nodes.bulkLoad.cachingThreshold=10
+nodes.bulkLoad.batchSize=256
+nodes.bulkLoad.forceBatching=false
+nodes.bulkLoad.preloadContentData=true
 
 # Multi-Tenancy
 

--- a/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
+++ b/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
@@ -296,14 +296,14 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
         assertNull(entityPairCacheCheck);
     }
 
-    public void testFindByValuesNotFound() throws Exception
+    public void testFindByValuesNotFound()
     {
         // Put some values in the "database"
         createValue(new TestValue("AAA"));
         createValue(new TestValue("BBB"));
         createValue(new TestValue("CCC"));
 
-        List<Object> valuesToFind = new ArrayList<Object>(3);
+        List<Object> valuesToFind = new ArrayList<>(3);
         valuesToFind.add(new TestValue("ZZZ"));
         valuesToFind.add(new TestValue("AAA"));
         valuesToFind.add(new TestValue("BBB"));
@@ -351,6 +351,7 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
         return dbValue;
     }
 
+    @Override
     public List<String> getValueKeys(List<Object> values)
     {
         List<String> keys = new ArrayList<>(values.size());
@@ -402,7 +403,7 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
         assertNotNull(values);
         assertFalse(values.isEmpty());
 
-        List<Pair<Long, Object>> results = new ArrayList<Pair<Long, Object>>(values.size());
+        List<Pair<Long, Object>> results = new ArrayList<>(values.size());
 
         for (Object value : values)
         {
@@ -412,7 +413,7 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
             {
                 if (EqualsHelper.nullSafeEquals(entry.getValue(), dbValue))
                 {
-                    results.add(new Pair<Long, Object>(entry.getKey(), entry.getValue()));
+                    results.add(new Pair<>(entry.getKey(), entry.getValue()));
                     break;
                 }
             }

--- a/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
+++ b/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
@@ -296,6 +296,23 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
         assertNull(entityPairCacheCheck);
     }
 
+    public void testFindByValuesNotFound() throws Exception
+    {
+        // Put some values in the "database"
+        createValue(new TestValue("AAA"));
+        createValue(new TestValue("BBB"));
+        createValue(new TestValue("CCC"));
+
+        List<Object> valuesToFind = new ArrayList<Object>(3);
+        valuesToFind.add(new TestValue("ZZZ"));
+        valuesToFind.add(new TestValue("AAA"));
+        valuesToFind.add(new TestValue("BBB"));
+
+        List<Pair<Long, Object>> results = findByValues(valuesToFind);
+        assertNotNull(results);
+        assertEquals(2, results.size());
+    }
+
     /**
      * Helper class to represent business object
      */
@@ -377,6 +394,31 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
             }
         }
         return null;
+    }
+
+    @Override
+    public List<Pair<Long, Object>> findByValues(List<Object> values)
+    {
+        assertNotNull(values);
+        assertFalse(values.isEmpty());
+
+        List<Pair<Long, Object>> results = new ArrayList<Pair<Long, Object>>(values.size());
+
+        for (Object value : values)
+        {
+            String dbValue = (value == null) ? null : ((TestValue) value).val;
+
+            for (Map.Entry<Long, String> entry : database.entrySet())
+            {
+                if (EqualsHelper.nullSafeEquals(entry.getValue(), dbValue))
+                {
+                    results.add(new Pair<Long, Object>(entry.getKey(), entry.getValue()));
+                    break;
+                }
+            }
+        }
+
+        return results;
     }
 
     /**

--- a/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
+++ b/repository/src/test/java/org/alfresco/repo/cache/lookup/EntityLookupCacheTest.java
@@ -28,6 +28,8 @@ package org.alfresco.repo.cache.lookup;
 import static org.junit.Assert.*;
 
 import java.sql.Savepoint;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -332,6 +334,16 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
         return dbValue;
     }
 
+    public List<String> getValueKeys(List<Object> values)
+    {
+        List<String> keys = new ArrayList<>(values.size());
+        for (Object value : values)
+        {
+            keys.add(getValueKey(value));
+        }
+        return keys;
+    }
+
     public Pair<Long, Object> findByKey(Long key)
     {
         assertNotNull(key);
@@ -344,6 +356,12 @@ public class EntityLookupCacheTest implements EntityLookupCallbackDAO<Long, Obje
         // Make a value object
         TestValue value = new TestValue(dbValue);
         return new Pair<Long, Object>(key, value);
+    }
+
+    @Override
+    public List<Pair<Long, Object>> findByKeys(List<Long> key)
+    {
+        throw new UnsupportedOperationException("Batch lookup not supported in test DAO.");
     }
 
     public Pair<Long, Object> findByValue(Object value)


### PR DESCRIPTION
- Batch processing of queries for the V1 Search API
- Configuration property added for nodes.bulkLoad.batchSize
- - This property configures the size of the preload batching of the search results (defaults to 256)
- Configuration property added for nodes.bulkLoad.forceBatching
- - This property forces batch querying (IN vs =) in db queries.  This bypasses the check of the state of the caches.
- Post processing of the search results also use batch queries.  Everything should be in the caches but just in case we reduce the number of extra queries needed to build the response