### PR TITLE
[MNT-25432] docker-maven-plugin bumped to 0.48.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1007,7 +1007,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.45.0</version>
+                    <version>0.48.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This pull request updates the version of the `docker-maven-plugin` used in the project. The new version may include bug fixes, new features, or security updates. No other changes are included.
