### PR TITLE
[PRODSEC-11536]: CVE Vulnerability CVE-2026-33871 in netty-codec-http2-4.1.127.Final.jar in Alfresco Azure Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,10 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-<!--        <dependency.camel.version>4.20.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
-<!--        <dependency.netty.version>4.2.12.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
-        <dependency.camel.version>4.17.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.130.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+<!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
+<!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.18.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.130.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
 <!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
 <!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.17.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.130.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,10 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+<!--        <dependency.camel.version>4.20.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
+<!--        <dependency.netty.version>4.2.12.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
+        <dependency.camel.version>4.17.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.130.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.camel.version>4.18.2</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
         <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
-<!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
-<!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.18.2</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.19.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
 <!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
 <!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
         <dependency.camel.version>4.18.2</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.netty.version>4.1.133.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.19.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
         <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
 <!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
 <!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.18.1</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.131.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.18.2</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
 <!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
 <!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <dependency.truezip.version>7.7.10</dependency.truezip.version>
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
-        <dependency.camel.version>4.18.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.130.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.camel.version>4.18.1</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
+        <dependency.netty.version>4.1.131.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
 <!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
 <!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
         <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>
         <dependency.apache-compress.version>1.27.1</dependency.apache-compress.version>
         <dependency.awaitility.version>4.2.2</dependency.awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency.poi.version>5.4.0</dependency.poi.version>
         <dependency.jboss.logging.version>3.5.0.Final</dependency.jboss.logging.version>
         <dependency.camel.version>4.20.0</dependency.camel.version> <!-- when bumping this version, please keep track/sync with included netty.io dependencies -->
-        <dependency.netty.version>4.2.12.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
+        <dependency.netty.version>4.1.132.Final</dependency.netty.version> <!-- must be in sync with camels transitive dependencies, e.g.: netty-common -->
 <!--        <dependency.camel.version>4.19.0</dependency.camel.version> &lt;!&ndash; when bumping this version, please keep track/sync with included netty.io dependencies &ndash;&gt;-->
 <!--        <dependency.netty.version>4.1.132.Final</dependency.netty.version> &lt;!&ndash; must be in sync with camels transitive dependencies, e.g.: netty-common &ndash;&gt;-->
         <dependency.activemq.version>5.18.6</dependency.activemq.version>


### PR DESCRIPTION
Why apache-amqp 4.18.2 and netty 4.1.133.Final are pinned

These versions are retained because newer releases require Spring 7, while ACS 25.x is built on the Spring 6 series.

Root Cause

Spring 7 introduces a covariant override of getSource() in ApplicationContextEvent:

    Spring 6 — inherits getSource() from java.util.EventObject, returning Object → descriptor: () java/lang/Object;

    Spring 7 — overrides it to return ApplicationContext → descriptor: () org/springframework/context/ApplicationContext;

Although the method name is the same, the JVM resolves methods by their full descriptor (name + return type). This makes the two versions binary-incompatible: any dependency compiled against Spring 7's getSource() will fail at runtime on Spring 6 with:
java.lang.NoSuchMethodError

Upgrading apache-amqp or netty beyond the pinned versions pulls in classes compiled against Spring 7, triggering this error in our Spring 6 environment.