### PR TITLE
Prevent SSTI/RCE by blocking modifications to executable folders in Data Dictionary

### DIFF
--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -4046,11 +4046,15 @@ public class NodesImpl implements Nodes
                     break;
                 }
 
+                // Fetch parentAssoc once per iteration — reused for both the
+                // protected-folder check and upward traversal to avoid double repository calls.
+                ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(current);
+
                 // Block only executable system paths under Data Dictionary
                 // (Web Scripts, Messages, Scripts). This is the SSTI/RCE
                 // injection surface. Other Data Dictionary children remain editable
                 // by admins (e.g. Node Templates, Space Templates, Email Templates).
-                if (isProtectedExecutableSystemFolder(current, dataDictionary))
+                if (isProtectedExecutableSystemFolder(current, parentAssoc, dataDictionary, type))
                 {
                     throw new PermissionDeniedException(
                             "Cannot perform operation on system path for requested node id '" + nodeRef.getId()
@@ -4065,10 +4069,7 @@ public class NodesImpl implements Nodes
                     break;
                 }
 
-                ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(current);
-
-                if (parentAssoc == null ||
-                        parentAssoc.getParentRef() == null)
+                if (parentAssoc == null || parentAssoc.getParentRef() == null)
                 {
                     break;
                 }
@@ -4104,18 +4105,16 @@ public class NodesImpl implements Nodes
     /**
      * @return {@code true} if {@code nodeRef} is a direct child of Data Dictionary whose name matches a protected executable folder (Web Scripts).
      */
-    private boolean isProtectedExecutableSystemFolder(NodeRef nodeRef, NodeRef dataDictionary)
+    private boolean isProtectedExecutableSystemFolder(NodeRef nodeRef, ChildAssociationRef parentAssoc, NodeRef dataDictionary, QName nodeType)
     {
-        if (dataDictionary == null || nodeRef == null)
+        if (dataDictionary == null || nodeRef == null || parentAssoc == null)
         {
             return false;
         }
-        ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(nodeRef);
-        if (parentAssoc == null || !dataDictionary.equals(parentAssoc.getParentRef()))
+        if (!dataDictionary.equals(parentAssoc.getParentRef()))
         {
             return false;
         }
-        QName nodeType = nodeService.getType(nodeRef);
         if (nodeType == null || !dictionaryService.isSubClass(nodeType, ContentModel.TYPE_FOLDER))
         {
             return false;

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -4014,7 +4014,6 @@ public class NodesImpl implements Nodes
         }
     }
 
-
     /**
      * Throws {@link PermissionDeniedException} if any ancestor node is an executable system-managed path (e.g. Data Dictionary/Web Scripts). Modifications under Data Dictionary itself (folder templates, node templates, etc.) remain allowed for admins so existing UI / regression flows are not impacted.
      */

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -4009,10 +4009,7 @@ public class NodesImpl implements Nodes
     }
 
     /**
-     * Names of folders directly under Data Dictionary that contain executable artifacts
-     * (FreeMarker templates, JavaScript controllers, messages). Modifications to
-     * content under these folders via the REST API are blocked to prevent SSTI/RCE via
-     * sandbox escape (e.g. overwriting web script templates).
+     * Names of folders directly under Data Dictionary that contain executable artifacts (FreeMarker templates, JavaScript controllers, messages). Modifications to content under these folders via the REST API are blocked to prevent SSTI/RCE via sandbox escape (e.g. overwriting web script templates).
      */
     private static final Set<String> PROTECTED_DD_EXECUTABLE_FOLDERS = new HashSet<>(Arrays.asList(
             "Web Scripts",
@@ -4021,10 +4018,7 @@ public class NodesImpl implements Nodes
             "Scripts"));
 
     /**
-     * Throws {@link PermissionDeniedException} if any ancestor node is an executable
-     * system-managed path (e.g. Data Dictionary/Web Scripts). Modifications under
-     * Data Dictionary itself (folder templates, node templates, etc.) remain allowed
-     * for admins so existing UI / regression flows are not impacted.
+     * Throws {@link PermissionDeniedException} if any ancestor node is an executable system-managed path (e.g. Data Dictionary/Web Scripts). Modifications under Data Dictionary itself (folder templates, node templates, etc.) remain allowed for admins so existing UI / regression flows are not impacted.
      */
     protected void checkNotSystemPath(NodeRef nodeRef)
     {
@@ -4089,8 +4083,7 @@ public class NodesImpl implements Nodes
     }
 
     /**
-     * @return the Data Dictionary {@link NodeRef} for the current tenant, or {@code null}
-     *         if it cannot be resolved.
+     * @return the Data Dictionary {@link NodeRef} for the current tenant, or {@code null} if it cannot be resolved.
      */
     private NodeRef getDataDictionaryNodeRef()
     {
@@ -4112,8 +4105,7 @@ public class NodesImpl implements Nodes
     }
 
     /**
-     * @return {@code true} if {@code nodeRef} is a direct child of Data Dictionary whose
-     *         name matches a protected executable folder (Web Scripts).
+     * @return {@code true} if {@code nodeRef} is a direct child of Data Dictionary whose name matches a protected executable folder (Web Scripts).
      */
     private boolean isProtectedExecutableSystemFolder(NodeRef nodeRef, NodeRef dataDictionary)
     {

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -4009,7 +4009,22 @@ public class NodesImpl implements Nodes
     }
 
     /**
-     * Throws {@link PermissionDeniedException} if any ancestor node is a system-protected path.
+     * Names of folders directly under Data Dictionary that contain executable artifacts
+     * (FreeMarker templates, JavaScript controllers, models, messages). Modifications to
+     * content under these folders via the REST API are blocked to prevent SSTI/RCE via
+     * sandbox escape (e.g. overwriting web script templates).
+     */
+    private static final Set<String> PROTECTED_DD_EXECUTABLE_FOLDERS = new HashSet<>(Arrays.asList(
+            "Web Scripts",
+            "Web Scripts Extensions",
+            "Messages",
+            "Scripts"));
+
+    /**
+     * Throws {@link PermissionDeniedException} if any ancestor node is an executable
+     * system-managed path (e.g. Data Dictionary/Web Scripts). Modifications under
+     * Data Dictionary itself (folder templates, node templates, etc.) remain allowed
+     * for admins so existing UI / regression flows are not impacted.
      */
     protected void checkNotSystemPath(NodeRef nodeRef)
     {
@@ -4024,6 +4039,7 @@ public class NodesImpl implements Nodes
                 return null;
             }
 
