### PR TITLE
ACS-12211 create terms query instead of a 2N clauses for N authorities

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -31,6 +31,7 @@ import static org.alfresco.service.cmr.security.AuthorityType.getAuthorityType;
 import static org.alfresco.service.cmr.security.PermissionService.ADMINISTRATOR_AUTHORITY;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,6 +42,8 @@ import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
 
 import org.alfresco.repo.search.adaptor.QueryConstants;
 import org.alfresco.service.cmr.security.AuthorityType;
@@ -120,8 +123,23 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
     private BoolQuery buildFilter(Set<String> authorities)
     {
         BoolQuery.Builder aclQueryBuilder = QueryBuilders.bool();
-        authorities.forEach(auth -> aclQueryBuilder.should(new Query.Builder().match(new MatchQuery.Builder().field(FIELD_READER).query(FieldValue.of(auth)).build()).build()));
-        authorities.forEach(auth -> aclQueryBuilder.mustNot(new Query.Builder().match(new MatchQuery.Builder().field(QueryConstants.FIELD_DENIED).query(FieldValue.of(auth)).build()).build()));
+
+        List<FieldValue> authorityValues = authorities.stream().map(FieldValue::of).toList();
+
+        aclQueryBuilder.should(new Query.Builder()
+                .terms(new TermsQuery.Builder()
+                        .field(FIELD_READER)
+                        .terms(new TermsQueryField.Builder().value(authorityValues).build())
+                        .build())
+                .build());
+
+        aclQueryBuilder.mustNot(new Query.Builder()
+                .terms(new TermsQuery.Builder()
+                        .field(QueryConstants.FIELD_DENIED)
+                        .terms(new TermsQueryField.Builder().value(authorityValues).build())
+                        .build())
+                .build());
+
         addOwnerQuery(authorities, aclQueryBuilder);
         return aclQueryBuilder.build();
     }

