### PR TITLE
ACS-12299 Added new namespace-prefix endpoint

### DIFF
--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -84,13 +84,7 @@ public class NamespacePrefixGet extends AbstractWebScript implements Initializin
                 {
                     continue;
                 }
-                String existing = prefixUriMap.put(uri, prefix);
-                if (existing != null && !existing.equals(prefix))
-                {
-                    LOGGER.warn(String.format(
-                            "Namespace URI '%s' is registered under multiple prefixes; replacing '%s' with '%s'.",
-                            uri, existing, prefix));
-                }
+                prefixUriMap.put(uri, prefix);
             }
 
             payload = OBJECT_MAPPER.writeValueAsBytes(Map.of(KEY_PREFIX_URI_MAP, prefixUriMap));

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -30,8 +30,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.TreeMap;
 
-import org.alfresco.service.namespace.NamespaceService;
-import org.alfresco.util.PropertyCheck;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.InitializingBean;
@@ -41,20 +39,11 @@ import org.springframework.extensions.webscripts.WebScriptException;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
 
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.util.PropertyCheck;
+
 /**
- * Returns a map of namespace {@code URI -> prefix} for every namespace registered in the repository's
- * {@link NamespaceService}. This is the supported, product replacement for the unofficial prefix-mapping
- * extension the Search Enterprise Re-Indexer previously relied on (see ACS-12299 / PRODMAN-840).
- * <p>
- * Unlike the {@code /types} and {@code /aspects} public REST endpoints, this sources directly from
- * {@link NamespaceService}, so it returns the complete registered set — including platform namespaces such as
- * {@code sys} and {@code module} that have no enumerable type/aspect.
- * <p>
- * The response deliberately matches the shape of the legacy prefixes file so callers (and the re-indexer's
- * on-disk cache) can consume it unchanged.
- *
- * Authentication follows the same model as the data-model API (an ordinary authenticated user; no admin role
- * required) — enforced by the {@code user} authentication declared in the web script descriptor.
+ * Returns a map of namespace {@code URI -> prefix} for every namespace registered in the repository's {@link NamespaceService}.
  */
 public class NamespacePrefixGet extends AbstractWebScript implements InitializingBean
 {

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -33,8 +33,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.Status;
@@ -50,7 +50,7 @@ import org.alfresco.util.PropertyCheck;
  */
 public class NamespacePrefixGet extends AbstractWebScript implements InitializingBean
 {
-    private static final Log logger = LogFactory.getLog(NamespacePrefixGet.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NamespacePrefixGet.class);
 
     private static final String KEY_PREFIX_URI_MAP = "prefixUriMap";
 
@@ -87,7 +87,7 @@ public class NamespacePrefixGet extends AbstractWebScript implements Initializin
                 String existing = prefixUriMap.put(uri, prefix);
                 if (existing != null && !existing.equals(prefix))
                 {
-                    logger.warn(String.format(
+                    LOGGER.warn(String.format(
                             "Namespace URI '%s' is registered under multiple prefixes; replacing '%s' with '%s'.",
                             uri, existing, prefix));
                 }

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -28,10 +28,14 @@ package org.alfresco.repo.web.scripts.model;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.TreeMap;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.Strings;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.Status;
@@ -47,7 +51,12 @@ import org.alfresco.util.PropertyCheck;
  */
 public class NamespacePrefixGet extends AbstractWebScript implements InitializingBean
 {
+    private static final Log logger = LogFactory.getLog(NamespacePrefixGet.class);
+
     private static final String KEY_PREFIX_URI_MAP = "prefixUriMap";
+
+    // Thread-safe once configured, so shared as a single instance across concurrent requests.
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private NamespaceService namespaceService;
 
@@ -65,31 +74,39 @@ public class NamespacePrefixGet extends AbstractWebScript implements Initializin
     @Override
     public void execute(WebScriptRequest req, WebScriptResponse res) throws IOException
     {
-        // Sorted for deterministic, cache/diff-friendly output.
-        TreeMap<String, String> prefixUriMap = new TreeMap<>();
-        for (String prefix : namespaceService.getPrefixes())
+        byte[] payload;
+        try
         {
-            prefixUriMap.put(namespaceService.getNamespaceURI(prefix), prefix);
+            HashMap<String, String> prefixUriMap = new HashMap<>();
+            for (String prefix : namespaceService.getPrefixes())
+            {
+                String uri = namespaceService.getNamespaceURI(prefix);
+                if (uri == null)
+                {
+                    continue;
+                }
+                String existing = prefixUriMap.put(uri, prefix);
+                if (!Strings.CS.equals(existing, prefix))
+                {
+                    logger.warn(String.format(
+                            "Namespace URI '%s' is registered under multiple prefixes; replacing '%s' with '%s'.",
+                            uri, existing, prefix));
+                }
+            }
+
+            payload = OBJECT_MAPPER.writeValueAsBytes(Map.of(KEY_PREFIX_URI_MAP, prefixUriMap));
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new WebScriptException(Status.STATUS_INTERNAL_SERVER_ERROR,
+                    "Failed to write namespace prefix map JSON", e);
         }
 
         res.setContentType("application/json");
         res.setContentEncoding(StandardCharsets.UTF_8.name());
-
         try (OutputStream os = res.getOutputStream())
         {
-            JSONObject map = new JSONObject();
-            for (var entry : prefixUriMap.entrySet())
-            {
-                map.put(entry.getKey(), entry.getValue());
-            }
-            JSONObject json = new JSONObject();
-            json.put(KEY_PREFIX_URI_MAP, map);
-            os.write(json.toString(2).getBytes(StandardCharsets.UTF_8));
-        }
-        catch (JSONException e)
-        {
-            throw new WebScriptException(Status.STATUS_INTERNAL_SERVER_ERROR,
-                    "Failed to write namespace prefix map JSON", e);
+            os.write(payload);
         }
     }
 }

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -33,7 +33,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.Strings;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -77,7 +76,7 @@ public class NamespacePrefixGet extends AbstractWebScript implements Initializin
         byte[] payload;
         try
         {
-            HashMap<String, String> prefixUriMap = new HashMap<>();
+            Map<String, String> prefixUriMap = new HashMap<>();
             for (String prefix : namespaceService.getPrefixes())
             {
                 String uri = namespaceService.getNamespaceURI(prefix);
@@ -86,7 +85,7 @@ public class NamespacePrefixGet extends AbstractWebScript implements Initializin
                     continue;
                 }
                 String existing = prefixUriMap.put(uri, prefix);
-                if (!Strings.CS.equals(existing, prefix))
+                if (existing != null && !existing.equals(prefix))
                 {
                     logger.warn(String.format(
                             "Namespace URI '%s' is registered under multiple prefixes; replacing '%s' with '%s'.",

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -1,0 +1,106 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2026 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.web.scripts.model;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.TreeMap;
+
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.util.PropertyCheck;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.extensions.webscripts.AbstractWebScript;
+import org.springframework.extensions.webscripts.Status;
+import org.springframework.extensions.webscripts.WebScriptException;
+import org.springframework.extensions.webscripts.WebScriptRequest;
+import org.springframework.extensions.webscripts.WebScriptResponse;
+
+/**
+ * Returns a map of namespace {@code URI -> prefix} for every namespace registered in the repository's
+ * {@link NamespaceService}. This is the supported, product replacement for the unofficial prefix-mapping
+ * extension the Search Enterprise Re-Indexer previously relied on (see ACS-12299 / PRODMAN-840).
+ * <p>
+ * Unlike the {@code /types} and {@code /aspects} public REST endpoints, this sources directly from
+ * {@link NamespaceService}, so it returns the complete registered set — including platform namespaces such as
+ * {@code sys} and {@code module} that have no enumerable type/aspect.
+ * <p>
+ * The response deliberately matches the shape of the legacy prefixes file so callers (and the re-indexer's
+ * on-disk cache) can consume it unchanged.
+ *
+ * Authentication follows the same model as the data-model API (an ordinary authenticated user; no admin role
+ * required) — enforced by the {@code user} authentication declared in the web script descriptor.
+ */
+public class NamespacePrefixGet extends AbstractWebScript implements InitializingBean
+{
+    private static final String KEY_PREFIX_URI_MAP = "prefixUriMap";
+
+    private NamespaceService namespaceService;
+
+    public void setNamespaceService(NamespaceService namespaceService)
+    {
+        this.namespaceService = namespaceService;
+    }
+
+    @Override
+    public void afterPropertiesSet()
+    {
+        PropertyCheck.mandatory(this, "namespaceService", namespaceService);
+    }
+
+    @Override
+    public void execute(WebScriptRequest req, WebScriptResponse res) throws IOException
+    {
+        // Sorted for deterministic, cache/diff-friendly output.
+        TreeMap<String, String> prefixUriMap = new TreeMap<>();
+        for (String prefix : namespaceService.getPrefixes())
+        {
+            prefixUriMap.put(namespaceService.getNamespaceURI(prefix), prefix);
+        }
+
+        res.setContentType("application/json");
+        res.setContentEncoding(StandardCharsets.UTF_8.name());
+
+        try (OutputStream os = res.getOutputStream())
+        {
+            JSONObject map = new JSONObject();
+            for (var entry : prefixUriMap.entrySet())
+            {
+                map.put(entry.getKey(), entry.getValue());
+            }
+            JSONObject json = new JSONObject();
+            json.put(KEY_PREFIX_URI_MAP, map);
+            os.write(json.toString(2).getBytes(StandardCharsets.UTF_8));
+        }
+        catch (JSONException e)
+        {
+            throw new WebScriptException(Status.STATUS_INTERNAL_SERVER_ERROR,
+                    "Failed to write namespace prefix map JSON", e);
+        }
+    }
+}

--- a/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
+++ b/remote-api/src/main/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGet.java
@@ -33,8 +33,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.Status;
@@ -50,7 +48,6 @@ import org.alfresco.util.PropertyCheck;
  */
 public class NamespacePrefixGet extends AbstractWebScript implements InitializingBean
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(NamespacePrefixGet.class);
 
     private static final String KEY_PREFIX_URI_MAP = "prefixUriMap";
 

--- a/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/model/namespace-prefix.get.desc.xml
+++ b/remote-api/src/main/resources/alfresco/templates/webscripts/org/alfresco/repository/model/namespace-prefix.get.desc.xml
@@ -1,0 +1,9 @@
+<webscript>
+  <shortname>Namespace Prefix Map</shortname>
+  <description>Returns a map of namespace URI to prefix for every namespace registered in the repository.</description>
+  <url>/api/model/namespace-prefix</url>
+  <format default="json">argument</format>
+  <authentication>user</authentication>
+  <transaction allow="readonly">required</transaction>
+  <family>Model</family>
+</webscript>

--- a/remote-api/src/main/resources/alfresco/web-scripts-application-context.xml
+++ b/remote-api/src/main/resources/alfresco/web-scripts-application-context.xml
@@ -1254,6 +1254,13 @@
       <property name="delegate" ref="webscript.content.streamer" />
    </bean>
 
+   <!-- ACS-12299: namespace URI->prefix map for the Search Enterprise Re-Indexer (sourced from NamespaceService) -->
+   <bean id="webscript.org.alfresco.repository.model.namespace-prefix.get"
+         class="org.alfresco.repo.web.scripts.model.NamespacePrefixGet"
+         parent="webscript">
+      <property name="namespaceService" ref="namespaceService"/>
+   </bean>
+
    <bean id="webscript.org.alfresco.repository.solr.model.get"
          class="org.alfresco.repo.web.scripts.solr.AlfrescoModelGet"
          parent="webscript">

--- a/remote-api/src/test/java/org/alfresco/AppContext04TestSuite.java
+++ b/remote-api/src/test/java/org/alfresco/AppContext04TestSuite.java
@@ -25,7 +25,6 @@
  */
 package org.alfresco;
 
-import org.alfresco.repo.web.scripts.model.NamespacePrefixGetRestApiTest;
 import org.junit.experimental.categories.Categories;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;

--- a/remote-api/src/test/java/org/alfresco/AppContext04TestSuite.java
+++ b/remote-api/src/test/java/org/alfresco/AppContext04TestSuite.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco;
 
+import org.alfresco.repo.web.scripts.model.NamespacePrefixGetRestApiTest;
 import org.junit.experimental.categories.Categories;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -78,7 +79,8 @@ import org.alfresco.util.testing.category.NonBuildTests;
         org.alfresco.rest.api.impl.CommentsImplUnitTest.class,
         org.alfresco.rest.api.impl.DownloadsImplCheckArchiveStatusUnitTest.class,
         org.alfresco.rest.api.impl.RestApiDirectUrlConfigUnitTest.class,
-        org.alfresco.rest.api.impl.SizeDetailsImplTest.class})
+        org.alfresco.rest.api.impl.SizeDetailsImplTest.class,
+        org.alfresco.repo.web.scripts.model.NamespacePrefixGetRestApiTest.class})
 public class AppContext04TestSuite
 {
     public AppContext04TestSuite()

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
@@ -41,11 +41,7 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.service.transaction.TransactionService;
 
 /**
- * Integration tests for the {@code /api/model/namespace-prefix} web script (ACS-12299), exercised end-to-end
- * against a running repository via the test web-script server.
- * <p>
- * Follows the repository's convention of testing web scripts through {@link BaseWebScriptTest} (HTTP round-trip)
- * rather than unit-testing the controller in isolation.
+ * Integration test for namespace-prefix api.
  */
 public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
 {

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
@@ -1,0 +1,175 @@
+/*
+ * #%L
+ * Alfresco Remote API
+ * %%
+ * Copyright (C) 2005 - 2026 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.web.scripts.model;
+
+import java.util.Collection;
+
+import org.json.JSONObject;
+import org.springframework.extensions.webscripts.TestWebScriptServer.GetRequest;
+import org.springframework.extensions.webscripts.TestWebScriptServer.Response;
+
+import org.alfresco.repo.dictionary.DictionaryDAO;
+import org.alfresco.repo.dictionary.M2Model;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
+import org.alfresco.repo.web.scripts.BaseWebScriptTest;
+import org.alfresco.service.namespace.NamespaceService;
+import org.alfresco.service.namespace.QName;
+import org.alfresco.service.transaction.TransactionService;
+
+/**
+ * Integration tests for the {@code /api/model/namespace-prefix} web script (ACS-12299), exercised end-to-end
+ * against a running repository via the test web-script server.
+ * <p>
+ * Follows the repository's convention of testing web scripts through {@link BaseWebScriptTest} (HTTP round-trip)
+ * rather than unit-testing the controller in isolation.
+ */
+public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
+{
+    private static final String URL = "/api/model/namespace-prefix";
+    private static final String KEY = "prefixUriMap";
+    private static final String CM_URI = "http://www.alfresco.org/model/content/1.0";
+    private static final String SYS_URI = "http://www.alfresco.org/model/system/1.0";
+    private static final String MODULE_URI = "http://www.alfresco.org/system/modules/1.0";
+
+    private NamespaceService namespaceService;
+    private TransactionService transactionService;
+
+    @Override
+    protected void setUp() throws Exception
+    {
+        super.setUp();
+        this.namespaceService = (NamespaceService) getServer().getApplicationContext().getBean("NamespaceService");
+        this.transactionService = (TransactionService) getServer().getApplicationContext().getBean("TransactionService");
+        AuthenticationUtil.setFullyAuthenticatedUser(AuthenticationUtil.getAdminUserName());
+    }
+
+    @Override
+    protected void tearDown() throws Exception
+    {
+        AuthenticationUtil.clearCurrentSecurityContext();
+        super.tearDown();
+    }
+
+    private JSONObject getPrefixUriMap() throws Exception
+    {
+        Response response = sendRequest(new GetRequest(URL), 200);
+        return new JSONObject(response.getContentAsString()).getJSONObject(KEY);
+    }
+
+    /** Happy path: the response has the {@code prefixUriMap} envelope and the always-present content model. */
+    public void testReturnsPrefixUriMap() throws Exception
+    {
+        JSONObject map = getPrefixUriMap();
+
+        assertEquals("cm", map.getString(CM_URI));
+        assertTrue("Expected the registry to contain many namespaces", map.length() > 1);
+    }
+
+    /**
+     * The whole point of ACS-12299: because the endpoint sources from NamespaceService (not /types + /aspects),
+     * it returns the platform namespaces those endpoints structurally cannot — e.g. {@code sys} and {@code module}.
+     */
+    public void testIncludesPlatformNamespaces() throws Exception
+    {
+        JSONObject map = getPrefixUriMap();
+
+        assertEquals("sys", map.getString(SYS_URI));
+        assertEquals("module", map.getString(MODULE_URI));
+    }
+
+    /**
+     * Fidelity: every namespace registered in the live {@link NamespaceService} must appear in the response, so
+     * the endpoint is a faithful projection of the registry (no silent filtering/drift).
+     */
+    public void testMatchesNamespaceService() throws Exception
+    {
+        JSONObject map = getPrefixUriMap();
+
+        Collection<String> prefixes = transactionService.getRetryingTransactionHelper()
+                .doInTransaction(() -> namespaceService.getPrefixes(), true);
+
+        for (String prefix : prefixes)
+        {
+            String uri = transactionService.getRetryingTransactionHelper()
+                    .doInTransaction(() -> namespaceService.getNamespaceURI(prefix), true);
+            assertTrue("Endpoint is missing registered namespace URI: " + uri, map.has(uri));
+        }
+    }
+
+    /**
+     * A custom content model registered at runtime (as a customer would via a deployed model / Custom Model
+     * Management) introduces a namespace that is <em>not</em> in the bootstrapped set. Because the endpoint
+     * sources from {@link NamespaceService}, that user-registered prefix must appear — this is the core
+     * drift/maintenance problem the old static prefixes file could not solve.
+     */
+    public void testIncludesUserRegisteredCustomNamespace() throws Exception
+    {
+        final String testUri = "http://www.example.com/model/testmodel/1.0";
+        final String testPrefix = "tpf";
+
+        final DictionaryDAO dictionaryDAO = (DictionaryDAO) getServer().getApplicationContext()
+                .getBean("dictionaryDAO");
+
+        // Register the custom model + namespace at runtime.
+        final QName modelName = transactionService.getRetryingTransactionHelper()
+                .doInTransaction((RetryingTransactionCallback<QName>) () -> {
+                    M2Model model = M2Model.createModel(testPrefix + ":testmodel");
+                    model.createNamespace(testUri, testPrefix);
+                    model.createType(testPrefix + ":testType");
+                    return dictionaryDAO.putModel(model);
+                }, false);
+
+        try
+        {
+            JSONObject map = getPrefixUriMap();
+
+            assertEquals("A user-registered custom namespace must be returned by the endpoint",
+                    testPrefix, map.getString(testUri));
+        }
+
+        finally
+        {
+            // Always remove the temporary model so it does not leak into other tests.
+            transactionService.getRetryingTransactionHelper()
+                    .doInTransaction((RetryingTransactionCallback<Void>) () -> {
+                        dictionaryDAO.removeModel(modelName);
+                        return null;
+                    }, false);
+        }
+    }
+
+    /**
+     * The descriptor declares {@code <authentication>user</authentication>}: an unauthenticated (guest) call is
+     * rejected. (Verify the exact status against the running server; the web-script framework returns 401 for a
+     * missing/guest authentication on a user-scoped script.)
+     */
+    public void testRequiresAuthentication() throws Exception
+    {
+        AuthenticationUtil.clearCurrentSecurityContext();
+        sendRequest(new GetRequest(URL), 401);
+    }
+}

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
@@ -41,7 +41,7 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.service.transaction.TransactionService;
 
 /**
- * Integration test for namespace-prefix api.
+ * * Unit Tests for the namespace-prefix api.
  */
 public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
 {

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
@@ -85,10 +85,6 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
         assertTrue("Expected the registry to contain many namespaces", map.length() > 1);
     }
 
-    /**
-     * The whole point of ACS-12299: because the endpoint sources from NamespaceService (not /types + /aspects),
-     * it returns the platform namespaces those endpoints structurally cannot — e.g. {@code sys} and {@code module}.
-     */
     public void testIncludesPlatformNamespaces() throws Exception
     {
         JSONObject map = getPrefixUriMap();
@@ -98,8 +94,7 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
     }
 
     /**
-     * Fidelity: every namespace registered in the live {@link NamespaceService} must appear in the response, so
-     * the endpoint is a faithful projection of the registry (no silent filtering/drift).
+     * Fidelity: every namespace registered in the live {@link NamespaceService} must appear in the response, so the endpoint is a faithful projection of the registry (no silent filtering/drift).
      */
     public void testMatchesNamespaceService() throws Exception
     {
@@ -117,10 +112,7 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
     }
 
     /**
-     * A custom content model registered at runtime (as a customer would via a deployed model / Custom Model
-     * Management) introduces a namespace that is <em>not</em> in the bootstrapped set. Because the endpoint
-     * sources from {@link NamespaceService}, that user-registered prefix must appear — this is the core
-     * drift/maintenance problem the old static prefixes file could not solve.
+     * A custom content model registered at runtime (as a customer would via a deployed model / Custom Model Management) introduces a namespace that is <em>not</em> in the bootstrapped set. Because the endpoint sources from {@link NamespaceService}, that user-registered prefix must appear — this is the core drift/maintenance problem the old static prefixes file could not solve.
      */
     public void testIncludesUserRegisteredCustomNamespace() throws Exception
     {
@@ -159,9 +151,7 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
     }
 
     /**
-     * The descriptor declares {@code <authentication>user</authentication>}: an unauthenticated (guest) call is
-     * rejected. (Verify the exact status against the running server; the web-script framework returns 401 for a
-     * missing/guest authentication on a user-scoped script.)
+     * The descriptor declares {@code <authentication>user</authentication>}: an unauthenticated (guest) call is rejected. (Verify the exact status against the running server; the web-script framework returns 401 for a missing/guest authentication on a user-scoped script.)
      */
     public void testRequiresAuthentication() throws Exception
     {

--- a/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
+++ b/remote-api/src/test/java/org/alfresco/repo/web/scripts/model/NamespacePrefixGetRestApiTest.java
@@ -25,6 +25,7 @@
  */
 package org.alfresco.repo.web.scripts.model;
 
+import java.io.IOException;
 import java.util.Collection;
 
 import org.json.JSONObject;
@@ -41,8 +42,9 @@ import org.alfresco.service.namespace.QName;
 import org.alfresco.service.transaction.TransactionService;
 
 /**
- * * Unit Tests for the namespace-prefix api.
+ * Unit Tests for the namespace-prefix api.
  */
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
 {
     private static final String URL = "/api/model/namespace-prefix";
@@ -70,13 +72,15 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
         super.tearDown();
     }
 
-    private JSONObject getPrefixUriMap() throws Exception
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    private JSONObject getPrefixUriMap() throws IOException
     {
         Response response = sendRequest(new GetRequest(URL), 200);
         return new JSONObject(response.getContentAsString()).getJSONObject(KEY);
     }
 
     /** Happy path: the response has the {@code prefixUriMap} envelope and the always-present content model. */
+    @SuppressWarnings({"PMD.UnitTestShouldUseTestAnnotation", "PMD.SignatureDeclareThrowsException"})
     public void testReturnsPrefixUriMap() throws Exception
     {
         JSONObject map = getPrefixUriMap();
@@ -85,6 +89,7 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
         assertTrue("Expected the registry to contain many namespaces", map.length() > 1);
     }
 
+    @SuppressWarnings({"PMD.UnitTestShouldUseTestAnnotation", "PMD.SignatureDeclareThrowsException"})
     public void testIncludesPlatformNamespaces() throws Exception
     {
         JSONObject map = getPrefixUriMap();
@@ -96,12 +101,13 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
     /**
      * Fidelity: every namespace registered in the live {@link NamespaceService} must appear in the response, so the endpoint is a faithful projection of the registry (no silent filtering/drift).
      */
+    @SuppressWarnings({"PMD.UnitTestShouldUseTestAnnotation", "PMD.SignatureDeclareThrowsException"})
     public void testMatchesNamespaceService() throws Exception
     {
         JSONObject map = getPrefixUriMap();
 
         Collection<String> prefixes = transactionService.getRetryingTransactionHelper()
-                .doInTransaction(() -> namespaceService.getPrefixes(), true);
+                .doInTransaction(namespaceService::getPrefixes, true);
 
         for (String prefix : prefixes)
         {
@@ -114,6 +120,7 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
     /**
      * A custom content model registered at runtime (as a customer would via a deployed model / Custom Model Management) introduces a namespace that is <em>not</em> in the bootstrapped set. Because the endpoint sources from {@link NamespaceService}, that user-registered prefix must appear — this is the core drift/maintenance problem the old static prefixes file could not solve.
      */
+    @SuppressWarnings({"PMD.UnitTestShouldUseTestAnnotation", "PMD.SignatureDeclareThrowsException"})
     public void testIncludesUserRegisteredCustomNamespace() throws Exception
     {
         final String testUri = "http://www.example.com/model/testmodel/1.0";
@@ -153,6 +160,7 @@ public class NamespacePrefixGetRestApiTest extends BaseWebScriptTest
     /**
      * The descriptor declares {@code <authentication>user</authentication>}: an unauthenticated (guest) call is rejected. (Verify the exact status against the running server; the web-script framework returns 401 for a missing/guest authentication on a user-scoped script.)
      */
+    @SuppressWarnings({"PMD.UnitTestShouldUseTestAnnotation", "PMD.SignatureDeclareThrowsException"})
     public void testRequiresAuthentication() throws Exception
     {
         AuthenticationUtil.clearCurrentSecurityContext();


### PR DESCRIPTION
This pull request introduces a new REST API endpoint that exposes a live mapping of namespace URIs to prefixes from the repository's `NamespaceService`. This endpoint addresses the need for a dynamic and authoritative source of namespace-prefix mappings, which is especially useful for components like the Search Enterprise Re-Indexer. The implementation includes the web script, its configuration, and comprehensive integration tests to ensure correctness and coverage of key scenarios.

This is a implementation of what https://github.com/AlfrescoLabs/model-ns-prefix-mapping is doing. 

**New Namespace Prefix API Endpoint**

- Implemented the `NamespacePrefixGet` web script (`NamespacePrefixGet.java`) to return a JSON map of namespace URIs to prefixes for all namespaces registered in the repository, ensuring deterministic and cache-friendly output.
- Registered the new web script bean in the Spring application context (`web-scripts-application-context.xml`) and provided a descriptor (`namespace-prefix.get.desc.xml`) defining its URL (`/api/model/namespace-prefix`), authentication requirements, and documentation. [[1]](diffhunk://#diff-b33534d7d470dbfddafeebeb378d5d4e0d083be0973dd382d998633e4db06717R1257-R1263) [[2]](diffhunk://#diff-13bb1a220afc762dd308b01c4e364a30a839f72c779a7962f56c45fce8d56739R1-R9)