+            NodeRef dataDictionary = getDataDictionaryNodeRef();
             NodeRef current = nodeRef;
 
             while (current != null)
@@ -4038,12 +4054,24 @@ public class NodesImpl implements Nodes
                 {
                     break;
                 }
-                if (isSpecialNode(current, type))
+
+                // Block only executable system paths under Data Dictionary
+                // (Web Scripts, Models, Messages, Scripts). This is the SSTI/RCE
+                // injection surface. Other Data Dictionary children remain editable
+                // by admins (e.g. Node Templates, Space Templates, Email Templates).
+                if (isProtectedExecutableSystemFolder(current, dataDictionary))
                 {
                     throw new PermissionDeniedException(
                             "Cannot perform operation on system path for requested node id '" + nodeRef.getId()
                                     + "' due to protected ancestor id '" + current.getId()
                                     + "' of type '" + type + "'");
+                }
+
+                // Stop traversal at Data Dictionary itself: legitimate admin operations
+                // (creating folder templates, etc.) directly under DD must continue to work.
+                if (current.equals(dataDictionary))
+                {
+                    break;
                 }
 
                 ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(current);
@@ -4058,6 +4086,48 @@ public class NodesImpl implements Nodes
             }
             return null;
         });
+    }
+
+    /**
+     * @return the Data Dictionary {@link NodeRef} for the current tenant, or {@code null}
+     *         if it cannot be resolved.
+     */
+    private NodeRef getDataDictionaryNodeRef()
+    {
+        String tenantDomain = TenantUtil.getCurrentDomain();
+        NodeRef ddNodeRef = ddCache.get(tenantDomain);
+        if (ddNodeRef == null)
+        {
+            List<ChildAssociationRef> ddAssocs = nodeService.getChildAssocs(
+                    repositoryHelper.getCompanyHome(),
+                    ContentModel.ASSOC_CONTAINS,
+                    QName.createQName(NamespaceService.APP_MODEL_1_0_URI, "dictionary"));
+            if (ddAssocs.size() == 1)
+            {
+                ddNodeRef = ddAssocs.get(0).getChildRef();
+                ddCache.put(tenantDomain, ddNodeRef);
+            }
+        }
+        return ddNodeRef;
+    }
+
+    /**
+     * @return {@code true} if {@code nodeRef} is a direct child of Data Dictionary whose
+     *         name matches a protected executable folder (Web Scripts, Models, etc.).
+     */
+    private boolean isProtectedExecutableSystemFolder(NodeRef nodeRef, NodeRef dataDictionary)
+    {
+        if (dataDictionary == null || nodeRef == null)
+        {
+            return false;
+        }
+        ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(nodeRef);
+        if (parentAssoc == null || !dataDictionary.equals(parentAssoc.getParentRef()))
+        {
+            return false;
+        }
+        String name = (String) nodeService.getProperty(nodeRef, ContentModel.PROP_NAME);
+        return name != null && PROTECTED_DD_EXECUTABLE_FOLDERS.contains(name);
     }
 
     /**

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -4010,7 +4010,7 @@ public class NodesImpl implements Nodes
 
     /**
      * Names of folders directly under Data Dictionary that contain executable artifacts
-     * (FreeMarker templates, JavaScript controllers, models, messages). Modifications to
+     * (FreeMarker templates, JavaScript controllers, messages). Modifications to
      * content under these folders via the REST API are blocked to prevent SSTI/RCE via
      * sandbox escape (e.g. overwriting web script templates).
      */