--- a/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
+++ b/repository/src/main/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactory.java
@@ -77,7 +77,7 @@ public class FlatElasticsearchPermissionQueryFactory implements ElasticsearchPer
     {
         Set<String> authorities = getAuthorisations(includeGroupsForRoleAdmin);
 
-        if (hasGlobalReader(authorities))
+        if (authorities.isEmpty() || hasGlobalReader(authorities))
         {
             // No filter will be applied, so a unfiltered query will be returned
             return queryBuilder;

--- a/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
+++ b/repository/src/test/java/org/alfresco/repo/search/impl/elasticsearch/permission/FlatElasticsearchPermissionQueryFactoryTest.java
@@ -26,6 +26,7 @@
 package org.alfresco.repo.search.impl.elasticsearch.permission;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atMostOnce;
@@ -35,6 +36,7 @@ import static org.mockito.internal.util.collections.Sets.newSet;
 import static org.alfresco.repo.search.impl.elasticsearch.shared.ElasticsearchConstants.OWNER;
 import static org.alfresco.repo.search.impl.elasticsearch.shared.ElasticsearchConstants.READER;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -75,6 +77,21 @@ public class FlatElasticsearchPermissionQueryFactoryTest
         Query query = QueryBuilders.matchAll().build().toQuery();
         Query queryBuilderWithPermissionSystem = flatPermissionService.getQueryWithPermissionFilter(query, true);
         assertEquals(query, queryBuilderWithPermissionSystem);
+    }
+
+    @Test
+    public void shouldGetUnfilteredQueryWhenAuthoritiesAreEmpty()
+    {
+        // PermissionServiceNOOPImpl#getAuthorisations() returns an empty set. In that case no
+        // permission filter must be applied, otherwise an empty terms query would be generated
+        // which OpenSearch treats as match-none (changing the previous match-all behaviour).
+        given(permissionService.getAuthorisations()).willReturn(Collections.emptySet());
+
+        Query query = QueryBuilders.matchAll().build().toQuery();
+        Query queryBuilderWithPermission = flatPermissionService.getQueryWithPermissionFilter(query, true);
+
+        assertSame("Expected the original query to be returned unchanged when there are no authorities",
+                query, queryBuilderWithPermission);
     }
 
     @Test
@@ -202,8 +219,9 @@ public class FlatElasticsearchPermissionQueryFactoryTest
 
         List<Query> should = filterQuery.bool().should();
         List<Query> mustNot = filterQuery.bool().mustNot();
-        int authoritiesPlusOwnerQueryCount = expectedAuths.length + 1;
-        assertEquals(authoritiesPlusOwnerQueryCount, should.size());
+        // The reader authorities are collapsed into a single terms clause, so the should clause
+        // contains the reader terms query plus the owner query.
+        assertEquals(2, should.size());
 
         String ownerName = expectedAuths[0];
         assertOwnerQuery(ownerName, should, roleOwnerInReaders);
@@ -214,27 +232,24 @@ public class FlatElasticsearchPermissionQueryFactoryTest
     private void assertAuthorities(String[] expectedAuths, List<Query> deniedQueries,
             List<Query> readerQueries)
     {
+        List<String> readerAuths = extractTermsValues(readerQueries, QueryConstants.FIELD_READER);
+        List<String> deniedAuths = extractTermsValues(deniedQueries, QueryConstants.FIELD_DENIED);
 
         for (String expected : expectedAuths)
         {
-            readerQueries.forEach(readerQuery -> {
-                if (readerQuery._kind().jsonValue().equals("match") && readerQuery.match().query()._get().toString().equals(expected) && readerQuery.match().field().equals(QueryConstants.FIELD_READER))
-                {
-
-                    boolean contains = true;
-                    assertTrue("Permission reader filter doesn't check " + expected, contains);
-                }
-            });
-
-            deniedQueries.forEach(deniedQuery -> {
-                if (deniedQuery._kind().jsonValue().equals("match") && deniedQuery.match().query()._get().toString().equals(expected) && deniedQuery.match().field().equals(QueryConstants.FIELD_DENIED))
-                {
-
-                    boolean contains = true;
-                    assertTrue("Permission denied filter doesn't check " + expected, contains);
-                }
-            });
+            assertTrue("Permission reader filter doesn't check " + expected, readerAuths.contains(expected));
+            assertTrue("Permission denied filter doesn't check " + expected, deniedAuths.contains(expected));
         }
+    }
+
+    private List<String> extractTermsValues(List<Query> queries, String field)
+    {
+        return queries.stream()
+                .filter(query -> query._kind().jsonValue().equals("terms"))
+                .filter(query -> query.terms().field().equals(field))
+                .flatMap(query -> query.terms().terms().value().stream())
+                .map(value -> value._get().toString())
+                .collect(java.util.stream.Collectors.toList());
     }
 
     private void assertOwnerQuery(String ownerName, List<Query> queries, boolean roleOwnerInReaders)


### PR DESCRIPTION
This pull request refactors how permission queries are constructed in the `FlatElasticsearchPermissionQueryFactory` class to improve efficiency and maintainability. The main change is replacing multiple individual match queries with consolidated terms queries for handling authorities, which simplifies the logic and should improve query performance.

**Permission query construction improvements:**

* Updated the `buildFilter` method to use a single `terms` query for all authorities instead of creating separate `match` queries for each authority for both allowed (`FIELD_READER`) and denied (`FIELD_DENIED`) fields. This reduces the number of queries generated and leverages OpenSearch’s optimized handling of terms queries.
* Added imports for `TermsQuery`, `TermsQueryField`, and `List` to support the new query construction approach. [[1]](diffhunk://#diff-4dfe4f74f9dfb4349b549854ea44ca9262de54d7b98cf97a11697bd7a1d5d3f3R34) [[2]](diffhunk://#diff-4dfe4f74f9dfb4349b549854ea44ca9262de54d7b98cf97a11697bd7a1d5d3f3R45-R46)