### PR TITLE
ACS-11286 Optimizing DisposableLifecycle FTS query  along with introducing CMIS query mode  

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
@@ -75,6 +75,13 @@ rm.dispositionlifecycletrigger.cronexpression=0 0/5 * * * ?
 rm.dispositionlifecycletrigger.batchsize=500
 
 #
+# When true, the disposition lifecycle job uses Elasticsearch filter queries (unscored, cacheable)
+# for better query performance. Only enable when Elasticsearch is the configured search subsystem.
+# Default false preserves the original combined FTS query — safe for Solr and DB fallback.
+#
+rm.dispositionlifecycletrigger.enableElasticOptimization=false
+
+#
 # Global RM publish updates cron job expression
 #
 rm.publishupdates.cronexpression=0/30 * * * * ?

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
@@ -74,23 +74,7 @@ rm.dispositionlifecycletrigger.cronexpression=0 0/5 * * * ?
 #
 rm.dispositionlifecycletrigger.batchsize=500
 
-#
-# When true, the disposition lifecycle job uses Elasticsearch filter queries (unscored, cacheable)
-#
-rm.dispositionlifecycletrigger.enableElasticOptimization=false
-
-#
-# When true, the disposition lifecycle job uses a transactional CMIS query routed to the database instead of an index-based FTS query.
-#
-rm.dispositionlifecycletrigger.useDbQuery=false
-
-
-#
-# When true, the disposition lifecycle job uses Elasticsearch filter queries (unscored, cacheable)
-# for better query performance. Only enable when Elasticsearch is the configured search subsystem.
-# Default false preserves the original combined FTS query — safe for Solr and DB fallback.
-#
-rm.dispositionlifecycletrigger.enableElasticOptimization=false
+rm.dispositionlifecycletrigger.queryMode=
 
 #
 # Global RM publish updates cron job expression

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
@@ -76,6 +76,17 @@ rm.dispositionlifecycletrigger.batchsize=500
 
 #
 # When true, the disposition lifecycle job uses Elasticsearch filter queries (unscored, cacheable)
+#
+rm.dispositionlifecycletrigger.enableElasticOptimization=false
+
+#
+# When true, the disposition lifecycle job uses a transactional CMIS query routed to the database instead of an index-based FTS query.
+#
+rm.dispositionlifecycletrigger.useDbQuery=false
+
+
+#
+# When true, the disposition lifecycle job uses Elasticsearch filter queries (unscored, cacheable)
 # for better query performance. Only enable when Elasticsearch is the configured search subsystem.
 # Default false preserves the original combined FTS query — safe for Solr and DB fallback.
 #

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/alfresco-global.properties
@@ -74,7 +74,13 @@ rm.dispositionlifecycletrigger.cronexpression=0 0/5 * * * ?
 #
 rm.dispositionlifecycletrigger.batchsize=500
 
-rm.dispositionlifecycletrigger.queryMode=
+# Global RM retention lifecycle CMIS query upper bound per job run.
+# Default is 0.1M records (100000).
+rm.dispositionlifecycletrigger.cmisquerylimit=100000
+
+# Query mode for RM disposition lifecycle trigger search execution.
+# Available values: fts (default), cmis.
+rm.dispositionlifecycletrigger.queryMode=fts
 
 #
 # Global RM publish updates cron job expression

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
@@ -82,8 +82,7 @@
       <property name="recordsManagementActionService" ref="recordsManagementActionService" />
       <property name="freezeService" ref="freezeService"/>
       <property name="batchSize" value="${rm.dispositionlifecycletrigger.batchsize}"/>
-      <property name="enableElasticOptimization" value="${rm.dispositionlifecycletrigger.enableElasticOptimization}"/>
-      <property name="useDbQuery" value="${rm.dispositionlifecycletrigger.useDbQuery}"/>
+      <property name="queryMode" value="${rm.dispositionlifecycletrigger.queryMode}"/>
    </bean>
 
    <bean id="scheduledDispositionLifecyceleSchedulerAccessor" class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
@@ -82,6 +82,7 @@
       <property name="recordsManagementActionService" ref="recordsManagementActionService" />
       <property name="freezeService" ref="freezeService"/>
       <property name="batchSize" value="${rm.dispositionlifecycletrigger.batchsize}"/>
+      <property name="enableElasticOptimization" value="${rm.dispositionlifecycletrigger.enableElasticOptimization}"/>
    </bean>
 
    <bean id="scheduledDispositionLifecyceleSchedulerAccessor" class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
@@ -83,6 +83,7 @@
       <property name="freezeService" ref="freezeService"/>
       <property name="batchSize" value="${rm.dispositionlifecycletrigger.batchsize}"/>
       <property name="enableElasticOptimization" value="${rm.dispositionlifecycletrigger.enableElasticOptimization}"/>
+      <property name="useDbQuery" value="${rm.dispositionlifecycletrigger.useDbQuery}"/>
    </bean>
 
    <bean id="scheduledDispositionLifecyceleSchedulerAccessor" class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">

--- a/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
+++ b/amps/ags/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/rm-job-context.xml
@@ -82,6 +82,7 @@
       <property name="recordsManagementActionService" ref="recordsManagementActionService" />
       <property name="freezeService" ref="freezeService"/>
       <property name="batchSize" value="${rm.dispositionlifecycletrigger.batchsize}"/>
+      <property name="cmisQueryLimit" value="${rm.dispositionlifecycletrigger.cmisquerylimit}"/>
       <property name="queryMode" value="${rm.dispositionlifecycletrigger.queryMode}"/>
    </bean>
 

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -95,6 +95,9 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** when true, query conditions are pushed into ES filter context (unscored, cacheable) for better performance */
     private boolean enableElasticOptimization = false;
 
+    /** when true, uses a transactional CMIS/DB query instead of an index-based FTS query */
+    private boolean useDbQuery = false;
+
     /**
      * @param freezeService
      *            freeze service
@@ -107,6 +110,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     public void setEnableElasticOptimization(boolean enableElasticOptimization)
     {
         this.enableElasticOptimization = enableElasticOptimization;
+    }
+
+    public void setUseDbQuery(boolean useDbQuery)
+    {
+        this.useDbQuery = useDbQuery;
     }
 
     /**
@@ -210,12 +218,59 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         return actionFilterQuery;
     }
 
+    /**
+     * Builds a transactional CMIS query for eligible disposition action nodes.
+     * The date cutoff is evaluated at call time so each job run uses the current date.
+     * Never cached — unlike {@link #getQuery()} — because the timestamp changes every run.
+     *
+     * @return CMIS SQL string
+     */
+    protected String getCmisQuery()
+    {
+        // Use end-of-current-day in UTC so that records due today are always included
+        // regardless of what time within the day the job fires.
+        String cutoff = LocalDate.now() + "T23:59:59.999Z";
+
+        StringBuilder sb = new StringBuilder("SELECT * FROM rma:dispositionAction WHERE ");
+        sb.append("rma:dispositionAction IN (");
+        boolean first = true;
+        for (String action : dispositionActions)
+        {
+            if (!first) sb.append(",");
+            sb.append("'").append(action).append("'");
+            first = false;
+        }
+        sb.append(") ");
+        sb.append("AND rma:dispositionActionCompletedAt IS NULL ");
+        sb.append("AND (rma:dispositionEventsEligible = true ");
+        sb.append("OR rma:dispositionAsOf <= TIMESTAMP '").append(cutoff).append("')");
+
+        log.debug("Constructed CMIS query: " + sb.toString());
+        return sb.toString();
+    }
 
     /**
      * @see org.alfresco.module.org_alfresco_module_rm.job.RecordsManagementJobExecuter#execute()
      */
     @Override
     public void executeImpl()
+    {
+        if (useDbQuery)
+        {
+            executeImplCmis();
+        }
+        else
+        {
+            executeImplFts();
+        }
+    }
+
+    /**
+     * FTS/index-based execution path (default).
+     * Paginates through search results using skipCount, relying on the search index
+     * (Elasticsearch or Solr) to resolve eligible nodes.
+     */
+    private void executeImplFts()
     {
         try
         {
@@ -251,6 +306,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                     params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
                     String tomorrow = LocalDate.now().plusDays(1).toString();
                     params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:[" + tomorrow + " TO MAX])");
+                    params.setTrackScore(false);
                 }
                 else
                 {
@@ -314,13 +370,141 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     }
 
     /**
-     * Helper method that executes a disposition action
+     * CMIS/DB-based execution path (enabled by {@code useDbQuery=true}).
      *
-     * @param eligibleNodes
-     *            map of disposition action node to its pre-computed primary parent;
+     * <p>Key differences from the FTS path:</p>
+     * <ul>
+     *   <li><b>Transactional consistency</b>: {@link QueryConsistency#TRANSACTIONAL} is forced
+     *       so the query always hits the DB. Processed nodes (with {@code dispositionActionCompletedAt}
+     *       set) are immediately invisible to the next query — no risk of re-processing.</li>
+     *   <li><b>Skip reset on progress</b>: When at least one node is actioned, skip resets to 0
+     *       because those nodes have vanished from the result set. The next query naturally returns
+     *       the next page of eligible nodes from the beginning.</li>
+     *   <li><b>Skip advance on no progress</b>: When a non-empty batch yields zero actioned nodes
+     *       (all frozen, deleted, or malformed) the skip advances by the raw page size. This prevents
+     *       an infinite loop over unprocessable records.</li>
+     *   <li><b>No index cap</b>: The 10 000-record Elasticsearch limit does not apply; the batch
+     *       size is the only cap and is fully configurable.</li>
+     * </ul>
      */
