### PR TITLE
[ACS-11932] Fix incomplete PARENT associations indexed by SOLR for nodes with more than 2000 parents (#4226)

### DIFF
--- a/repository/src/main/java/org/alfresco/repo/solr/SOLRTrackingComponentImpl.java
+++ b/repository/src/main/java/org/alfresco/repo/solr/SOLRTrackingComponentImpl.java
@@ -909,38 +909,11 @@ public class SOLRTrackingComponentImpl implements SearchTrackingComponent
 
             if (!ignoreLargeMetadata && (typeIndexFilter.isIgnorePathsForSpecificTypes() || aspectIndexFilter.isIgnorePathsForSpecificAspects() || includeParentAssociations))
             {
-                // check if parent should be ignored
-                final List<Long> parentIds = new LinkedList<Long>();
-                final List<ChildAssociationRef> parentAssocs = new ArrayList<ChildAssociationRef>(100);
-                nodeDAO.getParentAssocs(nodeId, null, null, true, new ChildAssocRefQueryCallback() {
-                    @Override
-                    public boolean preLoadNodes()
-                    {
-                        return false;
-                    }
-
-                    @Override
-                    public boolean orderResults()
-                    {
-                        return false;
-                    }
-
-                    @Override
-                    public boolean handle(Pair<Long, ChildAssociationRef> childAssocPair, Pair<Long, NodeRef> parentNodePair, Pair<Long, NodeRef> childNodePair)
-                    {
-                        parentIds.add(parentNodePair.getFirst());
-                        parentAssocs.add(tenantService.getBaseName(childAssocPair.getSecond(), true));
-                        return false;
-                    }
-
-                    @Override
-                    public void done()
-                    {}
-                });
-
-                if (!parentIds.isEmpty())
+                // check if parent should be ignored - only the primary parent's type/aspects are relevant here
+                Pair<Long, ChildAssociationRef> primaryParentAssoc = nodeDAO.getPrimaryParentAssoc(nodeId);
+                if (primaryParentAssoc != null)
                 {
-                    Long parentId = parentIds.iterator().next();
+                    Long parentId = primaryParentAssoc.getFirst();
                     if (typeIndexFilter.isIgnorePathsForSpecificTypes())
                     {
                         QName parentType = getNodeType(parentId);
@@ -954,6 +927,39 @@ public class SOLRTrackingComponentImpl implements SearchTrackingComponent
 
                 if (includeParentAssociations)
                 {
+                    // Fetch all parent associations (primary and non-primary, e.g. group membership) for indexing.
+                    // Do not filter by isPrimary here: doing so causes AbstractNodeDAOImpl.getParentAssocs to run a
+                    // DB query restricted to the primary parent once a node's total parent-assoc count exceeds
+                    // PARENT_ASSOCS_CACHE_FILTER_THRESHOLD, silently dropping non-primary parents (e.g. group
+                    // memberships) from what gets indexed.
+                    final List<ChildAssociationRef> parentAssocs = new ArrayList<>(100);
+                    nodeDAO.getParentAssocs(nodeId, null, null, null, new ChildAssocRefQueryCallback() {
+                        @Override
+                        public boolean preLoadNodes()
+                        {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean orderResults()
+                        {
+                            return false;
+                        }
+
+                        @Override
+                        public boolean handle(Pair<Long, ChildAssociationRef> childAssocPair, Pair<Long, NodeRef> parentNodePair, Pair<Long, NodeRef> childNodePair)
+                        {
+                            parentAssocs.add(tenantService.getBaseName(childAssocPair.getSecond(), true));
+                            return true;
+                        }
+
+                        @Override
+                        public void done()
+                        {
+                            // No action required once all parent associations have been handled.
+                        }
+                    });
+
                     for (ChildAssociationRef ref : categoryPaths.getCategoryParents())
                     {
                         parentAssocs.add(tenantService.getBaseName(ref, true));

--- a/repository/src/test/java/org/alfresco/repo/solr/SOLRTrackingComponentTest.java
+++ b/repository/src/test/java/org/alfresco/repo/solr/SOLRTrackingComponentTest.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -63,6 +64,7 @@ import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
 import org.alfresco.service.cmr.model.FileFolderService;
 import org.alfresco.service.cmr.model.FileInfo;
+import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.repository.StoreRef;
@@ -483,6 +485,94 @@ public class SOLRTrackingComponentTest extends BaseSpringTest
         // filter.setIncludePaths(false);
         filter.setIncludeChildAssociations(false);
         getNodeMetaData(nodeMetaDataParams, filter, st);
+    }
+
+    /**
+     * Nodes whose total number of parent associations (primary + secondary) exceed {@code AbstractNodeDAOImpl.PARENT_ASSOCS_CACHE_FILTER_THRESHOLD} (2000) used to have only its primary parent association reported by {@link SOLRTrackingComponentImpl#getNodesMetadata}, silently dropping every non-primary parent (e.g. group membership, modelled as a secondary child association) from what gets indexed by SOLR.
+     */
+    @Category(PerformanceTests.class)
+    @Test
+    public void testGetNodesMetadata_manyParentAssociations() throws Exception
+    {
+        final int numberOfSecondaryParents = 2005;
+
+        final Set<NodeRef> expectedParents = new HashSet<>();
+        expectedParents.add(rootNodeRef);
+
+        final NodeRef childNodeRef = txnHelper.doInTransaction(new RetryingTransactionCallback<>() {
+            @Override
+            public NodeRef execute() throws Throwable
+            {
+                Map<QName, Serializable> childProps = new PropertyMap();
+                childProps.put(ContentModel.PROP_NAME, "testGetNodesMetadata_manyParentAssociations_child");
+                NodeRef child = nodeService.createNode(
+                        rootNodeRef,
+                        ContentModel.ASSOC_CHILDREN,
+                        ContentModel.ASSOC_CHILDREN,
+                        ContentModel.TYPE_CONTENT,
+                        childProps).getChildRef();
+
+                for (int i = 0; i < numberOfSecondaryParents; i++)
+                {
+                    Map<QName, Serializable> parentProps = new PropertyMap();
+                    parentProps.put(ContentModel.PROP_NAME, "testGetNodesMetadata_manyParentAssociations_parent" + i);
+                    NodeRef secondaryParent = nodeService.createNode(
+                            rootNodeRef,
+                            ContentModel.ASSOC_CHILDREN,
+                            ContentModel.ASSOC_CHILDREN,
+                            ContentModel.TYPE_FOLDER,
+                            parentProps).getChildRef();
+                    expectedParents.add(secondaryParent);
+
+                    // Secondary (non-primary) child association - this is how group membership is modelled.
+                    nodeService.addChild(
+                            secondaryParent,
+                            child,
+                            ContentModel.ASSOC_CONTAINS,
+                            QName.createQName(NamespaceService.CONTENT_MODEL_1_0_URI, "secondaryParent" + i));
+                }
+
+                return child;
+            }
+        });
+
+        final Long childNodeId = nodeDAO.getNodeRefStatus(childNodeRef).getDbId();
+
+        final List<NodeMetaData> results = new ArrayList<>(1);
+        final NodeMetaDataQueryCallback callback = new NodeMetaDataQueryCallback() {
+            @Override
+            public boolean handleNodeMetaData(NodeMetaData nodeMetaData)
+            {
+                results.add(nodeMetaData);
+                return true;
+            }
+        };
+
+        final NodeMetaDataParameters params = new NodeMetaDataParameters();
+        params.setNodeIds(Collections.singletonList(childNodeId));
+        final MetaDataResultsFilter filter = new MetaDataResultsFilter();
+        filter.setIncludeParentAssociations(true);
+
+        txnHelper.doInTransaction(new RetryingTransactionCallback<Void>() {
+            @Override
+            public Void execute() throws Throwable
+            {
+                solrTrackingComponent.getNodesMetadata(params, filter, callback);
+                return null;
+            }
+        }, true, true);
+
+        assertEquals("Expected metadata for exactly one node", 1, results.size());
+
+        Set<NodeRef> actualParents = new HashSet<>();
+        for (ChildAssociationRef assoc : results.get(0).getParentAssocs())
+        {
+            actualParents.add(assoc.getParentRef());
+        }
+
+        assertEquals("Expected every parent association (primary and " + numberOfSecondaryParents
+                + " secondary) to be reported to SOLR, but some were silently dropped",
+                expectedParents, actualParents);
     }
 
     @Test


### PR DESCRIPTION
(cherry picked from commit a8992be75a029bba8b79cafa28a6e8e1e439dc56)