### PR TITLE
ACS-12072 Expand authority groups at index time and strip from query to resolve maxClauseCount failures in Search Enterprise

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -36,8 +36,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;

--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -58,6 +58,12 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
     private final HashSet<String> globalReaders;
     private final Set<String> stripFromQueryPrefixes;
 
+    @Deprecated
+    public FlatElasticsearchPermissionQueryFactory(PermissionService permissionService)
+    {
+        this(permissionService, null);
+    }
+
     public FlatElasticsearchPermissionQueryFactory(PermissionService permissionService, String stripFromQueryPrefixes)
     {
         this.permissionService = permissionService;
@@ -102,16 +108,15 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
         {
             return authorities;
         }
-        Set<String> strippedAuthorities = authorities.stream()
+        return authorities.stream()
                 .filter(authority -> !matchesAnyStripPrefix(authority))
                 .collect(Collectors.toSet());
-
-        return strippedAuthorities;
     }
 
     private boolean matchesAnyStripPrefix(String authority)
     {
-        return stripFromQueryPrefixes.stream().anyMatch(prefix -> authority.startsWith("GROUP_" + prefix));
+        final String groupPrefix = PermissionService.GROUP_PREFIX;
+        return stripFromQueryPrefixes.stream().anyMatch(prefix -> authority.startsWith(prefix.startsWith(groupPrefix) ? prefix : groupPrefix + prefix));
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -87,14 +87,14 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
 
         if (LOGGER.isDebugEnabled())
         {
-            LOGGER.debug("Full list of authorities: " + authorities);
+            LOGGER.debug("Authorities count before stripping : " + authorities.size());
         }
 
         authorities = stripNestedGroups(authorities);
 
         if (LOGGER.isDebugEnabled())
         {
-            LOGGER.debug("Stripped list of authorities: " + authorities);
+            LOGGER.debug("Authorities count after stripping : " + authorities.size());
         }
 
         if (hasGlobalReader(authorities))

--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -30,11 +30,14 @@ import static org.alfresco.repo.search.adaptor.QueryConstants.FIELD_READER;
 import static org.alfresco.service.cmr.security.AuthorityType.getAuthorityType;
 import static org.alfresco.service.cmr.security.PermissionService.ADMINISTRATOR_AUTHORITY;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
@@ -52,13 +55,21 @@ import org.alfresco.service.cmr.security.PermissionService;
 @SuppressWarnings("PMD.LooseCoupling")
 public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPermissionQueryFactory
 {
+    private static final Log LOGGER = LogFactory.getLog(FlatElasticsearchPermissionQueryFactory.class);
 
     private final PermissionService permissionService;
     private final HashSet<String> globalReaders;
+    private final Set<String> stripFromQueryPrefixes;
 
-    public FlatElasticsearchPermissionQueryFactory(PermissionService permissionService)
+    public FlatElasticsearchPermissionQueryFactory(PermissionService permissionService, String stripFromQueryPrefixes)
     {
         this.permissionService = permissionService;
+        this.stripFromQueryPrefixes = (stripFromQueryPrefixes == null || stripFromQueryPrefixes.isBlank())
+                ? Set.of()
+                : Arrays.stream(stripFromQueryPrefixes.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toSet());
         this.globalReaders = GlobalReaders.getReaders();
     }
 
@@ -74,6 +85,18 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
     {
         Set<String> authorities = getAuthorisations(includeGroupsForRoleAdmin);
 
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("Full list of authorities: " + authorities);
+        }
+
+        authorities = stripNestedGroups(authorities);
+
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("Stripped list of authorities: " + authorities);
+        }
+
         if (hasGlobalReader(authorities))
         {
             // No filter will be applied, so a unfiltered query will be returned
@@ -84,6 +107,24 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
             BoolQuery permissionQueryBuilder = buildFilter(authorities);
             return applyFilter(queryBuilder, permissionQueryBuilder).toQuery();
         }
+    }
+
+    private Set<String> stripNestedGroups(Set<String> authorities)
+    {
+        if (stripFromQueryPrefixes.isEmpty())
+        {
+            return authorities;
+        }
+        Set<String> strippedAuthorities = authorities.stream()
+                .filter(authority -> !matchesAnyStripPrefix(authority))
+                .collect(Collectors.toSet());
+
+        return strippedAuthorities;
+    }
+
+    private boolean matchesAnyStripPrefix(String authority)
+    {
+        return stripFromQueryPrefixes.stream().anyMatch(prefix -> authority.startsWith("GROUP_" + prefix));
     }
 
     /**

--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -55,7 +55,6 @@ import org.alfresco.service.cmr.security.PermissionService;
 @SuppressWarnings("PMD.LooseCoupling")
 public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPermissionQueryFactory
 {
-    private static final Log LOGGER = LogFactory.getLog(FlatElasticsearchPermissionQueryFactory.class);
 
     private final PermissionService permissionService;
     private final HashSet<String> globalReaders;
@@ -85,17 +84,7 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
     {
         Set<String> authorities = getAuthorisations(includeGroupsForRoleAdmin);
 
-        if (LOGGER.isDebugEnabled())
-        {
-            LOGGER.debug("Authorities count before stripping : " + authorities.size());
-        }
-
         authorities = stripNestedGroups(authorities);
-
-        if (LOGGER.isDebugEnabled())
-        {
-            LOGGER.debug("Authorities count after stripping : " + authorities.size());
-        }
 
         if (hasGlobalReader(authorities))
         {

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1427,3 +1427,6 @@ alfresco.documentation.acsVersion=&vrm_version=26.1
 alfresco.documentation.searchVersion=&vrm_version=2.0
 alfresco.documentation.searchEnterpriseVersion=&vrm_version=5.1
 alfresco.documentation.defaultDocumentationUrl=https://support.hyland.com/p/alfresco
+
+# Comma-separated list of authority prefixes to expand from permission queries
+search.enterprise.authority.expansion.prefixes=

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1428,5 +1428,5 @@ alfresco.documentation.searchVersion=&vrm_version=2.0
 alfresco.documentation.searchEnterpriseVersion=&vrm_version=5.1
 alfresco.documentation.defaultDocumentationUrl=https://support.hyland.com/p/alfresco
 
-# Comma-separated list of authority prefixes to expand from permission queries
+# Comma-separated list of group authority prefixes to strip from permission queries (authorities expanded at index time)
 search.enterprise.authority.expansion.prefixes=

--- a/repository/src/main/resources/alfresco/subsystems/Search/elasticsearch/elasticsearch-community-context.xml
+++ b/repository/src/main/resources/alfresco/subsystems/Search/elasticsearch/elasticsearch-community-context.xml
@@ -268,6 +268,7 @@
 
     <bean id="elasticsearchFlatPermissionFactory" class="org.alfresco.repo.search.impl.elasticsearch.permission.FlatElasticsearchPermissionQueryFactory">
         <constructor-arg name="permissionService" ref="permissionService"/>
+        <constructor-arg name="stripFromQueryPrefixes" value="${search.enterprise.authority.expansion.prefixes}"/>
     </bean>
 
     <bean id="elasticsearchResultSetBuilder" class="org.alfresco.repo.search.impl.elasticsearch.resultset.ElasticsearchResultSetBuilder">

--- a/repository/src/main/resources/alfresco/subsystems/Search/elasticsearch/elasticsearch.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/elasticsearch/elasticsearch.properties
@@ -77,5 +77,5 @@ elasticsearch.defaultFacetLimit=100
 # Fields that should have wildcard analyzing enabled (fields using locale_content analyzer)
 elasticsearch.query.analyzeWildcard.fields=cm:content,cm:persondescription,cm:preferenceValues,cm:tagScopeCache,sys:keyStore,sys:versionEdition,sys:versionProperties
 
-# Comma-separated list of authority prefixes to expand from permission queries
+# Comma-separated list of group authority prefixes to strip from permission queries (authorities expanded at index time)
 search.enterprise.authority.expansion.prefixes=

--- a/repository/src/main/resources/alfresco/subsystems/Search/elasticsearch/elasticsearch.properties
+++ b/repository/src/main/resources/alfresco/subsystems/Search/elasticsearch/elasticsearch.properties
@@ -77,3 +77,5 @@ elasticsearch.defaultFacetLimit=100
 # Fields that should have wildcard analyzing enabled (fields using locale_content analyzer)
 elasticsearch.query.analyzeWildcard.fields=cm:content,cm:persondescription,cm:preferenceValues,cm:tagScopeCache,sys:keyStore,sys:versionEdition,sys:versionProperties
 
+# Comma-separated list of authority prefixes to expand from permission queries
+search.enterprise.authority.expansion.prefixes=

--- a/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
@@ -26,6 +26,7 @@
 package org.alfresco.repo.search.impl.elasticsearch.permission;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atMostOnce;
@@ -35,7 +36,10 @@ import static org.mockito.internal.util.collections.Sets.newSet;
 import static org.alfresco.repo.search.impl.elasticsearch.shared.ElasticsearchConstants.OWNER;
 import static org.alfresco.repo.search.impl.elasticsearch.shared.ElasticsearchConstants.READER;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +67,7 @@ public class FlatElasticsearchPermissionQueryFactoryTest
     @Before
     public void setUp()
     {
-        this.flatPermissionService = new FlatElasticsearchPermissionQueryFactory(permissionService);
+        this.flatPermissionService = new FlatElasticsearchPermissionQueryFactory(permissionService, "");
         given(permissionService.getOwnerAuthority()).willReturn(PermissionService.OWNER_AUTHORITY);
     }
 
@@ -187,6 +191,190 @@ public class FlatElasticsearchPermissionQueryFactoryTest
 
         verify(permissionService, atMostOnce()).getAllAuthorities();
         assertAuthoritiesInFilterQuery(filteredQuery, "admin", PermissionService.ADMINISTRATOR_AUTHORITY);
+    }
+
+    // ---------------------------------------------------------------------
+    // Authority stripping tests (stripFromQueryPrefixes / stripNestedGroups)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void shouldNotStripAnyAuthorityWhenPrefixesConfigIsNotProvided()
+    {
+        // null, empty and blank CSVs must all disable stripping.
+        Set<String> authorities = newSet("username", "GROUP_site_alpha", "GROUP_ExtendedReaders123");
+
+        for (String noopConfig : new String[]{null, "", "   "})
+        {
+            assertEquals("Authorities must be unchanged for config: '" + noopConfig + "'",
+                    authorities, stripWithConfig(noopConfig, authorities));
+        }
+    }
+
+    @Test
+    public void shouldTrimWhitespaceAndIgnoreEmptyEntriesInCsvConfig()
+    {
+        // " site_ , , ExtendedReaders " must be parsed as { "site_", "ExtendedReaders" }
+        Set<String> authorities = newSet(
+                "username",
+                "GROUP_site_alpha",
+                "GROUP_ExtendedReaders123",
+                "GROUP_EVERYONE");
+
+        assertEquals(
+                newSet("username", "GROUP_EVERYONE"),
+                stripWithConfig(" site_ , , ExtendedReaders ", authorities));
+    }
+
+    @Test
+    public void shouldStripGroupsMatchingASingleConfiguredPrefix()
+    {
+        // Partial strip: only the GROUP_site_* entries go, the rest stay.
+        Set<String> mixed = newSet(
+                "username",
+                "GROUP_EVERYONE",
+                "GROUP_site_alpha",
+                "GROUP_site_alpha_SiteCollaborator",
+                "GROUP_site_beta");
+        assertEquals(
+                newSet("username", "GROUP_EVERYONE"),
+                stripWithConfig("site_", mixed));
+
+        // Full strip of every group, only the user survives.
+        Set<String> allMatching = newSet("username", "GROUP_site_a", "GROUP_site_b");
+        assertEquals(newSet("username"), stripWithConfig("site_", allMatching));
+    }
+
+    @Test
+    public void shouldStripGroupsMatchingAnyOfMultipleConfiguredPrefixes()
+    {
+        // Mirrors the production log line from the bug report.
+        String tenantId = "edc25e53-a350-4467-825e-53a350c4676d";
+        Set<String> authorities = newSet(
+                "ipr_user_1",
+                "GROUP_EVERYONE",
+                "ROLE_AUTHENTICATED",
+                "GROUP_site_rm",
+                "GROUP_site_site-alpha",
+                "GROUP_site_site-alpha_SiteCollaborator",
+                "GROUP_INPLACE_RECORD_MANAGEMENT",
+                "GROUP_ExtendedReaders" + tenantId,
+                "GROUP_ExtendedWriters" + tenantId,
+                "GROUP_AllRoles" + tenantId,
+                "GROUP_PowerUser" + tenantId);
+
+        assertEquals(
+                newSet("ipr_user_1", "GROUP_EVERYONE", "ROLE_AUTHENTICATED",
+                        "GROUP_INPLACE_RECORD_MANAGEMENT"),
+                stripWithConfig("site_,ExtendedReaders,ExtendedWriters,AllRoles,PowerUser", authorities));
+    }
+
+    @Test
+    public void shouldOnlyStripAuthoritiesStartingWithGroupPrefixPlusConfiguredPrefix()
+    {
+        // matchesAnyStripPrefix uses startsWith("GROUP_" + prefix) so:
+        // - a user literally called "site_user" must survive,
+        // - a "ROLE_site_admin" must survive,
+        // - "GROUP_X_site_alpha" (prefix in the middle) must survive,
+        // - only the genuine "GROUP_site_*" entries get stripped.
+        Set<String> authorities = newSet(
+                "site_user",
+                "ROLE_site_admin",
+                "GROUP_X_site_alpha",
+                "GROUP_OTHER",
+                "GROUP_site_alpha");
+
+        assertEquals(
+                newSet("site_user", "ROLE_site_admin", "GROUP_X_site_alpha", "GROUP_OTHER"),
+                stripWithConfig("site_", authorities));
+    }
+
+    @Test
+    public void strippedAuthoritiesMustNotAppearInTheGeneratedPermissionFilter()
+    {
+        // End-to-end check: the stripped authorities are absent from BOTH the
+        // reader (should) clauses and the denied (mustNot) clauses.
+        Set<String> globalReaders = GlobalReaders.getReaders();
+        HashSet<String> backup = new HashSet<>(globalReaders);
+        globalReaders.clear();
+        try
+        {
+            FlatElasticsearchPermissionQueryFactory factory = new FlatElasticsearchPermissionQueryFactory(permissionService, "site_,ExtendedReaders");
+
+            given(permissionService.getAuthorisations()).willReturn(newSet(
+                    "username",
+                    "GROUP_EVERYONE",
+                    "GROUP_site_alpha",
+                    "GROUP_site_alpha_SiteCollaborator",
+                    "GROUP_ExtendedReadersTENANT"));
+
+            Query result = factory.getQueryWithPermissionFilter(
+                    QueryBuilders.matchAll().build().toQuery(), true);
+
+            BoolQuery permissionFilter = result.bool().filter().get(0).bool();
+
+            Set<String> readers = matchValues(permissionFilter.should(), QueryConstants.FIELD_READER);
+            Set<String> denied = matchValues(permissionFilter.mustNot(), QueryConstants.FIELD_DENIED);
+
+            assertTrue("Reader filter must keep the user", readers.contains("username"));
+            assertTrue("Reader filter must keep GROUP_EVERYONE", readers.contains("GROUP_EVERYONE"));
+
+            for (String stripped : new String[]{
+                    "GROUP_site_alpha",
+                    "GROUP_site_alpha_SiteCollaborator",
+                    "GROUP_ExtendedReadersTENANT"})
+            {
+                assertFalse("Stripped authority '" + stripped + "' must not appear as a reader",
+                        readers.contains(stripped));
+                assertFalse("Stripped authority '" + stripped + "' must not appear as denied",
+                        denied.contains(stripped));
+            }
+        }
+        finally
+        {
+            globalReaders.clear();
+            globalReaders.addAll(backup);
+        }
+    }
+
+    /**
+     * Builds a factory with the given CSV prefix config, runs it against {@code authorities} and returns the set of authorities used to build the reader (should) clauses of the resulting permission filter -- i.e. the effective post-stripping set as observed by the rest of the system.
+     */
+    private Set<String> stripWithConfig(String prefixesCsv, Set<String> authorities)
+    {
+        // Drop global readers so the filter is actually built (otherwise the
+        // factory short-circuits and returns the unfiltered query).
+        Set<String> globalReaders = GlobalReaders.getReaders();
+        HashSet<String> backup = new HashSet<>(globalReaders);
+        globalReaders.clear();
+        try
+        {
+            FlatElasticsearchPermissionQueryFactory factory = new FlatElasticsearchPermissionQueryFactory(permissionService, prefixesCsv);
+
+            given(permissionService.getAuthorisations()).willReturn(authorities);
+
+            Query result = factory.getQueryWithPermissionFilter(
+                    QueryBuilders.matchAll().build().toQuery(), true);
+
+            BoolQuery permissionFilter = result.bool().filter().get(0).bool();
+            return matchValues(permissionFilter.should(), QueryConstants.FIELD_READER);
+        }
+        finally
+        {
+            globalReaders.clear();
+            globalReaders.addAll(backup);
+        }
+    }
+
+    /**
+     * Extracts the {@code query} values of every {@code match} clause that targets the given field. Non-match clauses (e.g. the owner term/bool clause) are ignored.
+     */
+    private static Set<String> matchValues(List<Query> clauses, String field)
+    {
+        return clauses.stream()
+                .filter(q -> "match".equals(q._kind().jsonValue()))
+                .filter(q -> field.equals(q.match().field()))
+                .map(q -> q.match().query()._get().toString())
+                .collect(Collectors.toSet());
     }
 
     private void assertAuthoritiesInFilterQuery(BoolQuery filteredQuery, String... expectedAuths)