-    private void executeAction(final Map<NodeRef, ChildAssociationRef> eligibleNodes)
+    private void executeImplCmis()
     {
+        try
+        {
+            log.debug("Job Starting (CMIS/DB mode)");
+
+            if (dispositionActions == null || dispositionActions.isEmpty())
+            {
+                log.debug("Job Finished as disposition action is empty");
+                return;
+            }
+
+            if (batchSize < 1)
+            {
+                log.debug("Invalid value for batch size: " + batchSize + " default value used instead.");
+                batchSize = DEFAULT_BATCH_SIZE;
+            }
+
+            log.trace("Using batch size of " + batchSize);
+
+            int skipCount = 0;
+
+            while (true)
+            {
+                SearchParameters params = new SearchParameters();
+                params.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
+                params.setLanguage(SearchService.LANGUAGE_CMIS_ALFRESCO);
+                params.setQuery(getCmisQuery());
+                params.setMaxItems(batchSize);
+                params.setSkipCount(skipCount);
+                // Force DB routing. CMIS goes to the DB by default but being explicit here
+                // guards against any future routing change that could silently reintroduce
+                // the async-indexing lag and the need for skip arithmetic.
+                params.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
+
+                ResultSet results = searchService.query(params);
+                if (results == null)
+                {
+                    log.warn("Disposition lifecycle CMIS query returned null; stopping.");
+                    break;
+                }
+
+                int rawPageSize;
+                Map<NodeRef, ChildAssociationRef> eligibleNodes;
+                try
+                {
+                    List<NodeRef> rawPage = results.getNodeRefs();
+                    rawPageSize = rawPage.size();
+                    if (rawPageSize == 0)
+                    {
+                        log.debug("No more eligible nodes found; job complete.");
+                        break;
+                    }
+
+                    eligibleNodes = new LinkedHashMap<>(rawPageSize);
+                    for (NodeRef node : rawPage)
+                    {
+                        ChildAssociationRef parent = nodeService.getPrimaryParent(node);
+                        NodeRef freezeTarget = parent != null ? parent.getParentRef() : node;
+                        if (!freezeService.isFrozenOrHasFrozenChildren(freezeTarget))
+                        {
+                            eligibleNodes.put(node, parent);
+                        }
+                    }
+                }
+                finally
+                {
+                    results.close();
+                }
+
+                log.debug("Processing " + eligibleNodes.size() + " nodes (CMIS mode)");
+
+                int processed = 0;
+                if (!eligibleNodes.isEmpty())
+                {
+                    processed = executeAction(eligibleNodes);
+                }
+
+                if (processed > 0)
+                {
+                    // Actioned nodes have dispositionActionCompletedAt set and will not reappear.
+                    // Reset skip so the next query starts from position 0 and picks up any nodes
+                    // that shifted into earlier positions as processed ones were removed.
+                    skipCount = 0;
+                }
+                else
+                {
+                    // The entire batch was unprocessable (frozen, non-existent, or malformed data).
+                    // Advance skip past these nodes to avoid fetching the same stuck batch forever.
+                    log.warn("No nodes processed from a batch of {}; advancing skip by {} to bypass unprocessable records.", rawPageSize, rawPageSize);
+                    skipCount += rawPageSize;
+                }
+            }
+            log.debug("Job Finished (CMIS/DB mode)");
+        }
+        catch (AlfrescoRuntimeException exception)
+        {
+            log.debug(exception.getMessage());
+        }
+    }
+
+    /**
+     * Executes the disposition action for each eligible node.
+     *
+     * <p>Returns the number of nodes for which the action was actually executed.
+     * Nodes discarded by the three internal guards (does not exist, wrong action,
+     * wrong parent association) are not counted. The caller uses this count to
+     * detect a stuck batch — a non-empty batch that yields zero processed nodes —
+     * and advance the skip offset accordingly.</p>
+     *
+     * @param eligibleNodes map of disposition action node to its pre-computed primary parent
+     * @return number of nodes for which the disposition action was successfully invoked
+     */
+    private int executeAction(final Map<NodeRef, ChildAssociationRef> eligibleNodes)
+    {
+        // int[] used so the lambda can mutate the counter.
+        final int[] processedCount = {0};
+
         RetryingTransactionCallback<Boolean> processTranCB = () -> {
             for (Map.Entry<NodeRef, ChildAssociationRef> entry : eligibleNodes.entrySet())
             {
@@ -349,22 +533,20 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
                 try
                 {
-                    // execute disposition action
                     recordsManagementActionService
                             .executeRecordsManagementAction(parent.getParentRef(), dispAction, props);
-
+                    processedCount[0]++;
                     log.debug("Processed action: " + dispAction + "on" + parent);
-
                 }
                 catch (AlfrescoRuntimeException exception)
                 {
                     log.debug(exception.getMessage());
-
                 }
             }
             return Boolean.TRUE;
         };
         retryingTransactionHelper.doInTransaction(processTranCB, false, true);
+        return processedCount[0];
     }
 
     public PersonService getPersonService()

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -31,24 +31,29 @@ import static org.alfresco.module.org_alfresco_module_rm.action.RMDispositionAct
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.module.org_alfresco_module_rm.action.RecordsManagementActionService;
 import org.alfresco.module.org_alfresco_module_rm.freeze.FreezeService;
+import org.alfresco.repo.batch.BatchProcessor;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.search.QueryConsistency;
 import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
 import org.alfresco.service.cmr.search.SearchService;
 import org.alfresco.service.cmr.security.PersonService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The Disposition Lifecycle Job Finds all disposition action nodes which are for disposition actions specified Where asOf &gt; now OR dispositionEventsEligible = true; Runs the cut off or retain action for eligible records.
@@ -85,6 +90,9 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** freeze service */
     private FreezeService freezeService;
 
+    /** when true, query conditions are pushed into ES filter context (unscored, cacheable) for better performance */
+    private boolean enableElasticOptimization = false;
+
     /**
      * @param freezeService
      *            freeze service
@@ -92,6 +100,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     public void setFreezeService(FreezeService freezeService)
     {
         this.freezeService = freezeService;
+    }
+
+    public void setEnableElasticOptimization(boolean enableElasticOptimization)
+    {
+        this.enableElasticOptimization = enableElasticOptimization;
     }
 
     /**
@@ -179,6 +192,23 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         return query;
     }
 
+    private String getActionFilterQuery()
+    {
+        String actionFilterQuery=null;
+        StringBuilder sb = new StringBuilder("@rma\\:dispositionAction:(");
+        boolean first = true;
+        for (String dispositionAction : dispositionActions)
+        {
+            if (!first) sb.append(" OR ");
+            sb.append("\"").append(dispositionAction).append("\"");
+            first = false;
+        }
+        actionFilterQuery = sb.append(")").toString();
+
+        return actionFilterQuery;
+    }
+
+
     /**
      * @see org.alfresco.module.org_alfresco_module_rm.job.RecordsManagementJobExecuter#execute()
      */
@@ -197,7 +227,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
             boolean hasMore = true;
             int skipCount = 0;
-            List<NodeRef> resultNodes = new ArrayList<>();
 
             if (batchSize < 1)
             {
@@ -212,27 +241,68 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 SearchParameters params = new SearchParameters();
                 params.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
                 params.setLanguage(SearchService.LANGUAGE_FTS_ALFRESCO);
-                params.setQuery(getQuery());
+
+                if (enableElasticOptimization)
+                {
+                    // Lean main query + dedicated filter clauses — ES places these in
+                    // filter context (unscored, cacheable), improving query performance.
+                    params.setQuery("TYPE:\"rma:dispositionAction\"");
+                    params.addFilterQuery(getActionFilterQuery());
+                    params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
+                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW])");
+                    params.setTrackScore(false);
+                }
+                else
+                {
+                    // Original combined FTS query — safe default, works with Solr and DB fallback.
+                    params.setQuery(getQuery());
+                }
+
                 params.setSkipCount(skipCount);
                 params.setMaxItems(batchSize);
 
                 // execute search
                 ResultSet results = searchService.query(params);
-                if (results != null)
+                if (results == null)
                 {
-                    // filtering out the hold/freezed cases from the result set
-                    resultNodes = results.getNodeRefs().stream().filter(node -> nodeService.getPrimaryParent(node) == null ? !freezeService.isFrozenOrHasFrozenChildren(node) : !freezeService.isFrozenOrHasFrozenChildren(nodeService.getPrimaryParent(node).getParentRef())).collect(Collectors.toList());
+                    log.warn("Disposition lifecycle search returned null; stopping pagination.");
+                    break;
                 }
-                hasMore = results.hasMore();
-                skipCount += resultNodes.size(); // increase by page size
-                results.close();
+                // Declared outside try so it remains in scope after results.close().
+                Map<NodeRef, ChildAssociationRef> eligibleNodes;
+                try
+                {
+                    List<NodeRef> rawPage = results.getNodeRefs();
+                    // Advance skip by raw hit count so paging stays aligned with the index; post-search
+                    // freeze filtering must not shrink the skip step (would duplicate or skip hits).
+                    int rawPageLength = rawPage.size();
+                    hasMore = results.hasMore();
+                    skipCount += rawPageLength;
 
-                log.debug("Processing " + resultNodes.size() + " nodes");
+                    // Single getPrimaryParent call per node: result is carried forward so
+                    // executeAction can reuse it without a second DB round-trip.
+                    eligibleNodes = new LinkedHashMap<>(rawPageLength);
+                    for (NodeRef node : rawPage)
+                    {
+                        ChildAssociationRef parent = nodeService.getPrimaryParent(node);
+                        NodeRef freezeTarget = parent != null ? parent.getParentRef() : node;
+                        if (!freezeService.isFrozenOrHasFrozenChildren(freezeTarget))
+                        {
+                            eligibleNodes.put(node, parent);
+                        }
+                    }
+                }
+                finally
+                {
+                    results.close();
+                }
+
+                log.debug("Processing " + eligibleNodes.size() + " nodes");
 
                 // process search results
-                if (!resultNodes.isEmpty())
+                if (!eligibleNodes.isEmpty())
                 {
-                    executeAction(resultNodes);
+                    executeAction(eligibleNodes);
                 }
             }
             log.debug("Job Finished");
@@ -246,14 +316,18 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /**
      * Helper method that executes a disposition action
      *
-     * @param actionNodes
-     *            - the disposition actions to execute
+     * @param eligibleNodes
+     *            map of disposition action node to its pre-computed primary parent;
      */