@@ -4056,7 +4056,7 @@ public class NodesImpl implements Nodes
                 }
 
                 // Block only executable system paths under Data Dictionary
-                // (Web Scripts, Models, Messages, Scripts). This is the SSTI/RCE
+                // (Web Scripts, Messages, Scripts). This is the SSTI/RCE
                 // injection surface. Other Data Dictionary children remain editable
                 // by admins (e.g. Node Templates, Space Templates, Email Templates).
                 if (isProtectedExecutableSystemFolder(current, dataDictionary))
@@ -4113,7 +4113,7 @@ public class NodesImpl implements Nodes
 
     /**
      * @return {@code true} if {@code nodeRef} is a direct child of Data Dictionary whose
-     *         name matches a protected executable folder (Web Scripts, Models, etc.).
+     *         name matches a protected executable folder (Web Scripts).
      */
     private boolean isProtectedExecutableSystemFolder(NodeRef nodeRef, NodeRef dataDictionary)
     {
@@ -4123,6 +4123,11 @@ public class NodesImpl implements Nodes
         }
         ChildAssociationRef parentAssoc = nodeService.getPrimaryParent(nodeRef);
         if (parentAssoc == null || !dataDictionary.equals(parentAssoc.getParentRef()))
+        {
+            return false;
+        }
+        QName nodeType = nodeService.getType(nodeRef);
+        if (nodeType == null || !dictionaryService.isSubClass(nodeType, ContentModel.TYPE_FOLDER))
         {
             return false;
         }

--- a/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
+++ b/remote-api/src/main/java/org/alfresco/rest/api/impl/NodesImpl.java
@@ -242,6 +242,12 @@ public class NodesImpl implements Nodes
 
     private ConcurrentHashMap<String, NodeRef> ddCache = new ConcurrentHashMap<>();
 
+    private static final Set<String> PROTECTED_DD_EXECUTABLE_FOLDERS = new HashSet<>(Arrays.asList(
+            "Web Scripts",
+            "Web Scripts Extensions",
+            "Messages",
+            "Scripts"));
+
     // pre-configured allow list of media/mime types, eg. specific types of images & also pdf
     private Set<String> nonAttachContentTypes = Collections.emptySet();
 