--- a/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
@@ -67,7 +67,7 @@ public class FlatElasticsearchPermissionQueryFactoryTest
     @Before
     public void setUp()
     {
-        this.flatPermissionService = new FlatElasticsearchPermissionQueryFactory(permissionService, "");
+        this.flatPermissionService = new FlatElasticsearchPermissionQueryFactory(permissionService);
         given(permissionService.getOwnerAuthority()).willReturn(PermissionService.OWNER_AUTHORITY);
     }
 

--- a/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
@@ -294,7 +294,7 @@ public class FlatElasticsearchPermissionQueryFactoryTest
         // End-to-end check: the stripped authorities are absent from BOTH the
         // reader (should) clauses and the denied (mustNot) clauses.
         Set<String> globalReaders = GlobalReaders.getReaders();
-        HashSet<String> backup = new HashSet<>(globalReaders);
+        Set<String> backup = new HashSet<>(globalReaders);
         globalReaders.clear();
         try
         {
@@ -344,7 +344,7 @@ public class FlatElasticsearchPermissionQueryFactoryTest
         // Drop global readers so the filter is actually built (otherwise the
         // factory short-circuits and returns the unfiltered query).
         Set<String> globalReaders = GlobalReaders.getReaders();
-        HashSet<String> backup = new HashSet<>(globalReaders);
+        Set<String> backup = new HashSet<>(globalReaders);
         globalReaders.clear();
         try
         {


### PR DESCRIPTION
This pull request introduces a new feature to allow configurable stripping of authorities with specific prefixes from Elasticsearch permission queries. This is intended to support scenarios where certain group authorities should be excluded from permission checks, and includes both the main implementation and comprehensive tests.

The most important changes are:

**Authority Prefix Stripping Feature:**

* Added a new constructor argument `stripFromQueryPrefixes` to `FlatElasticsearchPermissionQueryFactory` and implemented logic to remove authorities with configured prefixes from permission queries. The prefixes are provided as a comma-separated list and are matched against group authorities (e.g., `GROUP_site_*`). [[1]](diffhunk://#diff-4dfe4f74f9dfb4349b549854ea44ca9262de54d7b98cf97a11697bd7a1d5d3f3R58-R72) [[2]](diffhunk://#diff-4dfe4f74f9dfb4349b549854ea44ca9262de54d7b98cf97a11697bd7a1d5d3f3R112-R129)
* Integrated the new configuration property `search.enterprise.authority.expansion.prefixes` into the application’s properties and wiring, allowing administrators to specify which authority prefixes should be stripped. [[1]](diffhunk://#diff-8c89f143d45c441a96e7f2b19ceb9130f74b4d855a641843696e3e70143f0e96R1430-R1432) [[2]](diffhunk://#diff-36efba5813baad73f78d1b9c71f07b3f96a37406eb2ca9f0aae9fc5822516a69R80-R81) [[3]](diffhunk://#diff-b9deb4335a060f73f3c00962e0eb2f648d8bcf287f90148447839f4dbb584540R271)

**Debugging and Logging:**

* Added debug logging to output the full and stripped list of authorities during permission query generation, aiding in troubleshooting and verification of the stripping logic.

**Testing:**

* Added comprehensive unit tests to verify the stripping logic, including handling of blank/empty configs, whitespace trimming, multiple prefixes, and ensuring stripped authorities do not appear in the generated permission filters. [[1]](diffhunk://#diff-f47398a649c20871caa738f5694736dfc006782849119405852ac0fdbd90c7f7R196-R379) [[2]](diffhunk://#diff-f47398a649c20871caa738f5694736dfc006782849119405852ac0fdbd90c7f7R39-R42) [[3]](diffhunk://#diff-f47398a649c20871caa738f5694736dfc006782849119405852ac0fdbd90c7f7L66-R70) [[4]](diffhunk://#diff-f47398a649c20871caa738f5694736dfc006782849119405852ac0fdbd90c7f7R29)

These changes collectively make authority filtering more flexible and configurable, while ensuring correctness through extensive tests.