-    private void executeAction(final List<NodeRef> actionNodes)
+    private void executeAction(final Map<NodeRef, ChildAssociationRef> eligibleNodes)
     {
         RetryingTransactionCallback<Boolean> processTranCB = () -> {
-            for (NodeRef actionNode : actionNodes)
+            for (Map.Entry<NodeRef, ChildAssociationRef> entry : eligibleNodes.entrySet())
             {
+                NodeRef actionNode = entry.getKey();
+                // Reuse the parent computed during the freeze-filter pass — no extra DB call.
+                ChildAssociationRef parent = entry.getValue();
+
                 if (!nodeService.exists(actionNode))
                 {
                     continue;
@@ -267,8 +341,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                     continue;
                 }
 
-                ChildAssociationRef parent = nodeService.getPrimaryParent(actionNode);
-                if (!parent.getTypeQName().equals(ASSOC_NEXT_DISPOSITION_ACTION))
+                if (parent == null || !parent.getTypeQName().equals(ASSOC_NEXT_DISPOSITION_ACTION))
                 {
                     continue;
                 }

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -349,7 +349,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 }
 
                 // execute search
-                ResultSet results = searchService.query(params);
+                ResultSet results = executeSearch(params,batchNumber);
                 if (results == null)
                 {
                     log.warn("Disposition lifecycle search returned null; stopping pagination.");
@@ -470,7 +470,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 // the async-indexing lag and the need for skip arithmetic.
                 params.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
 
-                ResultSet results = searchService.query(params);
+                ResultSet results = executeSearch(params,batchNumber);
                 if (results == null)
                 {
                     log.warn("Disposition lifecycle CMIS query returned null; stopping.");
@@ -543,6 +543,17 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         {
             log.debug(exception.getMessage());
         }
+    }
+
+    private ResultSet executeSearch(SearchParameters params, int batchNumber)
+    {
+        long start = System.currentTimeMillis();
+
+        ResultSet results = searchService.query(params);
+
+        long elapsed = System.currentTimeMillis() - start;
+        log.debug("Executed batch-{} search results in {} ms.", batchNumber, elapsed);
+        return results;
     }
 
     /**

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -37,11 +37,11 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.module.org_alfresco_module_rm.action.RecordsManagementActionService;
 import org.alfresco.module.org_alfresco_module_rm.freeze.FreezeService;
-import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
@@ -51,7 +51,6 @@ import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
 import org.alfresco.service.cmr.search.SearchService;
 import org.alfresco.service.cmr.security.PersonService;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * The Disposition Lifecycle Job Finds all disposition action nodes which are for disposition actions specified Where asOf &gt; now OR dispositionEventsEligible = true; Runs the cut off or retain action for eligible records.
@@ -82,7 +81,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         }
     }
 
-
     /** batching properties */
     private int batchSize;
     public static final int DEFAULT_BATCH_SIZE = 500;
@@ -110,15 +108,14 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     private QueryMode queryMode;
 
-
     /**
      *
      * @param queryMode
      */
-    public void setQueryMode(String queryMode) {
+    public void setQueryMode(String queryMode)
+    {
         this.queryMode = QueryMode.getQueryMode(queryMode);
     }
-
 
     /**
      * @param freezeService
@@ -216,12 +213,13 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     private String getActionFilterQuery()
     {
-        String actionFilterQuery=null;
+        String actionFilterQuery = null;
         StringBuilder sb = new StringBuilder("@rma\\:dispositionAction:(");
         boolean first = true;
         for (String dispositionAction : dispositionActions)
         {
-            if (!first) sb.append(" OR ");
+            if (!first)
+                sb.append(" OR ");
             sb.append("\"").append(dispositionAction).append("\"");
             first = false;
         }
@@ -231,9 +229,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     }
 
     /**
-     * Builds a transactional CMIS query for eligible disposition action nodes.
-     * The date cutoff is evaluated at call time so each job run uses the current date.
-     * Never cached — unlike {@link #getQuery()} — because the timestamp changes every run.
+     * Builds a transactional CMIS query for eligible disposition action nodes. The date cutoff is evaluated at call time so each job run uses the current date. Never cached — unlike {@link #getQuery()} — because the timestamp changes every run.
      *
      * @return CMIS SQL string
      */
@@ -248,7 +244,8 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         boolean first = true;
         for (String action : dispositionActions)
         {
-            if (!first) sb.append(",");
+            if (!first)
+                sb.append(",");
             sb.append("'").append(action).append("'");
             first = false;
         }
@@ -269,22 +266,20 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     {
         switch (queryMode)
         {
-            case CMIS:
-                executeImplCmis();
-                break;
-            case FTS_OPTIMIZED_QUERY:
-            case FTS_OPTIMIZED_CUTOFF:
-            case FTS_DEFAULT:
-            default:
-                executeImplFts();
-                break;
+        case CMIS:
+            executeImplCmis();
+            break;
+        case FTS_OPTIMIZED_QUERY:
+        case FTS_OPTIMIZED_CUTOFF:
+        case FTS_DEFAULT:
+        default:
+            executeImplFts();
+            break;
         }
     }
 
     /**
-     * FTS/index-based execution path (default).
-     * Paginates through search results using skipCount, relying on the search index
-     * (Elasticsearch or Solr) to resolve eligible nodes.
+     * FTS/index-based execution path (default). Paginates through search results using skipCount, relying on the search index (Elasticsearch or Solr) to resolve eligible nodes.
      */
     private void executeImplFts()
     {
@@ -325,31 +320,31 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 params.setMaxItems(batchSize);
                 switch (queryMode)
                 {
-                    case FTS_OPTIMIZED_QUERY:
-                        params.setQuery("TYPE:\"rma:dispositionAction\"");
-                        params.addFilterQuery(getActionFilterQuery());
-                        params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                        params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW])");
-                        params.setTrackScore(false);
-                        break;
-                    case FTS_OPTIMIZED_CUTOFF:
-                        params.setQuery("TYPE:\"rma:dispositionAction\"");
-                        params.addFilterQuery(getActionFilterQuery());
-                        params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                        // Negated future range — semantically equivalent to [MIN TO NOW] but may
-                        // produce a different ES execution plan worth benchmarking.
-                        params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
-                                + LocalDate.now().plusDays(1) + " TO MAX])");
-                        params.setTrackScore(false);
-                        break;
-                    case FTS_DEFAULT:
-                    default:
-                        params.setQuery(getQuery());
-                        break;
+                case FTS_OPTIMIZED_QUERY:
+                    params.setQuery("TYPE:\"rma:dispositionAction\"");
+                    params.addFilterQuery(getActionFilterQuery());
+                    params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
+                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW])");
+                    params.setTrackScore(false);
+                    break;
+                case FTS_OPTIMIZED_CUTOFF:
+                    params.setQuery("TYPE:\"rma:dispositionAction\"");
+                    params.addFilterQuery(getActionFilterQuery());
+                    params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
+                    // Negated future range — semantically equivalent to [MIN TO NOW] but may
+                    // produce a different ES execution plan worth benchmarking.
+                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
+                            + LocalDate.now().plusDays(1) + " TO MAX])");
+                    params.setTrackScore(false);
+                    break;
+                case FTS_DEFAULT:
+                default:
+                    params.setQuery(getQuery());
+                    break;
                 }
 
                 // execute search
