### PR TITLE
ACS-11940 bump documentation links to 26.2

### DIFF
--- a/amps/ags/rm-community/documentation/destruction/README.md
+++ b/amps/ags/rm-community/documentation/destruction/README.md
@@ -23,7 +23,7 @@ Recorded content can be explicitly destroyed whilst maintaining the original nod
 * License: Alfresco Community
 * Issue Tracker Link: [JIRA RM](https://issues.alfresco.com/jira/projects/RM/summary)
 * Contribution Model: Alfresco Closed Source
-* Documentation: [docs.hyland.com (Records Management)](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1&component=Alfresco%20Governance%20Services%20Community%20Edition)
+* Documentation: [docs.hyland.com (Records Management)](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.2&component=Alfresco%20Governance%20Services%20Community%20Edition)
 
 *** 
 

--- a/amps/ags/rm-community/documentation/overview.md
+++ b/amps/ags/rm-community/documentation/overview.md
@@ -21,18 +21,18 @@ RM is split into two main parts - a repository integration and a Share integrati
 * [Community License](../LICENSE.txt)
 * [Enterprise License](../../rm-enterprise/LICENSE.txt) (this file will only be present in clones of the Enterprise repository)
 * [Issue Tracker Link](https://issues.alfresco.com/jira/projects/RM)
-* [Community Documentation Link](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1&component=Alfresco%20Governance%20Services%20Community%20Edition)
-* [Enterprise Documentation Link](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.1)
+* [Community Documentation Link](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.2&component=Alfresco%20Governance%20Services%20Community%20Edition)
+* [Enterprise Documentation Link](https://docs.hyland.com/access?dita:id=job1721300866386&vrm_version=26.2)
 * [Contribution Model](../../CONTRIBUTING.md)
 
 *** 
 
 ### Prerequisite Knowledge
-An understanding of Alfresco Content Services is assumed. The following pages from the [developer documentation](https://docs.hyland.com/access?dita:id=lsl1724405261585&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition) give useful background information:
+An understanding of Alfresco Content Services is assumed. The following pages from the [developer documentation](https://docs.hyland.com/access?dita:id=lsl1724405261585&vrm_version=26.2&component=Alfresco%20Content%20Services%20Community%20Edition) give useful background information:
 
-* [ACS Architecture](https://docs.hyland.com/access?dita:id=lfo1719554691023&vrm_version=26.1)
-* [Platform Extensions](https://docs.hyland.com/access?dita:id=ifr1720080387005&vrm_version=26.1)
-* [Share Extensions](https://docs.hyland.com/access?dita:id=wqu1720687386891&vrm_version=26.1)
+* [ACS Architecture](https://docs.hyland.com/access?dita:id=lfo1719554691023&vrm_version=26.2)
+* [Platform Extensions](https://docs.hyland.com/access?dita:id=ifr1720080387005&vrm_version=26.2)
+* [Share Extensions](https://docs.hyland.com/access?dita:id=wqu1720687386891&vrm_version=26.2)
 
 *** 
 
@@ -44,12 +44,12 @@ The RM Share module communicates with the repository module via REST APIs. Inter
 * A DAO layer responsible for CRUD operations against the database.
 
 #### REST API
-The REST API endpoints fall into two main types - v0 (Webscripts) and v1. The [v0 API](https://docs.hyland.com/access?dita:id=fga1720080409048&vrm_version=26.1) is older and not recommended for integrations. The [v1 API](https://docs.hyland.com/access?dita:id=cmm1721136574006&vrm_version=26.1) is newer but isn't yet feature complete. If you are running RM locally then the GS API Explorer will be available at [this link](http://localhost:8080/gs-api-explorer/).
+The REST API endpoints fall into two main types - v0 (Webscripts) and v1. The [v0 API](https://docs.hyland.com/access?dita:id=fga1720080409048&vrm_version=26.2) is older and not recommended for integrations. The [v1 API](https://docs.hyland.com/access?dita:id=cmm1721136574006&vrm_version=26.2) is newer but isn't yet feature complete. If you are running RM locally then the GS API Explorer will be available at [this link](http://localhost:8080/gs-api-explorer/).
 
 Internally the GS v1 REST API is built on the [Alfresco v1 REST API framework](https://community.alfresco.com/community/ecm/blog/2016/10/11/v1-rest-api-part-1-introduction). It aims to be consistent with this in terms of behaviour and naming.
 
 #### Java Public API
-The Java service layer is fronted by a [Java Public API](https://docs.hyland.com/access?dita:id=lol1721390191517&vrm_version=26.1), which we will ensure backward compatible with previous releases. Before we remove any methods there will first be a release containing that method deprecated to allow third party integrations to migrate to a new method.  The Java Public API also includes a set of POJO objects which are needed to communicate with the services. It is easy to identify classes that are part of the Java Public API as they are annotated `@AlfrescoPublicApi`.
+The Java service layer is fronted by a [Java Public API](https://docs.hyland.com/access?dita:id=lol1721390191517&vrm_version=26.2), which we will ensure backward compatible with previous releases. Before we remove any methods there will first be a release containing that method deprecated to allow third party integrations to migrate to a new method.  The Java Public API also includes a set of POJO objects which are needed to communicate with the services. It is easy to identify classes that are part of the Java Public API as they are annotated `@AlfrescoPublicApi`.
 
 Each Java service will have at least four beans defined for it:
 
@@ -61,7 +61,7 @@ Each Java service will have at least four beans defined for it:
 #### DAOs
 The DAOs are not part of the Java Public API, but handle CRUD operations against RM stored data. We have some custom queries to improve performance for particularly heavy operations.
 
-We use standard Alfresco [data modelling](https://docs.hyland.com/access?dita:id=ekx1720080373621&vrm_version=26.1) to store RM metadata. We extend the [Alfresco patching mechanism](https://docs.hyland.com/access?dita:id=ato1720080396825&vrm_version=26.1) to provide community and enterprise schema upgrades.
+We use standard Alfresco [data modelling](https://docs.hyland.com/access?dita:id=ekx1720080373621&vrm_version=26.2) to store RM metadata. We extend the [Alfresco patching mechanism](https://docs.hyland.com/access?dita:id=ato1720080396825&vrm_version=26.2) to provide community and enterprise schema upgrades.
 
 ***
 

--- a/packaging/tests/tas-cmis/README.md
+++ b/packaging/tests/tas-cmis/README.md
@@ -27,7 +27,7 @@
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://docs.hyland.com/access?dita:id=kvf1721390177551&vrm_version=26.2). 
+**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://docs.hyland.com/access?dita:id=kvf1721390177551&vrm_version=26.2).
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 

--- a/packaging/tests/tas-cmis/README.md
+++ b/packaging/tests/tas-cmis/README.md
@@ -27,7 +27,7 @@
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://docs.hyland.com/access?dita:id=kvf1721390177551&vrm_version=26.1). 
+**TAS**( **T**est **A**utomation **S**ystem)- **CMIS** is the project that handles the automated tests related only to CMIS API integrated with Alfresco One [Alfresco CMIS API](https://docs.hyland.com/access?dita:id=kvf1721390177551&vrm_version=26.2). 
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 

--- a/packaging/tests/tas-restapi/README.md
+++ b/packaging/tests/tas-restapi/README.md
@@ -27,7 +27,7 @@ Back to [TAS Master Documentation](https://git.alfresco.com/tas/alfresco-tas-uti
 
 ## Synopsis
 
-**TAS**( **T**est **A**utomation **S**ystem)- **RESTAPI** is the project that handles the automated tests related only to [Alfresco REST API](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide).
+**TAS**( **T**est **A**utomation **S**ystem)- **RESTAPI** is the project that handles the automated tests related only to [Alfresco REST API](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.2/Alfresco-Content-Services/Develop/REST-API-Guide).
 
 It is based on Apache Maven, compatible with major IDEs and is using also Spring capabilities for dependency injection.
 
@@ -271,7 +271,7 @@ restClient.onResponse().assertThat().body("entry.modifiedBy.firstName", org.hamc
 
 ### How to generate models or check coverage
 
-There are some simple generators that could parse [Swagger YAML](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some useful information to you like:
+There are some simple generators that could parse [Swagger YAML](https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.2/Alfresco-Content-Services/Develop/REST-API-Guide/Things-to-Know-Before-You-Start/The-API-Explorer-is-Your-Source-of-Truth) files and provide some useful information to you like:
  
 a) Show on screen the actual coverage of TAS vs requests that exists in each YAML file - defined in pom.xml) 
 

--- a/repository/docs/identity-provider/authentication/README.md
+++ b/repository/docs/identity-provider/authentication/README.md
@@ -27,7 +27,7 @@ to integrate with a number of external Authentication providers including
   * https://github.com/Alfresco/alfresco-data-model/tree/master/src/main/java/org/alfresco/repo/security/authentication
 * License: LGPL
 * Issue Tracker Link: https://issues.alfresco.com/jira/issues/?jql=project%3DREPO
-* Documentation Link: https://docs.hyland.com/access?dita:id=byj1720776091160&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
+* Documentation Link: https://docs.hyland.com/access?dita:id=byj1720776091160&vrm_version=26.2&component=Alfresco%20Content%20Services%20Community%20Edition
 * Contribution Model: Alfresco Open Source
 ***
 

--- a/repository/docs/meta-data-services/versions/README.md
+++ b/repository/docs/meta-data-services/versions/README.md
@@ -16,7 +16,7 @@
 * Source Code Link:m https://svn.alfresco.com/repos/alfresco-enterprise/alfresco/
 * License: LGPL
 * Issue Tracker Link: https://issues.alfresco.com/jira/secure/RapidBoard.jspa?projectKey=REPO&useStoredSettings=true&rapidView=379
-* Documentation Link: https://docs.hyland.com/access?dita:id=ybx1720084724583&vrm_version=26.1
+* Documentation Link: https://docs.hyland.com/access?dita:id=ybx1720084724583&vrm_version=26.2
 * Contribution Model: Alfresco publishes the source code and will review proposed patch requests
 ***
 

--- a/repository/src/main/java/org/alfresco/repo/template/DocumentationURLMethod.java
+++ b/repository/src/main/java/org/alfresco/repo/template/DocumentationURLMethod.java
@@ -79,13 +79,13 @@ public class DocumentationURLMethod extends BaseTemplateProcessorExtension imple
      * b) First argument is interpreted as Topic UID of the URL. The value is retrieved and treated as Topic UID appended after baseURL and before version.
      * 
      * <pre>
-     *      ${documentationUrl("eet567890373737")} -> https://docs.hyland.com/access?dita:id=eet567890373737&vrm_version=26.1
+     *      ${documentationUrl("eet567890373737")} -> https://docs.hyland.com/access?dita:id=eet567890373737&vrm_version=26.2
      * </pre>
      * 
      * c) Second argument(if required) is interpreted as an additional URL component, which will be appended to the URL to denote a specific component of Alfresco.
      * 
      * <pre>
-     *     ${documentationUrl("eeu1720075126296", "&component=Alfresco%20Content%20Services%20Community%20Edition")} -> https://docs.hyland.com/access?dita:id=eeu1720075126296&vrm_version=26.1&component=Alfresco%20Content%20Services%20Community%20Edition
+     *     ${documentationUrl("eeu1720075126296", "&component=Alfresco%20Content%20Services%20Community%20Edition")} -> https://docs.hyland.com/access?dita:id=eeu1720075126296&vrm_version=26.2&component=Alfresco%20Content%20Services%20Community%20Edition
      * </pre>
      *
      * d) Third argument (if required) is interpreted as the Alfresco component (e.g., "solr", "elasticsearch", or empty) to determine which version to use in the URL.

--- a/repository/src/main/resources/alfresco/repository.properties
+++ b/repository/src/main/resources/alfresco/repository.properties
@@ -1427,7 +1427,7 @@ default.nodeSize.workQueueSize=100
 
 # Documentation URLs properties
 alfresco.documentation.baseurl=https://docs.hyland.com/access?dita:id=
-alfresco.documentation.acsVersion=&vrm_version=26.1
+alfresco.documentation.acsVersion=&vrm_version=26.2
 alfresco.documentation.searchVersion=&vrm_version=2.0
-alfresco.documentation.searchEnterpriseVersion=&vrm_version=5.1
+alfresco.documentation.searchEnterpriseVersion=&vrm_version=5.7
 alfresco.documentation.defaultDocumentationUrl=https://docs.hyland.com/p/alfresco


### PR DESCRIPTION
Updates stale version  to latest available on docs.hyland.