### PR TITLE
MNT-25781 - Disposition Schedule filter manual actions on FTS query

### DIFF
--- a/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
+++ b/amps/ags/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuter.java
@@ -91,9 +91,6 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
     /** list of disposition actions to automatically execute */
     private List<String> dispositionActions;
 
-    /** query string */
-    private String query;
-
     /** records management action service */
     private RecordsManagementActionService recordsManagementActionService;
 
@@ -292,8 +289,8 @@ public class DispositionLifecycleJobExecuter extends RecordsManagementJobExecute
                 params.setQuery("TYPE:\"rma:dispositionAction\"");
                 params.addFilterQuery(getActionFilterQuery());
                 params.addFilterQuery("ISUNSET:\"rma:dispositionActionCompletedAt\"");
-                params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR -@rma\\:dispositionAsOf:["
-                        + LocalDate.now().plusDays(1) + " TO MAX])");
+                params.addFilterQuery("(@rma\\:dispositionEventsEligible:true OR (ISNOTNULL:\"rma:dispositionAsOf\" AND -@rma\\:dispositionAsOf:["
+                        + LocalDate.now().plusDays(1) + " TO MAX]))");
                 params.setTrackScore(false);
 
                 // execute search

--- a/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
+++ b/amps/ags/rm-community/rm-community-repo/unit-test/java/org/alfresco/module/org_alfresco_module_rm/job/DispositionLifecycleJobExecuterUnitTest.java
@@ -77,6 +77,8 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
     /** test query snippet */
     private static final String QUERY= "TYPE:\"rma:dispositionAction\"";
     private static final String FILTER_QUERY = "@rma\\:dispositionAction:(\"cutoff\" OR \"retain\")";
+    /** the dispositionAsOf branch must be guarded by a not-null check so unset values are not matched */
+    private static final String AS_OF_NOT_NULL_GUARD = "ISNOTNULL:\"rma:dispositionAsOf\" AND -@rma\\:dispositionAsOf:[";
     /** mocked result set */
     @Mock ResultSet mockedResultSet;
 
@@ -119,6 +121,7 @@ public class DispositionLifecycleJobExecuterUnitTest extends BaseUnitTest
         verify(mockedSearchService, times(numberOfInvocation)).query(paramsCaptor.capture());
         assertTrue(paramsCaptor.getValue().getQuery().contains(QUERY));
         assertTrue(paramsCaptor.getValue().getFilterQueries().toString().contains(FILTER_QUERY));
+        assertTrue(paramsCaptor.getValue().getFilterQueries().toString().contains(AS_OF_NOT_NULL_GUARD));
         verify(mockedResultSet, times(numberOfInvocation)).getNodeRefs();
         verify(mockedResultSet, times(numberOfInvocation)).close();
     }


### PR DESCRIPTION
* Add null check for rma:dispositionAsOf date when filtering to not catch results that do not have a disposition date due to being manual and not time based.