-                ResultSet results = executeSearch(params,batchNumber);
+                ResultSet results = executeSearch(params, batchNumber);
                 if (results == null)
                 {
                     log.warn("Disposition lifecycle search returned null; stopping pagination.");
@@ -414,19 +409,14 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /**
      * CMIS/DB-based execution path (enabled by {@code useDbQuery=true}).
      *
-     * <p>Key differences from the FTS path:</p>
+     * <p>
+     * Key differences from the FTS path:
+     * </p>
      * <ul>
-     *   <li><b>Transactional consistency</b>: {@link QueryConsistency#TRANSACTIONAL} is forced
-     *       so the query always hits the DB. Processed nodes (with {@code dispositionActionCompletedAt}
-     *       set) are immediately invisible to the next query — no risk of re-processing.</li>
-     *   <li><b>Skip reset on progress</b>: When at least one node is actioned, skip resets to 0
-     *       because those nodes have vanished from the result set. The next query naturally returns
-     *       the next page of eligible nodes from the beginning.</li>
-     *   <li><b>Skip advance on no progress</b>: When a non-empty batch yields zero actioned nodes
-     *       (all frozen, deleted, or malformed) the skip advances by the raw page size. This prevents
-     *       an infinite loop over unprocessable records.</li>
-     *   <li><b>No index cap</b>: The 10 000-record Elasticsearch limit does not apply; the batch
-     *       size is the only cap and is fully configurable.</li>
+     * <li><b>Transactional consistency</b>: {@link QueryConsistency#TRANSACTIONAL} is forced so the query always hits the DB. Processed nodes (with {@code dispositionActionCompletedAt} set) are immediately invisible to the next query — no risk of re-processing.</li>
+     * <li><b>Skip reset on progress</b>: When at least one node is actioned, skip resets to 0 because those nodes have vanished from the result set. The next query naturally returns the next page of eligible nodes from the beginning.</li>
+     * <li><b>Skip advance on no progress</b>: When a non-empty batch yields zero actioned nodes (all frozen, deleted, or malformed) the skip advances by the raw page size. This prevents an infinite loop over unprocessable records.</li>
+     * <li><b>No index cap</b>: The 10 000-record Elasticsearch limit does not apply; the batch size is the only cap and is fully configurable.</li>
      * </ul>
      */
     private void executeImplCmis()
@@ -459,67 +449,19 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
             {
                 batchNumber++;
 
-                SearchParameters params = new SearchParameters();
-                params.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
-                params.setLanguage(SearchService.LANGUAGE_CMIS_ALFRESCO);
-                params.setQuery(getCmisQuery());
-                params.setMaxItems(batchSize);
-                params.setSkipCount(skipCount);
-                // Force DB routing. CMIS goes to the DB by default but being explicit here
-                // guards against any future routing change that could silently reintroduce
-                // the async-indexing lag and the need for skip arithmetic.
-                params.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
+                int[] batch = runCmisBatch(skipCount, batchNumber);
+                int rawPageSize = batch[0];
+                int eligible = batch[1];
+                int processed = batch[2];
 
-                ResultSet results = executeSearch(params,batchNumber);
-                if (results == null)
+                if (rawPageSize == 0)
                 {
-                    log.warn("Disposition lifecycle CMIS query returned null; stopping.");
+                    log.debug("No more eligible nodes found; job complete.");
                     break;
                 }
-
-                int rawPageSize;
-                Map<NodeRef, ChildAssociationRef> eligibleNodes;
-                try
-                {
-                    List<NodeRef> rawPage = results.getNodeRefs();
-                    rawPageSize = rawPage.size();
-                    if (rawPageSize == 0)
-                    {
-                        log.debug("No more eligible nodes found; job complete.");
-                        break;
-                    }
-                    totalReturned += rawPageSize;
-
-                    eligibleNodes = new LinkedHashMap<>(rawPageSize);
-                    for (NodeRef node : rawPage)
-                    {
-                        ChildAssociationRef parent = nodeService.getPrimaryParent(node);
-                        NodeRef freezeTarget = parent != null ? parent.getParentRef() : node;
-                        if (!freezeService.isFrozenOrHasFrozenChildren(freezeTarget))
-                        {
-                            eligibleNodes.put(node, parent);
-                        }
-                    }
-                }
-                finally
-                {
-                    results.close();
-                }
-
-                int batchEligible = eligibleNodes.size();
-                totalEligible += batchEligible;
-
-                log.debug("Batch {} — returned: {}, eligible (not frozen): {}, skip: {}",
-                        batchNumber, rawPageSize, batchEligible, skipCount);
-
-                int processed = 0;
-                if (!eligibleNodes.isEmpty())
-                {
-                    processed = executeAction(eligibleNodes);
-                }
+                totalReturned += rawPageSize;
+                totalEligible += eligible;
                 totalProcessed += processed;
-
-                log.debug("Batch {} — actioned: {}", batchNumber, processed);
 
                 if (processed > 0)
                 {
@@ -545,6 +487,70 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         }
     }
 
+    /**
+     * Runs one CMIS batch — search, freeze filter, and action execution — inside a single transaction.
+     *
+     * @param skipCount
+     *            current pagination offset
+     * @param batchNumber
+     *            1-based batch index used in log messages
+     * @return int[3] — {rawPageSize, eligible, processed}; all zeros when no results found
+     */
+    private int[] runCmisBatch(int skipCount, int batchNumber)
+    {
+        return retryingTransactionHelper.doInTransaction(() -> {
+            SearchParameters params = new SearchParameters();
+            params.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
+            params.setLanguage(SearchService.LANGUAGE_CMIS_ALFRESCO);
+            params.setQuery(getCmisQuery());
+            params.setMaxItems(batchSize);
+            params.setSkipCount(skipCount);
+            // Force DB routing. CMIS goes to the DB by default but being explicit here
+            // guards against any future routing change that could silently reintroduce
+            // the async-indexing lag and the need for skip arithmetic.
+            params.setQueryConsistency(QueryConsistency.TRANSACTIONAL);
+
+            ResultSet results = executeSearch(params, batchNumber);
+            if (results == null)
+            {
+                log.warn("Disposition lifecycle CMIS query returned null; stopping.");
+                return new int[]{0, 0, 0};
+            }
+            try
+            {
+                List<NodeRef> rawPage = results.getNodeRefs();
+                int rawPageSize = rawPage.size();
+                if (rawPageSize == 0)
+                {
+                    return new int[]{0, 0, 0};
+                }
+
+                Map<NodeRef, ChildAssociationRef> eligibleNodes = new LinkedHashMap<>(rawPageSize);
+                for (NodeRef node : rawPage)
+                {
+                    ChildAssociationRef parent = nodeService.getPrimaryParent(node);
+                    NodeRef freezeTarget = parent != null ? parent.getParentRef() : node;
+                    if (!freezeService.isFrozenOrHasFrozenChildren(freezeTarget))
+                    {
+                        eligibleNodes.put(node, parent);
+                    }
+                }
+                int eligible = eligibleNodes.size();
+                log.debug("Batch {} — returned: {}, eligible (not frozen): {}, skip: {}",
+                        batchNumber, rawPageSize, eligible, skipCount);
+
+                int processed = eligibleNodes.isEmpty() ? 0 : executeAction(eligibleNodes);
+                log.debug("Batch {} — actioned: {}", batchNumber, processed);
+
+                return new int[]{rawPageSize, eligible, processed};
+            }
+            finally
+            {
+                results.close();
+            }
+        }, false, true); // readOnly=false, requiresNew=true
+    }
+
     private ResultSet executeSearch(SearchParameters params, int batchNumber)
     {
         long start = System.currentTimeMillis();
@@ -559,62 +565,56 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /**
      * Executes the disposition action for each eligible node.
      *
-     * <p>Returns the number of nodes for which the action was actually executed.
-     * Nodes discarded by the three internal guards (does not exist, wrong action,
-     * wrong parent association) are not counted. The caller uses this count to
-     * detect a stuck batch — a non-empty batch that yields zero processed nodes —
-     * and advance the skip offset accordingly.</p>
+     * <p>
+     * Returns the number of nodes for which the action was actually executed. Nodes discarded by the three internal guards (does not exist, wrong action, wrong parent association) are not counted. The caller uses this count to detect a stuck batch — a non-empty batch that yields zero processed nodes — and advance the skip offset accordingly.
+     * </p>
      *
-     * @param eligibleNodes map of disposition action node to its pre-computed primary parent
+     * @param eligibleNodes
+     *            map of disposition action node to its pre-computed primary parent
      * @return number of nodes for which the disposition action was successfully invoked
      */
     private int executeAction(final Map<NodeRef, ChildAssociationRef> eligibleNodes)
     {
-        // int[] used so the lambda can mutate the counter.
-        final int[] processedCount = {0};
+        int processedCount = 0;
 
-        RetryingTransactionCallback<Boolean> processTranCB = () -> {
-            for (Map.Entry<NodeRef, ChildAssociationRef> entry : eligibleNodes.entrySet())
+        for (Map.Entry<NodeRef, ChildAssociationRef> entry : eligibleNodes.entrySet())
+        {
+            NodeRef actionNode = entry.getKey();
+            // Reuse the parent computed during the freeze-filter pass — no extra DB call.
+            ChildAssociationRef parent = entry.getValue();
+
+            if (!nodeService.exists(actionNode))
             {
-                NodeRef actionNode = entry.getKey();
-                // Reuse the parent computed during the freeze-filter pass — no extra DB call.
-                ChildAssociationRef parent = entry.getValue();
-
-                if (!nodeService.exists(actionNode))
-                {
-                    continue;
-                }
-
-                final String dispAction = (String) nodeService.getProperty(actionNode, PROP_DISPOSITION_ACTION);
-
-                // Run disposition action
-                if (dispAction == null || !dispositionActions.contains(dispAction))
-                {
-                    continue;
-                }
-
-                if (parent == null || !parent.getTypeQName().equals(ASSOC_NEXT_DISPOSITION_ACTION))
-                {
-                    continue;
-                }
-                Map<String, Serializable> props = Map.of(PARAM_NO_ERROR_CHECK, false);
-
-                try
-                {
-                    recordsManagementActionService
-                            .executeRecordsManagementAction(parent.getParentRef(), dispAction, props);
-                    processedCount[0]++;
-                    log.trace("Processed action: {} on {}", dispAction, parent);
-                }
-                catch (AlfrescoRuntimeException exception)
-                {
-                    log.debug(exception.getMessage());
-                }
+                continue;
             }
-            return Boolean.TRUE;
-        };
-        retryingTransactionHelper.doInTransaction(processTranCB, false, true);
-        return processedCount[0];
+
+            final String dispAction = (String) nodeService.getProperty(actionNode, PROP_DISPOSITION_ACTION);
+
+            // Run disposition action
+            if (dispAction == null || !dispositionActions.contains(dispAction))
+            {
+                continue;
+            }
+
+            if (parent == null || !parent.getTypeQName().equals(ASSOC_NEXT_DISPOSITION_ACTION))
+            {
+                continue;
+            }
+            Map<String, Serializable> props = Map.of(PARAM_NO_ERROR_CHECK, false);
+
+            try
+            {
+                recordsManagementActionService
+                        .executeRecordsManagementAction(parent.getParentRef(), dispAction, props);
+                processedCount++;
+                log.trace("Processed action: {} on {}", dispAction, parent);
+            }
+            catch (AlfrescoRuntimeException exception)
+            {
+                log.debug(exception.getMessage());
+            }
+        }
+        return processedCount;
     }
 
     public PersonService getPersonService()

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -30,6 +30,7 @@ package org.alfresco.module.org_alfresco_module_rm.job;
 import static org.alfresco.module.org_alfresco_module_rm.action.RMDispositionActionExecuterAbstractBase.PARAM_NO_ERROR_CHECK;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,6 +53,7 @@ import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
 import org.alfresco.service.cmr.search.SearchService;
 import org.alfresco.service.cmr.security.PersonService;
+import org.alfresco.util.DateUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -244,13 +246,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
                 if (enableElasticOptimization)
                 {
-                    // Lean main query + dedicated filter clauses — ES places these in
-                    // filter context (unscored, cacheable), improving query performance.
                     params.setQuery("TYPE:\"rma:dispositionAction\"");
                     params.addFilterQuery(getActionFilterQuery());
                     params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW])");
-                    params.setTrackScore(false);
+                    String tomorrow = LocalDate.now().plusDays(1).toString();
+                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:[" + tomorrow + " TO MAX])");
                 }
                 else
                 {

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -31,7 +31,7 @@ import static org.alfresco.module.org_alfresco_module_rm.action.RMDispositionAct
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,8 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.module.org_alfresco_module_rm.action.RecordsManagementActionService;
 import org.alfresco.module.org_alfresco_module_rm.freeze.FreezeService;
-import org.alfresco.repo.batch.BatchProcessor;
-import org.alfresco.repo.security.authentication.AuthenticationUtil;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -53,9 +51,7 @@ import org.alfresco.service.cmr.search.ResultSet;
 import org.alfresco.service.cmr.search.SearchParameters;
 import org.alfresco.service.cmr.search.SearchService;
 import org.alfresco.service.cmr.security.PersonService;
-import org.alfresco.util.DateUtil;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * The Disposition Lifecycle Job Finds all disposition action nodes which are for disposition actions specified Where asOf &gt; now OR dispositionEventsEligible = true; Runs the cut off or retain action for eligible records.
@@ -66,6 +62,26 @@ import org.apache.commons.logging.LogFactory;
 @Slf4j
 public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecuter
 {
+
+    public enum QueryMode
+    {
+        FTS_DEFAULT, FTS_OPTIMIZED_QUERY, FTS_OPTIMIZED_CUTOFF, CMIS;
+
+        public static QueryMode getQueryMode(String queryMode)
+        {
+            if (StringUtils.isBlank(queryMode))
+            {
+                return FTS_DEFAULT;
+            }
+
+            String normalizedQueryMode = queryMode.trim();
+            return EnumSet.allOf(QueryMode.class).stream()
+                    .filter(mode -> mode.name().equalsIgnoreCase(normalizedQueryMode))
+                    .findFirst()
+                    .orElse(FTS_DEFAULT);
+        }
+    }
+
 
     /** batching properties */
     private int batchSize;
@@ -92,11 +108,17 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** freeze service */
     private FreezeService freezeService;
 
-    /** when true, query conditions are pushed into ES filter context (unscored, cacheable) for better performance */
-    private boolean enableElasticOptimization = false;
+    private QueryMode queryMode;
 
-    /** when true, uses a transactional CMIS/DB query instead of an index-based FTS query */
-    private boolean useDbQuery = false;
+
+    /**
+     *
+     * @param queryMode
+     */
+    public void setQueryMode(String queryMode) {
+        this.queryMode = QueryMode.getQueryMode(queryMode);
+    }
+
 
     /**
      * @param freezeService
@@ -105,16 +127,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     public void setFreezeService(FreezeService freezeService)
     {
         this.freezeService = freezeService;
-    }
-
-    public void setEnableElasticOptimization(boolean enableElasticOptimization)
-    {
-        this.enableElasticOptimization = enableElasticOptimization;
-    }
-
-    public void setUseDbQuery(boolean useDbQuery)
-    {
-        this.useDbQuery = useDbQuery;
     }
 
     /**
@@ -255,13 +267,17 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     @Override
     public void executeImpl()
     {
-        if (useDbQuery)
+        switch (queryMode)
         {
-            executeImplCmis();
-        }
-        else
-        {
-            executeImplFts();
+            case CMIS:
+                executeImplCmis();
+                break;
+            case FTS_OPTIMIZED_QUERY:
+            case FTS_OPTIMIZED_CUTOFF:
+            case FTS_DEFAULT:
+            default:
+                executeImplFts();
+                break;
         }
     }
 
@@ -274,7 +290,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     {
         try
         {
-            log.debug("Job Starting");
+            log.debug("Job Starting (FTS mode)");
 
             if (dispositionActions == null || dispositionActions.isEmpty())
             {
@@ -293,29 +309,44 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
             log.trace("Using batch size of " + batchSize);
 
+            int batchNumber = 0;
+            int totalReturned = 0;
+            int totalEligible = 0;
+            int totalProcessed = 0;
+
             while (hasMore)
             {
+                batchNumber++;
+
                 SearchParameters params = new SearchParameters();
                 params.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
                 params.setLanguage(SearchService.LANGUAGE_FTS_ALFRESCO);
-
-                if (enableElasticOptimization)
-                {
-                    params.setQuery("TYPE:\"rma:dispositionAction\"");
-                    params.addFilterQuery(getActionFilterQuery());
-                    params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                    String tomorrow = LocalDate.now().plusDays(1).toString();
-                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:[" + tomorrow + " TO MAX])");
-                    params.setTrackScore(false);
-                }
-                else
-                {
-                    // Original combined FTS query — safe default, works with Solr and DB fallback.
-                    params.setQuery(getQuery());
-                }
-
                 params.setSkipCount(skipCount);
                 params.setMaxItems(batchSize);
+                switch (queryMode)
+                {
+                    case FTS_OPTIMIZED_QUERY:
+                        params.setQuery("TYPE:\"rma:dispositionAction\"");
+                        params.addFilterQuery(getActionFilterQuery());
+                        params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
+                        params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW])");
+                        params.setTrackScore(false);
+                        break;
+                    case FTS_OPTIMIZED_CUTOFF:
+                        params.setQuery("TYPE:\"rma:dispositionAction\"");
+                        params.addFilterQuery(getActionFilterQuery());
+                        params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
+                        // Negated future range — semantically equivalent to [MIN TO NOW] but may
+                        // produce a different ES execution plan worth benchmarking.
+                        params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
+                                + LocalDate.now().plusDays(1) + " TO MAX])");
+                        params.setTrackScore(false);
+                        break;
+                    case FTS_DEFAULT:
+                    default:
+                        params.setQuery(getQuery());
+                        break;
+                }
 
                 // execute search
                 ResultSet results = searchService.query(params);
@@ -326,14 +357,16 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 }
                 // Declared outside try so it remains in scope after results.close().
                 Map<NodeRef, ChildAssociationRef> eligibleNodes;
+                int rawPageLength;
                 try
                 {
                     List<NodeRef> rawPage = results.getNodeRefs();
                     // Advance skip by raw hit count so paging stays aligned with the index; post-search
                     // freeze filtering must not shrink the skip step (would duplicate or skip hits).
-                    int rawPageLength = rawPage.size();
+                    rawPageLength = rawPage.size();
                     hasMore = results.hasMore();
                     skipCount += rawPageLength;
+                    totalReturned += rawPageLength;
 
                     // Single getPrimaryParent call per node: result is carried forward so
                     // executeAction can reuse it without a second DB round-trip.
@@ -353,15 +386,24 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                     results.close();
                 }
 
-                log.debug("Processing " + eligibleNodes.size() + " nodes");
+                int batchEligible = eligibleNodes.size();
+                totalEligible += batchEligible;
 
-                // process search results
+                log.debug("Batch {} — returned: {}, eligible (not frozen): {}, hasMore: {}",
+                        batchNumber, rawPageLength, batchEligible, hasMore);
+
+                int batchProcessed = 0;
                 if (!eligibleNodes.isEmpty())
                 {
-                    executeAction(eligibleNodes);
+                    batchProcessed = executeAction(eligibleNodes);
                 }
+                totalProcessed += batchProcessed;
+
+                log.debug("Batch {} — actioned: {}", batchNumber, batchProcessed);
             }
-            log.debug("Job Finished");
+
+            log.debug("Job Finished (FTS mode) — batches: {}, total returned by search: {}, total eligible: {}, total actioned: {}",
+                    batchNumber, totalReturned, totalEligible, totalProcessed);
         }
         catch (AlfrescoRuntimeException exception)
         {
@@ -408,9 +450,15 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
             log.trace("Using batch size of " + batchSize);
 
             int skipCount = 0;
+            int batchNumber = 0;
+            int totalReturned = 0;
+            int totalEligible = 0;
+            int totalProcessed = 0;
 
             while (true)
             {
+                batchNumber++;
+
                 SearchParameters params = new SearchParameters();
                 params.addStore(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE);
                 params.setLanguage(SearchService.LANGUAGE_CMIS_ALFRESCO);
@@ -440,6 +488,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                         log.debug("No more eligible nodes found; job complete.");
                         break;
                     }
+                    totalReturned += rawPageSize;
 
                     eligibleNodes = new LinkedHashMap<>(rawPageSize);
                     for (NodeRef node : rawPage)
@@ -457,13 +506,20 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                     results.close();
                 }
 
-                log.debug("Processing " + eligibleNodes.size() + " nodes (CMIS mode)");
+                int batchEligible = eligibleNodes.size();
+                totalEligible += batchEligible;
+
+                log.debug("Batch {} — returned: {}, eligible (not frozen): {}, skip: {}",
+                        batchNumber, rawPageSize, batchEligible, skipCount);
 
                 int processed = 0;
                 if (!eligibleNodes.isEmpty())
                 {
                     processed = executeAction(eligibleNodes);
                 }
+                totalProcessed += processed;
+
+                log.debug("Batch {} — actioned: {}", batchNumber, processed);
 
                 if (processed > 0)
                 {
@@ -480,7 +536,8 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                     skipCount += rawPageSize;
                 }
             }
-            log.debug("Job Finished (CMIS/DB mode)");
+            log.debug("Job Finished (CMIS/DB mode) — batches: {}, total returned by query: {}, total eligible: {}, total actioned: {}",
+                    batchNumber, totalReturned, totalEligible, totalProcessed);
         }
         catch (AlfrescoRuntimeException exception)
         {
@@ -536,7 +593,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                     recordsManagementActionService
                             .executeRecordsManagementAction(parent.getParentRef(), dispAction, props);
                     processedCount[0]++;
-                    log.debug("Processed action: " + dispAction + "on" + parent);
+                    log.trace("Processed action: {} on {}", dispAction, parent);
                 }
                 catch (AlfrescoRuntimeException exception)
                 {

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -65,27 +65,28 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     public enum QueryMode
     {
-        FTS_DEFAULT, CMIS;
+        FTS, CMIS;
 
         public static QueryMode getQueryMode(String queryMode)
         {
             if (StringUtils.isBlank(queryMode))
             {
-                return FTS_DEFAULT;
+                return FTS;
             }
 
             String normalizedQueryMode = queryMode.trim();
             return EnumSet.allOf(QueryMode.class).stream()
                     .filter(mode -> mode.name().equalsIgnoreCase(normalizedQueryMode))
                     .findFirst()
-                    .orElse(FTS_DEFAULT);
+                    .orElse(FTS);
         }
     }
 
     /** batching properties */
     private int batchSize;
     public static final int DEFAULT_BATCH_SIZE = 500;
-    private static final int CMIS_QUERY_LIMIT = 100000;
+    public static final int DEFAULT_CMIS_QUERY_LIMIT = 100000;
+    private int cmisQueryLimit = DEFAULT_CMIS_QUERY_LIMIT;
 
     /** list of disposition actions to automatically execute */
     private List<String> dispositionActions;
@@ -108,7 +109,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** freeze service */
     private FreezeService freezeService;
 
-    private QueryMode queryMode = QueryMode.FTS_DEFAULT;
+    private QueryMode queryMode = QueryMode.FTS;
 
     /**
      *
@@ -142,6 +143,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     public void setBatchSize(int batchSize)
     {
         this.batchSize = batchSize;
+    }
+
+    public void setCmisQueryLimit(int cmisQueryLimit)
+    {
+        this.cmisQueryLimit = cmisQueryLimit;
     }
 
     /**
@@ -349,7 +355,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         }
         catch (AlfrescoRuntimeException exception)
         {
-            log.debug(exception.getMessage());
+            log.error("Disposition lifecycle job failed in FTS mode.", exception);
         }
     }
 
@@ -374,7 +380,14 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 batchSize = DEFAULT_BATCH_SIZE;
             }
 
+            if (cmisQueryLimit < 1)
+            {
+                log.debug("Invalid value for CMIS query limit: {} default value used instead.", cmisQueryLimit);
+                cmisQueryLimit = DEFAULT_CMIS_QUERY_LIMIT;
+            }
+
             log.trace("Using batch size of {}", batchSize);
+            log.trace("Using CMIS query limit of {}", cmisQueryLimit);
 
             int skipCount = 0;
             int batchNumber = 0;
@@ -382,7 +395,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
             int totalEligible = 0;
             int totalProcessed = 0;
 
-            while (totalReturned < CMIS_QUERY_LIMIT)
+            while (totalReturned < cmisQueryLimit)
             {
                 batchNumber++;
 
@@ -420,7 +433,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         }
         catch (AlfrescoRuntimeException exception)
         {
-            log.debug(exception.getMessage());
+            log.error("Disposition lifecycle job failed in CMIS mode.", exception);
         }
     }
 
@@ -548,7 +561,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
             }
             catch (AlfrescoRuntimeException exception)
             {
-                log.debug(exception.getMessage());
+                log.error("Failed to process disposition action '{}' for node {}.", dispAction, actionNode, exception);
             }
         }
         return processedCount;

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -330,7 +330,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 int batchProcessed = 0;
                 if (!eligibleNodes.isEmpty())
                 {
-                    batchProcessed = executeAction(eligibleNodes);
+                    batchProcessed = retryingTransactionHelper.doInTransaction(() -> executeAction(eligibleNodes), false, true);
                 }
                 totalProcessed += batchProcessed;
 

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -65,7 +65,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     public enum QueryMode
     {
-        FTS_DEFAULT,CMIS;
+        FTS_DEFAULT, CMIS;
 
         public static QueryMode getQueryMode(String queryMode)
         {
@@ -171,7 +171,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         this.searchService = searchService;
     }
 
-
     private String getActionFilterQuery()
     {
         String actionFilterQuery = null;
@@ -190,8 +189,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     }
 
     /**
-     * Builds a transactional CMIS query for eligible disposition action nodes.
-     * The date cutoff is evaluated at call time so each job run uses the current date.
+     * Builds a transactional CMIS query for eligible disposition action nodes. The date cutoff is evaluated at call time so each job run uses the current date.
      *
      * @return CMIS SQL string
      */
@@ -226,9 +224,12 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     @Override
     public void executeImpl()
     {
-        if (Objects.requireNonNull(queryMode) == QueryMode.CMIS) {
+        if (Objects.requireNonNull(queryMode) == QueryMode.CMIS)
+        {
             executeImplCmis();
-        } else {
+        }
+        else
+        {
             executeImplFts();
         }
     }
@@ -274,7 +275,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 params.setSkipCount(skipCount);
                 params.setMaxItems(batchSize);
 
-                //set query
+                // set query
                 params.setQuery("TYPE:\"rma:dispositionAction\"");
                 params.addFilterQuery(getActionFilterQuery());
                 params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -31,11 +31,11 @@ import static org.alfresco.module.org_alfresco_module_rm.action.RMDispositionAct
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -108,7 +108,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** freeze service */
     private FreezeService freezeService;
 
-    private QueryMode queryMode;
+    private QueryMode queryMode = QueryMode.FTS_DEFAULT;
 
     /**
      *
@@ -193,11 +193,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
      *
      * @return CMIS SQL string
      */
-    protected String getCmisQuery()
+    public String getCmisQuery()
     {
         // Use end-of-current-day in UTC so that records due today are always included
         // regardless of what time within the day the job fires.
-        String cutoff = LocalDate.now() + "T23:59:59.999Z";
+        String cutoff = LocalDate.now(ZoneOffset.UTC) + "T23:59:59.999Z";
 
         StringBuilder sb = new StringBuilder("SELECT * FROM rma:dispositionAction WHERE ");
         sb.append("rma:dispositionAction IN (");
@@ -214,7 +214,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         sb.append("AND (rma:dispositionEventsEligible = true ");
         sb.append("OR rma:dispositionAsOf <= TIMESTAMP '").append(cutoff).append("')");
 
-        log.debug("Constructed CMIS query: " + sb.toString());
+        log.debug("Constructed CMIS query: {}", sb);
         return sb.toString();
     }
 
@@ -224,7 +224,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     @Override
     public void executeImpl()
     {
-        if (Objects.requireNonNull(queryMode) == QueryMode.CMIS)
+        if (queryMode == QueryMode.CMIS)
         {
             executeImplCmis();
         }
@@ -254,11 +254,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
             if (batchSize < 1)
             {
-                log.debug("Invalid value for batch size: " + batchSize + " default value used instead.");
+                log.debug("Invalid value for batch size: {} default value used instead.", batchSize);
                 batchSize = DEFAULT_BATCH_SIZE;
             }
 
-            log.trace("Using batch size of " + batchSize);
+            log.trace("Using batch size of {}", batchSize);
 
             int batchNumber = 0;
             int totalReturned = 0;
@@ -279,7 +279,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 params.setQuery("TYPE:\"rma:dispositionAction\"");
                 params.addFilterQuery(getActionFilterQuery());
                 params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                // Negated future range — semantically equivalent to [MIN TO NOW] but may
                 params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
                         + LocalDate.now().plusDays(1) + " TO MAX])");
                 params.setTrackScore(false);
@@ -348,17 +347,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     }
 
     /**
-     * CMIS/DB-based execution path (enabled by {@code useDbQuery=true}).
-     *
-     * <p>
-     * Key differences from the FTS path:
-     * </p>
-     * <ul>
-     * <li><b>Transactional consistency</b>: {@link QueryConsistency#TRANSACTIONAL} is forced so the query always hits the DB. Processed nodes (with {@code dispositionActionCompletedAt} set) are immediately invisible to the next query — no risk of re-processing.</li>
-     * <li><b>Skip reset on progress</b>: When at least one node is actioned, skip resets to 0 because those nodes have vanished from the result set. The next query naturally returns the next page of eligible nodes from the beginning.</li>
-     * <li><b>Skip advance on no progress</b>: When a non-empty batch yields zero actioned nodes (all frozen, deleted, or malformed) the skip advances by the raw page size. This prevents an infinite loop over unprocessable records.</li>
-     * <li><b>No index cap</b>: The 10 000-record Elasticsearch limit does not apply; the batch size is the only cap and is fully configurable.</li>
-     * </ul>
+     * CMIS/DB-based execution path (enabled by {@code queryMode=CMIS}).
      */
     private void executeImplCmis()
     {
@@ -374,11 +363,11 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
             if (batchSize < 1)
             {
-                log.debug("Invalid value for batch size: " + batchSize + " default value used instead.");
+                log.debug("Invalid value for batch size: {} default value used instead.", batchSize);
                 batchSize = DEFAULT_BATCH_SIZE;
             }
 
-            log.trace("Using batch size of " + batchSize);
+            log.trace("Using batch size of {}", batchSize);
 
             int skipCount = 0;
             int batchNumber = 0;

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -35,6 +35,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -64,7 +65,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     public enum QueryMode
     {
-        FTS_DEFAULT, FTS_OPTIMIZED_QUERY, FTS_OPTIMIZED_CUTOFF, CMIS;
+        FTS_DEFAULT,CMIS;
 
         public static QueryMode getQueryMode(String queryMode)
         {
@@ -84,6 +85,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** batching properties */
     private int batchSize;
     public static final int DEFAULT_BATCH_SIZE = 500;
+    private static final int CMIS_QUERY_LIMIT = 100000;
 
     /** list of disposition actions to automatically execute */
     private List<String> dispositionActions;
@@ -169,47 +171,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         this.searchService = searchService;
     }
 
-    /**
-     * Get the search query string.
-     *
-     * @return job query string
-     */
-    protected String getQuery()
-    {
-        if (query == null)
-        {
-            StringBuilder sb = new StringBuilder();
-
-            sb.append("TYPE:\"rma:dispositionAction\" AND ");
-            sb.append("(@rma\\:dispositionAction:(");
-
-            boolean bFirst = true;
-            for (String dispositionAction : dispositionActions)
-            {
-                if (bFirst)
-                {
-                    bFirst = false;
-                }
-                else
-                {
-                    sb.append(" OR ");
-                }
-
-                sb.append("\"").append(dispositionAction).append("\"");
-            }
-
-            sb.append("))");
-            sb.append(" AND ISUNSET:\"rma:dispositionActionCompletedAt\" ");
-            sb.append(" AND ( ");
-            sb.append("@rma\\:dispositionEventsEligible:true ");
-            sb.append("OR @rma\\:dispositionAsOf:[MIN TO NOW] ");
-            sb.append(") ");
-
-            query = sb.toString();
-        }
-
-        return query;
-    }
 
     private String getActionFilterQuery()
     {
@@ -229,7 +190,8 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     }
 
     /**
-     * Builds a transactional CMIS query for eligible disposition action nodes. The date cutoff is evaluated at call time so each job run uses the current date. Never cached — unlike {@link #getQuery()} — because the timestamp changes every run.
+     * Builds a transactional CMIS query for eligible disposition action nodes.
+     * The date cutoff is evaluated at call time so each job run uses the current date.
      *
      * @return CMIS SQL string
      */
@@ -264,17 +226,10 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     @Override
     public void executeImpl()
     {
-        switch (queryMode)
-        {
-        case CMIS:
+        if (Objects.requireNonNull(queryMode) == QueryMode.CMIS) {
             executeImplCmis();
-            break;
-        case FTS_OPTIMIZED_QUERY:
-        case FTS_OPTIMIZED_CUTOFF:
-        case FTS_DEFAULT:
-        default:
+        } else {
             executeImplFts();
-            break;
         }
     }
 
@@ -318,30 +273,15 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 params.setLanguage(SearchService.LANGUAGE_FTS_ALFRESCO);
                 params.setSkipCount(skipCount);
                 params.setMaxItems(batchSize);
-                switch (queryMode)
-                {
-                case FTS_OPTIMIZED_QUERY:
-                    params.setQuery("TYPE:\"rma:dispositionAction\"");
-                    params.addFilterQuery(getActionFilterQuery());
-                    params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW])");
-                    params.setTrackScore(false);
-                    break;
-                case FTS_OPTIMIZED_CUTOFF:
-                    params.setQuery("TYPE:\"rma:dispositionAction\"");
-                    params.addFilterQuery(getActionFilterQuery());
-                    params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                    // Negated future range — semantically equivalent to [MIN TO NOW] but may
-                    // produce a different ES execution plan worth benchmarking.
-                    params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
-                            + LocalDate.now().plusDays(1) + " TO MAX])");
-                    params.setTrackScore(false);
-                    break;
-                case FTS_DEFAULT:
-                default:
-                    params.setQuery(getQuery());
-                    break;
-                }
+
+                //set query
+                params.setQuery("TYPE:\"rma:dispositionAction\"");
+                params.addFilterQuery(getActionFilterQuery());
+                params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
+                // Negated future range — semantically equivalent to [MIN TO NOW] but may
+                params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
+                        + LocalDate.now().plusDays(1) + " TO MAX])");
+                params.setTrackScore(false);
 
                 // execute search
                 ResultSet results = executeSearch(params, batchNumber);
@@ -445,7 +385,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
             int totalEligible = 0;
             int totalProcessed = 0;
 
-            while (true)
+            while (totalReturned < CMIS_QUERY_LIMIT)
             {
                 batchNumber++;
 

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -173,7 +173,7 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     private String getActionFilterQuery()
     {
-        String actionFilterQuery=null;
+        String actionFilterQuery = null;
         StringBuilder sb = new StringBuilder("@rma\\:dispositionAction:(");
         boolean first = true;
         for (String dispositionAction : dispositionActions)
@@ -185,11 +185,10 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
             sb.append("\"").append(dispositionAction).append("\"");
             first = false;
         }
-        if(dispositionActions.size() > 1)
+        if (dispositionActions.size() > 1)
         {
             actionFilterQuery = sb.append(")").toString();
         }
-
 
         return actionFilterQuery;
     }

--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -173,17 +173,23 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
 
     private String getActionFilterQuery()
     {
-        String actionFilterQuery = null;
+        String actionFilterQuery=null;
         StringBuilder sb = new StringBuilder("@rma\\:dispositionAction:(");
         boolean first = true;
         for (String dispositionAction : dispositionActions)
         {
             if (!first)
+            {
                 sb.append(" OR ");
+            }
             sb.append("\"").append(dispositionAction).append("\"");
             first = false;
         }
-        actionFilterQuery = sb.append(")").toString();
+        if(dispositionActions.size() > 1)
+        {
+            actionFilterQuery = sb.append(")").toString();
+        }
+
 
         return actionFilterQuery;
     }
@@ -205,7 +211,9 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
         for (String action : dispositionActions)
         {
             if (!first)
+            {
                 sb.append(",");
+            }
             sb.append("'").append(action).append("'");
             first = false;
         }

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
@@ -75,8 +75,8 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
     private static final int BATCH_SIZE = 1;
 
     /** test query snippet */
-    private static final String QUERY = "\"" + CUTOFF + "\" OR \"" + RETAIN + "\"";
-
+    private static final String QUERY= "TYPE:\"rma:dispositionAction\"";
+    private static final String FILTER_QUERY = "@rma\\:dispositionAction:(\"cutoff\" OR \"retain\")";
     /** mocked result set */
     @Mock ResultSet mockedResultSet;
 
@@ -118,6 +118,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         ArgumentCaptor<SearchParameters> paramsCaptor = ArgumentCaptor.forClass(SearchParameters.class);
         verify(mockedSearchService, times(numberOfInvocation)).query(paramsCaptor.capture());
         assertTrue(paramsCaptor.getValue().getQuery().contains(QUERY));
+        assertTrue(paramsCaptor.getValue().getFilterQueries().toString().contains(FILTER_QUERY));
         verify(mockedResultSet, times(numberOfInvocation)).getNodeRefs();
         verify(mockedResultSet, times(numberOfInvocation)).close();
     }
