### PR TITLE
[PRODSEC-11536]: CVE Vulnerability CVE-2026-33871 in netty-codec-http2-4.1.127.Final.jar in Alfresco Azure Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.15.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.127.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.17.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.130.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>


### PR DESCRIPTION
Cherry pick: https://github.com/Alfresco/alfresco-community-repo/commit/bac549c39fc6455e7244b868a4516e4871bec848