@@ -4008,14 +4014,6 @@ public class NodesImpl implements Nodes
         }
     }
 
-    /**
-     * Names of folders directly under Data Dictionary that contain executable artifacts (FreeMarker templates, JavaScript controllers, messages). Modifications to content under these folders via the REST API are blocked to prevent SSTI/RCE via sandbox escape (e.g. overwriting web script templates).
-     */
-    private static final Set<String> PROTECTED_DD_EXECUTABLE_FOLDERS = new HashSet<>(Arrays.asList(
-            "Web Scripts",
-            "Web Scripts Extensions",
-            "Messages",
-            "Scripts"));
 
     /**
      * Throws {@link PermissionDeniedException} if any ancestor node is an executable system-managed path (e.g. Data Dictionary/Web Scripts). Modifications under Data Dictionary itself (folder templates, node templates, etc.) remain allowed for admins so existing UI / regression flows are not impacted.

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/NodesImplSystemPathTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/NodesImplSystemPathTest.java
@@ -58,7 +58,7 @@ import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
+@RunWith(MockitoJUnitRunner.class)
 public class NodesImplSystemPathTest
 {
     @Mock
@@ -128,9 +128,8 @@ public class NodesImplSystemPathTest
         when(nodeService.getType(parentRef)).thenReturn(ContentModel.TYPE_FOLDER);
         when(nodeService.getPrimaryParent(parentRef)).thenReturn(
                 new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, dataDictionaryRef, null, parentRef));
+        when(dictionaryService.isSubClass(ContentModel.TYPE_FOLDER, ContentModel.TYPE_FOLDER)).thenReturn(true);
         when(nodeService.getProperty(parentRef, ContentModel.PROP_NAME)).thenReturn("Web Scripts");
-
-        when(nodeService.getType(dataDictionaryRef)).thenReturn(ContentModel.TYPE_FOLDER);
 
         assertThrows(PermissionDeniedException.class,
                 () -> nodesImpl.checkNotSystemPath(childRef));
@@ -149,17 +148,46 @@ public class NodesImplSystemPathTest
     @Test
     public void testDirectParentIsSpecialNode_ThrowPermissionDenied()
     {
+        // Simulate the actual "Scripts" folder (cm:folder) directly under Data Dictionary
         NodeRef childRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "child-under-dd");
 
-        when(nodeService.getType(childRef)).thenReturn(ContentModel.TYPE_CONTENT);
+        when(nodeService.getType(childRef)).thenReturn(ContentModel.TYPE_FOLDER);
         when(nodeService.getPrimaryParent(childRef)).thenReturn(
                 new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, dataDictionaryRef, null, childRef));
+        when(dictionaryService.isSubClass(ContentModel.TYPE_FOLDER, ContentModel.TYPE_FOLDER)).thenReturn(true);
         when(nodeService.getProperty(childRef, ContentModel.PROP_NAME)).thenReturn("Scripts");
-
-        when(nodeService.getType(dataDictionaryRef)).thenReturn(ContentModel.TYPE_FOLDER);
 
         assertThrows(PermissionDeniedException.class,
                 () -> nodesImpl.checkNotSystemPath(childRef));
+    }
+
+    @Test
+    public void testNodeUnderNonProtectedDDChild_ShouldNotBeBlocked()
+    {
+        // Simulate: file inside "Node Templates" (a DD child that is NOT in the protected list)
+        // Path: fileRef -> nodeTemplatesFolder -> dataDictionary -> companyHome
+        NodeRef nodeTemplatesRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "node-templates");
+        NodeRef fileRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "file-in-node-templates");
+
+        when(nodeService.getType(fileRef)).thenReturn(ContentModel.TYPE_CONTENT);
+        when(nodeService.getPrimaryParent(fileRef)).thenReturn(
+                new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, nodeTemplatesRef, null, fileRef));
+
+        when(nodeService.getType(nodeTemplatesRef)).thenReturn(ContentModel.TYPE_FOLDER);
+        when(nodeService.getPrimaryParent(nodeTemplatesRef)).thenReturn(
+                new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, dataDictionaryRef, null, nodeTemplatesRef));
+        when(dictionaryService.isSubClass(ContentModel.TYPE_FOLDER, ContentModel.TYPE_FOLDER)).thenReturn(true);
+        when(nodeService.getProperty(nodeTemplatesRef, ContentModel.PROP_NAME)).thenReturn("Node Templates");
+
+        when(nodeService.getType(dataDictionaryRef)).thenReturn(ContentModel.TYPE_FOLDER);
+        when(nodeService.getPrimaryParent(dataDictionaryRef)).thenReturn(
+                new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, companyHomeRef, null, dataDictionaryRef));
+
+        // Should NOT throw — "Node Templates" is not a protected executable folder
+        nodesImpl.checkNotSystemPath(fileRef);
+
+        // Traversal stops at Data Dictionary — should never go above it
+        verify(nodeService, never()).getPrimaryParent(companyHomeRef);
     }
 
     @Test

--- a/remote-api/src/test/java/org/alfresco/rest/api/impl/NodesImplSystemPathTest.java
+++ b/remote-api/src/test/java/org/alfresco/rest/api/impl/NodesImplSystemPathTest.java
@@ -26,22 +26,28 @@
 package org.alfresco.rest.api.impl;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.repo.download.DownloadModel;
 import org.alfresco.repo.model.Repository;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.site.SiteModel;
 import org.alfresco.rest.framework.core.exceptions.PermissionDeniedException;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
@@ -52,7 +58,7 @@ import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class NodesImplSystemPathTest
 {
     @Mock
@@ -70,9 +76,18 @@ public class NodesImplSystemPathTest
     private NodeRef companyHomeRef;
     private NodeRef dataDictionaryRef;
 
+    private MockedStatic<AuthenticationUtil> authUtilMock;
+
     @Before
     public void setUp()
     {
+        authUtilMock = Mockito.mockStatic(AuthenticationUtil.class);
+        authUtilMock.when(() -> AuthenticationUtil.runAsSystem(any(RunAsWork.class)))
+                .thenAnswer(invocation -> {
+                    RunAsWork<?> work = invocation.getArgument(0);
+                    return work.doWork();
+                });
+
         companyHomeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "company-home");
         dataDictionaryRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "data-dictionary");
 
@@ -91,6 +106,15 @@ public class NodesImplSystemPathTest
                         .thenReturn(Collections.singletonList(ddToCompanyHome));
     }
 
+    @After
+    public void tearDown()
+    {
+        if (authUtilMock != null)
+        {
+            authUtilMock.close();
+        }
+    }
+
     @Test
     public void testNodeWithSpecialAncestor_PermissionDenied()
     {
@@ -104,6 +128,7 @@ public class NodesImplSystemPathTest
         when(nodeService.getType(parentRef)).thenReturn(ContentModel.TYPE_FOLDER);
         when(nodeService.getPrimaryParent(parentRef)).thenReturn(
                 new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, dataDictionaryRef, null, parentRef));
+        when(nodeService.getProperty(parentRef, ContentModel.PROP_NAME)).thenReturn("Web Scripts");
 
         when(nodeService.getType(dataDictionaryRef)).thenReturn(ContentModel.TYPE_FOLDER);
 
@@ -112,29 +137,10 @@ public class NodesImplSystemPathTest
     }
 
     @Test
-    public void testNodeWithNormalAncestors_Succeed()
-    {
-        NodeRef parentRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "normal-parent");
-        NodeRef childRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "normal-child");
-
-        when(nodeService.getType(childRef)).thenReturn(ContentModel.TYPE_CONTENT);
-        when(nodeService.getPrimaryParent(childRef)).thenReturn(
-                new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, parentRef, null, childRef));
-
-        when(nodeService.getType(parentRef)).thenReturn(ContentModel.TYPE_FOLDER);
-        when(nodeService.getPrimaryParent(parentRef)).thenReturn(
-                new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, companyHomeRef, null, parentRef));
-
-        // Should not throw PermissionDeniedException for a normal node path
-        nodesImpl.checkNotSystemPath(childRef);
-
-        verify(nodeService).getPrimaryParent(childRef);
-    }
-
-    @Test
     public void testCompanyHome_ShouldNotTraverseFurther()
     {
-        // checkNotSystemPath should break at Company Home without traversing above it
+        when(nodeService.getType(companyHomeRef)).thenReturn(ContentModel.TYPE_FOLDER);
+
         nodesImpl.checkNotSystemPath(companyHomeRef);
 
         verify(nodeService, never()).getPrimaryParent(companyHomeRef);
@@ -148,6 +154,7 @@ public class NodesImplSystemPathTest
         when(nodeService.getType(childRef)).thenReturn(ContentModel.TYPE_CONTENT);
         when(nodeService.getPrimaryParent(childRef)).thenReturn(
                 new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, dataDictionaryRef, null, childRef));
+        when(nodeService.getProperty(childRef, ContentModel.PROP_NAME)).thenReturn("Scripts");
 
         when(nodeService.getType(dataDictionaryRef)).thenReturn(ContentModel.TYPE_FOLDER);
 
@@ -158,8 +165,6 @@ public class NodesImplSystemPathTest
     @Test
     public void testNodeInsideSite_ShouldNotBeBlocked()
     {
-        // Simulate: documentLibrary/myFile.txt under a site (st:site ancestor)
-        // Path: myFile -> documentLibrary -> siteNode (st:site) -> companyHome
         NodeRef siteNodeRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "site-node");
         NodeRef docLibRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "doc-lib");
         NodeRef fileRef = new NodeRef(StoreRef.STORE_REF_WORKSPACE_SPACESSTORE, "file-in-site");
@@ -172,13 +177,10 @@ public class NodesImplSystemPathTest
         when(nodeService.getPrimaryParent(docLibRef)).thenReturn(
                 new ChildAssociationRef(ContentModel.ASSOC_CONTAINS, siteNodeRef, null, docLibRef));
 
-        // st:site ancestor - traversal should stop here (break)
         when(nodeService.getType(siteNodeRef)).thenReturn(SiteModel.TYPE_SITE);
 
-        // Should not throw - normal site content must be allowed
         nodesImpl.checkNotSystemPath(fileRef);
 
-        // Verify traversal stopped at st:site - did not go above it
         verify(nodeService, never()).getPrimaryParent(siteNodeRef);
     }
 


### PR DESCRIPTION
Prevents REST API modifications (create, update, delete, move/copy) to nodes under protected executable system folders within Data Dictionary — specifically Web Scripts, Web Scripts Extensions, Messages, and Scripts. This closes an authenticated SSTI-to-RCE exploit chain where an admin could overwrite web script templates via the REST API and achieve OS-level command execution through FreeMarker
Changes:
Added checkNotSystemPath() guard in NodesImpl.java that traverses the node's parent chain and rejects operations (403) if any ancestor is a protected executable folder directly under Data Dictionary.
Guard is applied to updateContent(), createNode(), deleteNode(), and moveOrCopyNode().
Traversal stops early at Company Home, st:site nodes, or Data Dictionary itself — ensuring normal user/admin operations (My Files, Sites, folder templates, model uploads) are unaffected.
dl:download nodes are excluded from the check.
Removed "Models" from protected list to preserve legitimate admin model upload workflows.
What's blocked:
REST API writes under Data Dictionary/Web Scripts/**
REST API writes under Data Dictionary/Web Scripts Extensions/**
REST API writes under Data Dictionary/Scripts/**
REST API writes under Data Dictionary/Messages/**
What's NOT blocked (unchanged behavior):
Admin operations under Data Dictionary/Models, Node Templates, Space Templates, etc.
All normal user file operations in My Files / Sites
UI-driven workflows remain fully functional