@@ -146,7 +147,6 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
     /**
      * When the disposition actions do not match those that can be processed automatically.
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void dispositionActionDoesNotMatch()
     {
@@ -174,12 +174,10 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         // ensure the query is executed and closed
         verifyQueryTimes(2);
 
-        // ensure work is executed in transaction for each node processed
+        // ensure node existence is checked for each result
         verify(mockedNodeService, times(2)).exists(any(NodeRef.class));
-        verify(mockedRetryingTransactionHelper, times(2)).doInTransaction(any(RetryingTransactionCallback.class),
-            anyBoolean(), anyBoolean());
 
-        // ensure each node is process correctly
+        // ensure each node is processed correctly
         verify(mockedNodeService, times(1)).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
         verify(mockedNodeService, times(1)).getProperty(node2, RecordsManagementModel.PROP_DISPOSITION_ACTION);
 
@@ -221,7 +219,6 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
     /**
      * When there are disposition actions eligible for processing
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void dispositionActionProcessed()
     {
@@ -254,19 +251,17 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         // ensure the query is executed and closed
         verifyQueryTimes(2);
 
-        // ensure work is executed in transaction for each node processed
+        // ensure work is executed for each node
         verify(mockedNodeService, times(2)).exists(any(NodeRef.class));
-        verify(mockedRetryingTransactionHelper, times(2)).doInTransaction(any(RetryingTransactionCallback.class),
-            anyBoolean(), anyBoolean());
 
-        // ensure each node is process correctly
+        // ensure each node is processed correctly
         // node1
         verify(mockedNodeService, times(1)).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
-        verify(mockedNodeService, times(3)).getPrimaryParent(node1);
+        verify(mockedNodeService, times(1)).getPrimaryParent(node1);
         verify(mockedRecordsManagementActionService, times(1)).executeRecordsManagementAction(eq(parent), eq(CUTOFF), anyMap());
         // node2
         verify(mockedNodeService, times(1)).getProperty(node2, RecordsManagementModel.PROP_DISPOSITION_ACTION);
-        verify(mockedNodeService, times(3)).getPrimaryParent(node2);
+        verify(mockedNodeService, times(1)).getPrimaryParent(node2);
         verify(mockedRecordsManagementActionService, times(1)).executeRecordsManagementAction(eq(parent), eq(RETAIN), anyMap());
 
         // ensure no more interactions
@@ -274,20 +269,138 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
     }
 
     /**
-     * Brittle unit test that simply checks the generated query is an exact string when the supplied disposition actions
-     * are "CUTOFF" and "RETAIN" (see {@link #before}).
+     * Verify that getCmisQuery() generates a valid CMIS query containing the required action filters and conditions.
+     * The query includes a dynamic UTC timestamp cutoff, so we verify key components rather than exact string match.
      */
     @Test
