### PR TITLE
ACS-11940 move help links to docs.hyland.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ Please use [**this guide**](CONTRIBUTING.md) to make a contribution to the proje
 
 ## Helpful links
 
-- [Alfresco Content Services Documentation](https://docs.alfresco.com/content-services/latest/)
+- [Alfresco Content Services Documentation](https://docs.hyland.com/p/alfresco)
 - [Alfresco Platform](https://www.hyland.com/en/products/alfresco-platform)

--- a/amps/ags/rm-community/documentation/destruction/README.md
+++ b/amps/ags/rm-community/documentation/destruction/README.md
@@ -23,7 +23,7 @@ Recorded content can be explicitly destroyed whilst maintaining the original nod
 * License: Alfresco Community
 * Issue Tracker Link: [JIRA RM](https://issues.alfresco.com/jira/projects/RM/summary)
 * Contribution Model: Alfresco Closed Source
-* Documentation: [docs.alfresco.com (Records Management)](https://support.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1&component=Alfresco%20Governance%20Services%20Community%20Edition)
+* Documentation: [docs.hyland.com (Records Management)](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1&component=Alfresco%20Governance%20Services%20Community%20Edition)
 
 *** 
 

--- a/amps/ags/rm-community/documentation/overview.md
+++ b/amps/ags/rm-community/documentation/overview.md
@@ -21,18 +21,18 @@ RM is split into two main parts - a repository integration and a Share integrati
 * [Community License](../LICENSE.txt)
 * [Enterprise License](../../rm-enterprise/LICENSE.txt) (this file will only be present in clones of the Enterprise repository)
 * [Issue Tracker Link](https://issues.alfresco.com/jira/projects/RM)
-* [Community Documentation Link](https://support.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1&component=Alfresco%20Governance%20Services%20Community%20Edition)
-* [Enterprise Documentation Link](https://support.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1)
+* [Community Documentation Link](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1&component=Alfresco%20Governance%20Services%20Community%20Edition)
+* [Enterprise Documentation Link](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1)
 * [Contribution Model](../../CONTRIBUTING.md)
 
 *** 
 
 ### Prerequisite Knowledge
-An understanding of Alfresco Content Services is assumed. The following pages from the [developer documentation](https://support.hyland.com/access?dita:id=lsl1724405261585&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition) give useful background information:
+An understanding of Alfresco Content Services is assumed. The following pages from the [developer documentation](https://docs.hyland.com/access?dita:id=lsl1724405261585&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition) give useful background information:
 
-* [ACS Architecture](https://support.hyland.com/access?dita:id=lfo1719554691023&vrm_version=26.1)
-* [Platform Extensions](https://support.hyland.com/access?dita:id=ifr1720080387005&vrm_version=26.1)
-* [Share Extensions](https://support.hyland.com/access?dita:id=wqu1720687386891&vrm_version=26.1)
+* [ACS Architecture](https://docs.hyland.com/access?dita:id=lfo1719554691023&vrm_version=26.1)
+* [Platform Extensions](https://docs.hyland.com/access?dita:id=ifr1720080387005&vrm_version=26.1)
+* [Share Extensions](https://docs.hyland.com/access?dita:id=wqu1720687386891&vrm_version=26.1)
 
 *** 
 
@@ -44,12 +44,12 @@ The RM Share module communicates with the repository module via REST APIs. Inter
 * A DAO layer responsible for CRUD operations against the database.
 
 #### REST API
-The REST API endpoints fall into two main types - v0 (Webscripts) and v1. The [v0 API](https://support.hyland.com/access?dita:id=fga1720080409048&vrm_version=26.1) is older and not recommended for integrations. The [v1 API](https://support.hyland.com/access?dita:id=cmm1721136574006&vrm_version=26.1) is newer but isn't yet feature complete. If you are running RM locally then the GS API Explorer will be available at [this link](http://localhost:8080/gs-api-explorer/).
+The REST API endpoints fall into two main types - v0 (Webscripts) and v1. The [v0 API](https://docs.hyland.com/access?dita:id=fga1720080409048&vrm_version=26.1) is older and not recommended for integrations. The [v1 API](https://docs.hyland.com/access?dita:id=cmm1721136574006&vrm_version=26.1) is newer but isn't yet feature complete. If you are running RM locally then the GS API Explorer will be available at [this link](http://localhost:8080/gs-api-explorer/).
 
 Internally the GS v1 REST API is built on the [Alfresco v1 REST API framework](https://community.alfresco.com/community/ecm/blog/2016/10/11/v1-rest-api-part-1-introduction). It aims to be consistent with this in terms of behaviour and naming.
 
 #### Java Public API
-The Java service layer is fronted by a [Java Public API](https://support.hyland.com/access?dita:id=lol1721390191517&vrm_version=26.1), which we will ensure backward compatible with previous releases. Before we remove any methods there will first be a release containing that method deprecated to allow third party integrations to migrate to a new method.  The Java Public API also includes a set of POJO objects which are needed to communicate with the services. It is easy to identify classes that are part of the Java Public API as they are annotated `@AlfrescoPublicApi`.
+The Java service layer is fronted by a [Java Public API](https://docs.hyland.com/access?dita:id=lol1721390191517&vrm_version=26.1), which we will ensure backward compatible with previous releases. Before we remove any methods there will first be a release containing that method deprecated to allow third party integrations to migrate to a new method.  The Java Public API also includes a set of POJO objects which are needed to communicate with the services. It is easy to identify classes that are part of the Java Public API as they are annotated `@AlfrescoPublicApi`.
 
 Each Java service will have at least four beans defined for it:
 
@@ -61,7 +61,7 @@ Each Java service will have at least four beans defined for it:
 #### DAOs
 The DAOs are not part of the Java Public API, but handle CRUD operations against RM stored data. We have some custom queries to improve performance for particularly heavy operations.
 
-We use standard Alfresco [data modelling](https://support.hyland.com/access?dita:id=ekx1720080373621&vrm_version=26.1) to store RM metadata. We extend the [Alfresco patching mechanism](https://support.hyland.com/access?dita:id=ato1720080396825&vrm_version=26.1) to provide community and enterprise schema upgrades.
+We use standard Alfresco [data modelling](https://docs.hyland.com/access?dita:id=ekx1720080373621&vrm_version=26.1) to store RM metadata. We extend the [Alfresco patching mechanism](https://docs.hyland.com/access?dita:id=ato1720080396825&vrm_version=26.1) to provide community and enterprise schema upgrades.
 
 ***
 

--- a/packaging/tests/tas-cmis/README.md
+++ b/packaging/tests/tas-cmis/README.md
@@ -27,7 +27,7 @@
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://support.hyland.com/access?dita:id=kvf1721390177551&vrm_version=26.1). 
+**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://docs.hyland.com/access?dita:id=kvf1721390177551&vrm_version=26.1). 
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 

--- a/packaging/tests/tas-restapi/README.md
+++ b/packaging/tests/tas-restapi/README.md
@@ -27,7 +27,7 @@ Back to [TAS Master Documentation](https://git.alfresco.com/tas/alfresco-tas-uti
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **RESTAPI** is the project that handles the automated tests related only to [Alfresco REST API](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide).
+**TAS**( **T**est **A**utomation **S**ystem)- **RESTAPI** is the project that handles the automated tests related only to [Alfresco REST API](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide).
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 
@@ -271,7 +271,7 @@ restClient.onResponse().assertThat().body("entry.modifiedBy.firstName", org.hamc
 
 ### How to generate models or check coverage
 
-There are some simple generators that could parse [Swagger YAML](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some usefull information to you like:
+There are some simple generators that could parse [Swagger YAML](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some usefull information to you like:
  
 a) Show on screen the actual coverage of TAS vs requests that exists in each YAML file - defined in pom.xml) 
 

--- a/packaging/tests/tas-restapi/README.md
+++ b/packaging/tests/tas-restapi/README.md
@@ -271,7 +271,7 @@ restClient.onResponse().assertThat().body("entry.modifiedBy.firstName", org.hamc
 
 ### How to generate models or check coverage
 
-There are some simple generators that could parse [Swagger YAML](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some usefull information to you like:
+There are some simple generators that could parse [Swagger YAML](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some useful information to you like:
  
 a) Show on screen the actual coverage of TAS vs requests that exists in each YAML file - defined in pom.xml) 
 

--- a/packaging/war/src/main/webapp/index.jsp
+++ b/packaging/war/src/main/webapp/index.jsp
@@ -74,7 +74,7 @@ ModuleDetails shareServicesModule = moduleService.getModule("alfresco-share-serv
          <div class="index-list">
             <h4><%=descriptorService.getServerDescriptor().getEdition()%></h4>
             <p></p>
-            <p><a href="https://support.hyland.com/p/alfresco">Online Documentation</a></p>
+            <p><a href="https://docs.hyland.com/p/alfresco">Online Documentation</a></p>
             <p></p>
              <%
                  if (shareServicesModule != null && ModuleInstallState.INSTALLED.equals(shareServicesModule.getInstallState()))

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency.alfresco-hb-data-sender.version>1.1.1</dependency.alfresco-hb-data-sender.version>
         <dependency.alfresco-trashcan-cleaner.version>2.4.2</dependency.alfresco-trashcan-cleaner.version>
         <dependency.alfresco-jlan.version>7.5</dependency.alfresco-jlan.version>
-        <dependency.alfresco-server-root.version>8.0.0</dependency.alfresco-server-root.version>
+        <dependency.alfresco-server-root.version>8.0.1</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
         <dependency.alfresco-transform-core.version>5.4.3</dependency.alfresco-transform-core.version>

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/SOLRAuthenticationFilter.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/SOLRAuthenticationFilter.java
@@ -113,7 +113,7 @@ public class SOLRAuthenticationFilter implements DependencyInjectedFilter, Initi
         {
             if (sharedSecret == null || sharedSecret.length() == 0)
             {
-                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.hyland.com/p/alfresco");
+                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.hyland.com/r/Alfresco/Alfresco-Search-Services/2.0/Alfresco-Search-Services/Install/Installation-options/Install-without-mutual-TLS-HTTP-with-secret-word-in-request-header");
                 throw new AlfrescoRuntimeException("Missing value for solr.sharedSecret configuration property");
             }
             if (sharedSecretHeader == null || sharedSecretHeader.length() == 0)

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/SOLRAuthenticationFilter.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/solr/SOLRAuthenticationFilter.java
@@ -113,7 +113,7 @@ public class SOLRAuthenticationFilter implements DependencyInjectedFilter, Initi
         {
             if (sharedSecret == null || sharedSecret.length() == 0)
             {
-                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.alfresco.com/search-services/latest/install/options/");
+                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.hyland.com/p/alfresco");
                 throw new AlfrescoRuntimeException("Missing value for solr.sharedSecret configuration property");
             }
             if (sharedSecretHeader == null || sharedSecretHeader.length() == 0)

--- a/remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java
+++ b/remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java
@@ -76,7 +76,7 @@ public class AlfrescoX509ServletFilter extends X509ServletFilterBase
         {
             if (sharedSecret == null || sharedSecret.length() == 0)
             {
-                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.alfresco.com/search-services/latest/install/options/");
+                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.hyland.com/p/alfresco");
                 throw new AlfrescoRuntimeException("Missing value for solr.sharedSecret configuration property");
             }
             if (sharedSecretHeader == null || sharedSecretHeader.length() == 0)

--- a/remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java
+++ b/remote-api/src/main/java/org/alfresco/web/app/servlet/AlfrescoX509ServletFilter.java
@@ -76,7 +76,7 @@ public class AlfrescoX509ServletFilter extends X509ServletFilterBase
         {
             if (sharedSecret == null || sharedSecret.length() == 0)
             {
-                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.hyland.com/p/alfresco");
+                logger.fatal("Missing value for solr.sharedSecret configuration property. If solr.secureComms is set to \"secret\", a value for solr.sharedSecret is required. See https://docs.hyland.com/r/Alfresco/Alfresco-Search-Services/2.0/Alfresco-Search-Services/Install/Installation-options/Install-without-mutual-TLS-HTTP-with-secret-word-in-request-header");
                 throw new AlfrescoRuntimeException("Missing value for solr.sharedSecret configuration property");
             }
             if (sharedSecretHeader == null || sharedSecretHeader.length() == 0)

--- a/repository/docs/identity-provider/authentication/README.md
+++ b/repository/docs/identity-provider/authentication/README.md
@@ -27,7 +27,7 @@ to integrate with a number of external Authentication providers including
   * https://github.com/Alfresco/alfresco-data-model/tree/master/src/main/java/org/alfresco/repo/security/authentication
 * License: LGPL
 * Issue Tracker Link: https://issues.alfresco.com/jira/issues/?jql=project%3DREPO
-* Documentation Link: https://support.hyland.com/access?dita:id=byj1720776091160&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
+* Documentation Link: https://docs.hyland.com/access?dita:id=byj1720776091160&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
 * Contribution Model: Alfresco Open Source
 ***
 

--- a/repository/docs/meta-data-services/versions/README.md
+++ b/repository/docs/meta-data-services/versions/README.md
@@ -16,7 +16,7 @@
 * Source Code Link:m https://svn.alfresco.com/repos/alfresco-enterprise/alfresco/
 * License: LGPL
 * Issue Tracker Link: https://issues.alfresco.com/jira/secure/RapidBoard.jspa?projectKey=REPO&useStoredSettings=true&rapidView=379
-* Documentation Link: https://support.hyland.com/access?dita:id=ybx1720084724583&vrm_version=26.1
+* Documentation Link: https://docs.hyland.com/access?dita:id=ybx1720084724583&vrm_version=26.1
 * Contribution Model: Alfresco publishes the source code and will review proposed patch requests
 ***
 

--- a/repository/src/main/java/org/alfresco/repo/template/DocumentationURLMethod.java
+++ b/repository/src/main/java/org/alfresco/repo/template/DocumentationURLMethod.java
@@ -73,25 +73,25 @@ public class DocumentationURLMethod extends BaseTemplateProcessorExtension imple
      * Returns documentation URL. You can specify property key which should hold value of topic uid and url component(if required). * a) If no arguments are provided, the default documentation URL is returned.
      * 
      * <pre>
-     *      ${documentationUrl() -> https://support.hyland.com/p/alfresco
+     *      ${documentationUrl() -> https://docs.hyland.com/p/alfresco
      * </pre>
      * 
      * b) First argument is interpreted as Topic UID of the URL. The value is retrieved and treated as Topic UID appended after baseURL and before version.
      * 
      * <pre>
-     *      ${documentationURL("eet567890373737")} -> https://support.hyland.com/access?dita:id=eet567890373737&vrm_version=26.1
+     *      ${documentationURL("eet567890373737")} -> https://docs.hyland.com/access?dita:id=eet567890373737&vrm_version=26.1
      * </pre>
      * 
      * c) Second argument(if required) is interpreted as an additional URL component, which will be appended to the URL to denote a specific component of Alfresco.
      * 
      * <pre>
-     *     ${documentationUrl("eeu1720075126296", "&component=Alfresco%20Content%20Services%20Community%20Edition"} -> https://support.hyland.com/access?dita:id=eeu1720075126296&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
+     *     ${documentationUrl("eeu1720075126296", "&component=Alfresco%20Content%20Services%20Community%20Edition"} -> https://docs.hyland.com/access?dita:id=eeu1720075126296&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
      * </pre>
      *
      * d) Third argument (if required) is interpreted as the Alfresco component (e.g., "solr", "elasticsearch", or empty) to determine which version to use in the URL.
      *
      * <pre>
-     *     ${documentationUrl("eeu1720075126296", "", "solr")} -> https://support.hyland.com/access?dita:id=eeu1720075126296&vrm_version=2.0
+     *     ${documentationUrl("eeu1720075126296", "", "solr")} -> https://docs.hyland.com/access?dita:id=eeu1720075126296&vrm_version=2.0
      * </pre>
      *
      * @param args

--- a/repository/src/main/java/org/alfresco/repo/template/DocumentationURLMethod.java
+++ b/repository/src/main/java/org/alfresco/repo/template/DocumentationURLMethod.java
@@ -73,19 +73,19 @@ public class DocumentationURLMethod extends BaseTemplateProcessorExtension imple
      * Returns documentation URL. You can specify property key which should hold value of topic uid and url component(if required). * a) If no arguments are provided, the default documentation URL is returned.
      * 
      * <pre>
-     *      ${documentationUrl() -> https://docs.hyland.com/p/alfresco
+     *      ${documentationUrl()} -> https://docs.hyland.com/p/alfresco
      * </pre>
      * 
      * b) First argument is interpreted as Topic UID of the URL. The value is retrieved and treated as Topic UID appended after baseURL and before version.
      * 
      * <pre>
-     *      ${documentationURL("eet567890373737")} -> https://docs.hyland.com/access?dita:id=eet567890373737&vrm_version=26.1
+     *      ${documentationUrl("eet567890373737")} -> https://docs.hyland.com/access?dita:id=eet567890373737&vrm_version=26.1
      * </pre>
      * 
      * c) Second argument(if required) is interpreted as an additional URL component, which will be appended to the URL to denote a specific component of Alfresco.
      * 
      * <pre>
-     *     ${documentationUrl("eeu1720075126296", "&component=Alfresco%20Content%20Services%20Community%20Edition"} -> https://docs.hyland.com/access?dita:id=eeu1720075126296&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
+     *     ${documentationUrl("eeu1720075126296", "&component=Alfresco%20Content%20Services%20Community%20Edition")} -> https://docs.hyland.com/access?dita:id=eeu1720075126296&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
      * </pre>
      *
      * d) Third argument (if required) is interpreted as the Alfresco component (e.g., "solr", "elasticsearch", or empty) to determine which version to use in the URL.

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1426,8 +1426,8 @@ default.nodeSize.maximumPoolSize=10
 default.nodeSize.workQueueSize=100
 
 # Documentation URLs properties
-alfresco.documentation.baseurl=https://support.hyland.com/access?dita:id=
+alfresco.documentation.baseurl=https://docs.hyland.com/access?dita:id=
 alfresco.documentation.acsVersion=&vrm_version=26.1
 alfresco.documentation.searchVersion=&vrm_version=2.0
 alfresco.documentation.searchEnterpriseVersion=&vrm_version=5.1
-alfresco.documentation.defaultDocumentationUrl=https://support.hyland.com/p/alfresco
+alfresco.documentation.defaultDocumentationUrl=https://docs.hyland.com/p/alfresco

--- a/repository/src/test/java/org/alfresco/repo/action/executer/TakeOwnershipActionExecuterTest.java
+++ b/repository/src/test/java/org/alfresco/repo/action/executer/TakeOwnershipActionExecuterTest.java
@@ -113,7 +113,7 @@ public class TakeOwnershipActionExecuterTest
                 assertEquals("Wrong owner at test start.", SITE_INFO.siteContributor, OWNABLE_SERVICE.getOwner(TEST_DOC));
 
                 // Then the site owner (user 1) takes ownership of the document.
-                // See e.g. https://docs.alfresco.com/4.1/concepts/cuh-user-roles-permissions.html
+                // See e.g. https://docs.hyland.com/p/alfresco
                 // for details on who has permission to take ownership.
                 assertEquals(TEST_USER1.getUsername(), AuthenticationUtil.getRunAsUser());
 


### PR DESCRIPTION
This change logically depends on https://github.com/Alfresco/alfresco-server-root/pull/8, because alfresco-server-root is a dependency in this project.

alfresco-community-repo — 13 files (26 lines)
- repository.properties:1429,1433: documentation.baseurl and defaultDocumentationUrl → docs.hyland.com. This alone re-points all 22 context-aware Help links (1 community + 21 enterprise Admin Console templates) at runtime, since they all resolve through the documentationUrl() FreeMarker method and no enterprise override exists.
- Hardcoded: packaging/war/.../index.jsp.
- Docs/comments: 2 tas READMEs, RM overview.md + destruction/README.md (incl. the stale "docs.alfresco.com" label text), 2 repository/docs READMEs, DocumentationURLMethod Javadoc examples.


Deliberately excluded (1 file)

amps/ags/rm-community/.../api-explorer-26.2.0/changelogs/core-5.1-5.2.json — looks like generated file so I kept it as is