-    public void testGetQuery()
+    public void testGetCmisQuery()
     {
-        String actual = executer.getQuery();
+        String actual = executer.getCmisQuery();
 
-        String expected = "TYPE:\"rma:dispositionAction\" AND " +
-                "(@rma\\:dispositionAction:(\"cutoff\" OR \"retain\")) " +
-                "AND ISUNSET:\"rma:dispositionActionCompletedAt\"  " +
-                "AND ( @rma\\:dispositionEventsEligible:true OR @rma\\:dispositionAsOf:[MIN TO NOW] ) ";
+        // Verify the CMIS query contains all required components
+        assertTrue("CMIS query should start with SELECT statement", actual.contains("SELECT * FROM rma:dispositionAction"));
+        assertTrue("CMIS query should filter by disposition actions", actual.contains("rma:dispositionAction IN ('cutoff','retain')"));
+        assertTrue("CMIS query should exclude completed actions", actual.contains("rma:dispositionActionCompletedAt IS NULL"));
+        assertTrue("CMIS query should check for eligible events", actual.contains("rma:dispositionEventsEligible = true"));
+        assertTrue("CMIS query should check asOf date with UTC timestamp", actual.contains("rma:dispositionAsOf <= TIMESTAMP"));
+        assertTrue("CMIS query should use UTC timezone (Z suffix)", actual.contains("T23:59:59.999Z"));
+    }
 
-        assertEquals(expected, actual);
+    /**
+     * CMIS mode: when there are no results the job finishes after a single query.
+     */
+    @Test
+    public void cmisNoResultsInQuery()
+    {
+        executer.setQueryMode("CMIS");
+        doReturn(Collections.EMPTY_LIST).when(mockedResultSet).getNodeRefs();
+
+        executer.executeImpl();
+
+        verify(mockedSearchService, times(1)).query(any(SearchParameters.class));
+        verify(mockedResultSet, times(1)).getNodeRefs();
+        verify(mockedResultSet, times(1)).close();
+        verifyNoMoreInteractions(mockedNodeService, mockedRecordsManagementActionService);
+    }
+
+    /**
+     * CMIS mode: when a node no longer exists it is skipped, no action is executed,
+     * and the skip offset advances so the job does not loop on the same batch forever.
+     */
+    @Test
+    public void cmisNodeDoesNotExist()
+    {
+        executer.setQueryMode("CMIS");
+        NodeRef node1 = generateNodeRef(null, false); // exists = false
+        ChildAssociationRef parentAssoc = new ChildAssociationRef(
+                ASSOC_NEXT_DISPOSITION_ACTION, generateNodeRef(), generateQName(), generateNodeRef());
+        doReturn(parentAssoc).when(mockedNodeService).getPrimaryParent(node1);
+        doReturn(false).when(mockedFreezeService).isFrozenOrHasFrozenChildren(any(NodeRef.class));
+
+        // first batch returns the non-existent node; second batch (after skip advance) is empty
+        when(mockedResultSet.getNodeRefs())
+                .thenReturn(Collections.singletonList(node1))
+                .thenReturn(Collections.emptyList());
+
+        executer.executeImpl();
+
+        // two queries: one for the real batch, one after skip advance that finds nothing
+        verify(mockedSearchService, times(2)).query(any(SearchParameters.class));
+        verify(mockedNodeService, times(1)).getPrimaryParent(node1);
+        verify(mockedNodeService, times(1)).exists(node1);
+        verifyNoMoreInteractions(mockedRecordsManagementActionService);
+    }
+
+    /**
+     * CMIS mode: when the disposition action on the node does not match any configured
+     * action the node is skipped and the skip offset advances.
+     */
+    @Test
+    public void cmisDispositionActionDoesNotMatch()
+    {
+        executer.setQueryMode("CMIS");
+        NodeRef node1 = generateNodeRef();
+        ChildAssociationRef parentAssoc = new ChildAssociationRef(
+                ASSOC_NEXT_DISPOSITION_ACTION, generateNodeRef(), generateQName(), generateNodeRef());
+        doReturn(DESTROY).when(mockedNodeService).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
+        doReturn(parentAssoc).when(mockedNodeService).getPrimaryParent(node1);
+        doReturn(false).when(mockedFreezeService).isFrozenOrHasFrozenChildren(any(NodeRef.class));
+
+        when(mockedResultSet.getNodeRefs())
+                .thenReturn(Collections.singletonList(node1))
+                .thenReturn(Collections.emptyList());
+
+        executer.executeImpl();
+
+        verify(mockedSearchService, times(2)).query(any(SearchParameters.class));
+        verify(mockedNodeService, times(1)).getPrimaryParent(node1);
+        verify(mockedNodeService, times(1)).exists(node1);
+        verify(mockedNodeService, times(1)).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
+        verifyNoMoreInteractions(mockedRecordsManagementActionService);
+    }
+
+    /**
+     * CMIS mode: when disposition actions are eligible they are processed, the skip offset
+     * is reset to zero after a successful batch, and the job continues until no more results.
+     */
+    @Test
+    public void cmisDispositionActionProcessed()
+    {
+        executer.setQueryMode("CMIS");
+        NodeRef node1 = generateNodeRef();
+        NodeRef node2 = generateNodeRef();
+        NodeRef parent = generateNodeRef();
+        ChildAssociationRef parentAssoc = new ChildAssociationRef(
+                ASSOC_NEXT_DISPOSITION_ACTION, parent, generateQName(), generateNodeRef());
+
+        doReturn(CUTOFF).when(mockedNodeService).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
+        doReturn(RETAIN).when(mockedNodeService).getProperty(node2, RecordsManagementModel.PROP_DISPOSITION_ACTION);
+        doReturn(parentAssoc).when(mockedNodeService).getPrimaryParent(any(NodeRef.class));
+        doReturn(false).when(mockedFreezeService).isFrozenOrHasFrozenChildren(any(NodeRef.class));
+
+        // batch 1 → node1 processed → skip resets to 0
+        // batch 2 → node2 processed → skip resets to 0
+        // batch 3 → empty → loop stops
+        when(mockedResultSet.getNodeRefs())
+                .thenReturn(Collections.singletonList(node1))
+                .thenReturn(Collections.singletonList(node2))
+                .thenReturn(Collections.emptyList());
+
+        executer.executeImpl();
+
+        verify(mockedSearchService, times(3)).query(any(SearchParameters.class));
+
+        verify(mockedNodeService, times(1)).exists(node1);
+        verify(mockedNodeService, times(1)).getPrimaryParent(node1);
+        verify(mockedNodeService, times(1)).getProperty(node1, RecordsManagementModel.PROP_DISPOSITION_ACTION);
+        verify(mockedRecordsManagementActionService, times(1))
+                .executeRecordsManagementAction(eq(parent), eq(CUTOFF), anyMap());
+
+        verify(mockedNodeService, times(1)).exists(node2);
+        verify(mockedNodeService, times(1)).getPrimaryParent(node2);
+        verify(mockedNodeService, times(1)).getProperty(node2, RecordsManagementModel.PROP_DISPOSITION_ACTION);
+        verify(mockedRecordsManagementActionService, times(1))
+                .executeRecordsManagementAction(eq(parent), eq(RETAIN), anyMap());
     }
 
     /**
@@ -348,8 +461,8 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         executer.executeImpl();
 
         ArgumentCaptor<SearchParameters> paramsCaptor = ArgumentCaptor.forClass(SearchParameters.class);
-        verify(mockedSearchService, times(1)).query(paramsCaptor.capture());;
-        assertEquals(executer.DEFAULT_BATCH_SIZE, paramsCaptor.getValue().getMaxItems());
+        verify(mockedSearchService, times(1)).query(paramsCaptor.capture());
+        assertEquals(DispositionLifecycleJobExecuter.DEFAULT_BATCH_SIZE, paramsCaptor.getValue().getMaxItems());
         verify(mockedResultSet, times(1)).close();
 
         executer.setBatchSize(BATCH_SIZE);

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
@@ -404,6 +404,32 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
     }
 
     /**
+     * CMIS mode: the configured query limit caps how many rows are read in one run.
+     */
+    @Test
+    public void cmisQueryLimitStopsLoop()
+    {
+        executer.setQueryMode("CMIS");
+        executer.setCmisQueryLimit(2);
+
+        NodeRef node1 = generateNodeRef();
+        ChildAssociationRef parentAssoc = new ChildAssociationRef(
+                ASSOC_NEXT_DISPOSITION_ACTION, generateNodeRef(), generateQName(), generateNodeRef());
+        doReturn(parentAssoc).when(mockedNodeService).getPrimaryParent(node1);
+        doReturn(false).when(mockedFreezeService).isFrozenOrHasFrozenChildren(any(NodeRef.class));
+        doReturn(false).when(mockedNodeService).exists(node1);
+
+        when(mockedResultSet.getNodeRefs())
+                .thenReturn(Collections.singletonList(node1));
+
+        executer.executeImpl();
+
+        verify(mockedSearchService, times(2)).query(any(SearchParameters.class));
+        verify(mockedResultSet, times(2)).getNodeRefs();
+        verify(mockedResultSet, times(2)).close();
+    }
+
+    /**
      * Given the maximum page of elements for search service is 2
      *       and search service finds more than one page of elements
      * When the job executer runs

--- a/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
@@ -196,6 +196,8 @@ public class SearchParameters implements BasicSearchParameters
      */
     private int trackTotalHits;
 
+    private boolean trackScore=true;
+
     /**
      * Default constructor
      */
@@ -247,6 +249,7 @@ public class SearchParameters implements BasicSearchParameters
         sp.ranges = this.ranges;
         sp.timezone = this.timezone;
         sp.trackTotalHits = this.trackTotalHits;
+        sp.trackScore=this.trackScore;
         return sp;
     }
 
@@ -272,6 +275,24 @@ public class SearchParameters implements BasicSearchParameters
         {
             setLimitBy(LimitBy.UNLIMITED);
         }
+    }
+
+
+    public boolean isTrackScore()
+    {
+        return trackScore;
+    }
+
+    /**
+     * Controls whether relevance scores are computed for search hits.
+     * This hint is only acted upon by the Elasticsearch search subsystem;
+     * Solr and DB query paths ignore it.
+     *
+     * @param trackScore true to compute scores (default), false to skip scoring for better performance
+     */
+    public void setTrackScore(boolean trackScore)
+    {
+        this.trackScore = trackScore;
     }
 
     /**

--- a/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
+++ b/data-model/src/main/java/org/alfresco/service/cmr/search/SearchParameters.java
@@ -196,7 +196,7 @@ public class SearchParameters implements BasicSearchParameters
      */
     private int trackTotalHits;
 
-    private boolean trackScore=true;
+    private boolean trackScore = true;
 
     /**
      * Default constructor
@@ -249,7 +249,7 @@ public class SearchParameters implements BasicSearchParameters
         sp.ranges = this.ranges;
         sp.timezone = this.timezone;
         sp.trackTotalHits = this.trackTotalHits;
-        sp.trackScore=this.trackScore;
+        sp.trackScore = this.trackScore;
         return sp;
     }
 
@@ -277,18 +277,16 @@ public class SearchParameters implements BasicSearchParameters
         }
     }
 
-
     public boolean isTrackScore()
     {
         return trackScore;
     }
 
     /**
-     * Controls whether relevance scores are computed for search hits.
-     * This hint is only acted upon by the Elasticsearch search subsystem;
-     * Solr and DB query paths ignore it.
+     * Controls whether relevance scores are computed for search hits. This hint is only acted upon by the Elasticsearch search subsystem; Solr and DB query paths ignore it.
      *
-     * @param trackScore true to compute scores (default), false to skip scoring for better performance
+     * @param trackScore
+     *            true to compute scores (default), false to skip scoring for better performance
      */
     public void setTrackScore(boolean trackScore)
     {


### PR DESCRIPTION
This pull request introduces a new "query mode" feature to the `DispositionLifecycleJobExecuter`, enabling the disposition lifecycle job to be executed using either the default FTS (Full Text Search) or CMIS (Content Management Interoperability Services) query modes. The main goal is to provide an alternative, database-backed execution path (CMIS) that avoids limitations and inconsistencies of the search index, especially for large result sets and transactional consistency. The implementation includes significant refactoring and enhancements to support this dual-mode operation, as well as improvements to logging, configurability, and batch processing logic.

**Query Mode Support and Job Execution Enhancements**

* Added a new `queryMode` property (configurable via `alfresco-global.properties` and Spring XML) and supporting logic in `DispositionLifecycleJobExecuter` to allow switching between FTS (default) and CMIS query modes. Includes a robust enum-based implementation and setter. [[1]](diffhunk://#diff-0ff8077d5dbb0d56d8560273c5b264eae36cc1b444cba2ffe88b2bc92c47333aR77-R78) [[2]](diffhunk://#diff-49d1554e8d9feaa34b6cb1de7c5facd408460b9c5b038438295389f4af552c4dR85) [[3]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877R66-R88) [[4]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877R111-R121)

**CMIS/DB Query Path Implementation**

* Implemented a complete CMIS-based job execution path (`executeImplCmis` and helpers), providing transactional consistency, improved pagination, and avoidance of search index limitations. This includes a new CMIS query builder, batch processing with skip logic, and handling for unprocessable records. [[1]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877L140-R244) [[2]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877L247-R526)

**FTS Query**

* Refactored the FTS-based execution path (`executeImplFts`) for clarity and maintainability, including improved query construction, batch tracking, detailed logging, and optimized freeze filtering. [[1]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877L140-R244) [[2]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877L200) [[3]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877R263-R342)

**Action Execution Improvements**

* Rewrote the action execution logic to operate on a map of eligible nodes with their pre-computed parent associations, reducing redundant DB calls and improving efficiency. The method now returns the number of processed nodes for better batch control. [[1]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877L247-R526) [[2]](diffhunk://#diff-798628b93cec8414060925132262bab0834238b3bea01f057a47f0201e403877L270-R558)

**Minor Enhancements**

* Added a `trackScore` property to `SearchParameters` (defaulting to true) to allow disabling score tracking for performance optimization during job execution.

**N.B**  when running the CMIS query for millions of  records and we should follow this procedure to prevent DB bottlenecks https://hyland.atlassian.net/browse/MNT-25579?focusedCommentId=2865018
 