### PR TITLE
ACS-12437 Enhance get-downstream-commit-message action

### DIFF
--- a/.github/actions/get-downstream-commit-message/action.sh
+++ b/.github/actions/get-downstream-commit-message/action.sh
@@ -8,7 +8,6 @@ if [[ "${COMMIT_TITLE}" =~ (\[force[^]]*\]) ]]; then
     if [[ "${TRIGGER_RELEASE_ON_FORCE:-false}" == "true" ]]; then
         force_prefix="${force_prefix}[release][skip tests]"
     fi
-    force_prefix="${force_prefix}"
     allow_empty_commit="true"
 fi
 

--- a/.github/actions/get-downstream-commit-message/action.sh
+++ b/.github/actions/get-downstream-commit-message/action.sh
@@ -8,7 +8,7 @@ if [[ "${COMMIT_TITLE}" =~ (\[force[^]]*\]) ]]; then
     if [[ "${TRIGGER_RELEASE_ON_FORCE:-false}" == "true" ]]; then
         force_prefix="${force_prefix}[release][skip tests]"
     fi
-    force_prefix="${force_prefix} "
+    force_prefix="${force_prefix}"
     allow_empty_commit="true"
 fi
 
@@ -18,18 +18,26 @@ if [[ -n "${DIRECTIVES:-}" ]]; then
     if [[ "${COMMIT_TITLE}" =~ \[publish\] ]] && [[ "${directives}" != *"[publish]"* ]]; then
         directives="${directives}[publish]"
     fi
-    directives_prefix="${directives} "
+    directives_prefix="${directives}"
+fi
+
+# Build the message: tokens are concatenated without spaces; a single trailing
+# space separates the token block from the message body.
+if [[ -n "${force_prefix}${directives_prefix}" ]]; then
+    token_block="${force_prefix}${directives_prefix} "
+else
+    token_block=""
 fi
 
 if [[ -z "${DOWNSTREAM_REPO:-}" ]]; then
-    message="${force_prefix}${directives_prefix}${VERSION}"
+    message="${token_block}${VERSION}"
 else
-    message="${force_prefix}${directives_prefix}Update ${DOWNSTREAM_REPO} version to ${VERSION}"
+    message="${token_block}Update ${DOWNSTREAM_REPO} version to ${VERSION}"
 fi
 message="${message//$'\n'/ }"
 message="${message//$'\r'/ }"
 
-if [[ -n "${PENDING_DOWNSTREAM}" ]]; then
+if [[ -n "${PENDING_DOWNSTREAM:-}" ]]; then
     if [[ "${BRANCH_NAME}" == "master" ]]; then
         directive="[skip docker_latest]"
     else

--- a/.github/actions/get-downstream-commit-message/action.sh
+++ b/.github/actions/get-downstream-commit-message/action.sh
@@ -4,11 +4,28 @@ set -euo pipefail
 force_prefix=""
 allow_empty_commit="false"
 if [[ "${COMMIT_TITLE}" =~ (\[force[^]]*\]) ]]; then
-    force_prefix="${BASH_REMATCH[1]} "
+    force_prefix="${BASH_REMATCH[1]}"
+    if [[ "${TRIGGER_RELEASE_ON_FORCE:-false}" == "true" ]]; then
+        force_prefix="${force_prefix}[release][skip tests]"
+    fi
+    force_prefix="${force_prefix} "
     allow_empty_commit="true"
 fi
 
-message="${force_prefix}Update ${DOWNSTREAM_REPO} version to ${VERSION}"
+directives_prefix=""
+if [[ -n "${DIRECTIVES:-}" ]]; then
+    directives="${DIRECTIVES}"
+    if [[ "${COMMIT_TITLE}" =~ \[publish\] ]]; then
+        directives="${directives}[publish]"
+    fi
+    directives_prefix="${directives} "
+fi
+
+if [[ -z "${DOWNSTREAM_REPO:-}" ]]; then
+    message="${force_prefix}${directives_prefix}${VERSION}"
+else
+    message="${force_prefix}${directives_prefix}Update ${DOWNSTREAM_REPO} version to ${VERSION}"
+fi
 message="${message//$'\n'/ }"
 message="${message//$'\r'/ }"
 

--- a/.github/actions/get-downstream-commit-message/action.sh
+++ b/.github/actions/get-downstream-commit-message/action.sh
@@ -15,7 +15,7 @@ fi
 directives_prefix=""
 if [[ -n "${DIRECTIVES:-}" ]]; then
     directives="${DIRECTIVES}"
-    if [[ "${COMMIT_TITLE}" =~ \[publish\] ]]; then
+    if [[ "${COMMIT_TITLE}" =~ \[publish\] ]] && [[ "${directives}" != *"[publish]"* ]]; then
         directives="${directives}[publish]"
     fi
     directives_prefix="${directives} "

--- a/.github/actions/get-downstream-commit-message/action.yml
+++ b/.github/actions/get-downstream-commit-message/action.yml
@@ -6,6 +6,16 @@ description: >
   that token is prepended to the message and allow-empty-commit is set to true, so the downstream
   commit is created even when no files changed.
 
+  If trigger-release-on-force is set to 'true' and a [force...] token is present, [release][skip
+  tests] is appended directly after the force token so the downstream repo triggers its own release.
+
+  If directives is set (e.g. '[release]'), those tokens are prepended to the message body.
+  '[publish]' is appended to directives automatically when the upstream commit title contains a
+  [publish] token (producing e.g. '[release][publish]').
+
+  If downstream-repo is omitted the message body is the bare version string (e.g. '[release]
+  26.3.0-A.4') instead of 'Update <repo> version to <version>'.
+
   If pending-downstream is provided, a directive is appended indicating that the build should be
   skipped until that downstream repo triggers it: "[skip docker_latest/docker_release] until
   <pending-downstream> triggers the build or it is built manually".
@@ -30,7 +40,7 @@ inputs:
     required: false
     default: ""
   trigger-release-on-force:
-    description: "When true and a [force...] token is present, appends [release][skip tests] after the force token so the downstream repo triggers its own release. Defaults to false for backward compatibility."
+    description: "Set to 'true' (string) to append [release][skip tests] directly after the [force...] token when one is present, so the downstream repo triggers its own release. Defaults to 'false' for backward compatibility."
     required: false
     default: "false"
   directives:

--- a/.github/actions/get-downstream-commit-message/action.yml
+++ b/.github/actions/get-downstream-commit-message/action.yml
@@ -18,14 +18,26 @@ inputs:
     description: "Version string to embed in the commit message"
     required: true
   downstream-repo:
-    description: "Short name of the downstream repository, used in the commit message (e.g. enterprise-repo)"
-    required: true
+    description: "Short name of the downstream repository (e.g. 'enterprise-repo'). When provided, the message body is 'Update <downstream-repo> version to <version>'. When omitted, the body is just the bare version string (e.g. '[release] 26.3.0-A.4')."
+    required: false
+    default: ""
   pending-downstream:
     description: "Name of the downstream repo that will trigger the real build (e.g. alfresco-enterprise-share). When set, a skip directive is appended."
     required: false
     default: ""
   branch-name:
     description: "Current branch name, used to pick the correct skip directive (master → skip docker_latest, else → skip docker_release). Only used when pending-downstream is set."
+    required: false
+    default: ""
+  trigger-release-on-force:
+    description: "When true and a [force...] token is present, appends [release][skip tests] after the force token so the downstream repo triggers its own release. Defaults to false for backward compatibility."
+    required: false
+    default: "false"
+  directives:
+    description: >
+      Base directives to prepend to the message (e.g. '[release]'). When set, '[publish]' is
+      appended automatically if the upstream commit title contains a [publish] token
+      (producing e.g. '[release][publish]'). Defaults to empty for backward compatibility.
     required: false
     default: ""
 
@@ -48,5 +60,7 @@ runs:
         DOWNSTREAM_REPO: ${{ inputs.downstream-repo }}
         PENDING_DOWNSTREAM: ${{ inputs.pending-downstream }}
         BRANCH_NAME: ${{ inputs.branch-name }}
+        TRIGGER_RELEASE_ON_FORCE: ${{ inputs.trigger-release-on-force }}
+        DIRECTIVES: ${{ inputs.directives }}
       shell: bash
       run: ${{ github.action_path }}/action.sh

--- a/.github/actions/get-downstream-commit-message/tests/get-downstream-commit-message.bats
+++ b/.github/actions/get-downstream-commit-message/tests/get-downstream-commit-message.bats
@@ -12,6 +12,8 @@ setup() {
     export DOWNSTREAM_REPO="community-repo"
     export PENDING_DOWNSTREAM=""
     export BRANCH_NAME=""
+    export TRIGGER_RELEASE_ON_FORCE="false"
+    export DIRECTIVES=""
 }
 
 teardown() {
@@ -108,6 +110,74 @@ get_output() {
     [ "$(get_output allow-empty-commit)" = "true" ]
 }
 
+# downstream-repo omitted → bare version body
+
+@test "downstream-repo omitted produces bare version as message body" {
+    unset DOWNSTREAM_REPO
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "26.3.0-A.4" ]
+}
+
+@test "downstream-repo empty produces bare version as message body" {
+    export DOWNSTREAM_REPO=""
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "26.3.0-A.4" ]
+}
+
+@test "downstream-repo omitted with directives=[release] produces '[release] <version>'" {
+    unset DOWNSTREAM_REPO
+    export DIRECTIVES="[release]"
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[release] 26.3.0-A.4" ]
+}
+
+@test "downstream-repo omitted with directives=[release] and [publish] produces '[release][publish] <version>'" {
+    unset DOWNSTREAM_REPO
+    export DIRECTIVES="[release]"
+    export COMMIT_TITLE="ACS-123: publish this [publish]"
+    export VERSION="26.2.0"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[release][publish] 26.2.0" ]
+}
+
+@test "downstream-repo omitted with [force] prefixes force token before version" {
+    unset DOWNSTREAM_REPO
+    export COMMIT_TITLE="[force] ACS-123: force release"
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force] 26.3.0-A.4" ]
+    [ "$(get_output allow-empty-commit)" = "true" ]
+}
+
+@test "downstream-repo omitted does not include repo name in message" {
+    unset DOWNSTREAM_REPO
+    export DIRECTIVES="[release]"
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$(get_output message)" != *"version to"* ]]
+}
+
 # pending-downstream tests
 
 @test "pending-downstream appends skip docker_release directive on non-master branch" {
@@ -179,4 +249,199 @@ get_output() {
 
     [ "$status" -eq 0 ]
     [ "$(get_output message)" = "Update community-repo version to 1.2.3" ]
+}
+
+# trigger-release-on-force tests
+
+@test "trigger-release-on-force=false with [force] does not add [release][skip tests]" {
+    export COMMIT_TITLE="[force] ACS-123: trigger downstream CI"
+    export TRIGGER_RELEASE_ON_FORCE="false"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force] Update community-repo version to 1.2.3" ]
+}
+
+@test "trigger-release-on-force omitted with [force] does not add [release][skip tests]" {
+    export COMMIT_TITLE="[force] ACS-123: trigger downstream CI"
+    unset TRIGGER_RELEASE_ON_FORCE
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force] Update community-repo version to 1.2.3" ]
+}
+
+@test "trigger-release-on-force=true with [force] appends [release][skip tests] after force token" {
+    export COMMIT_TITLE="[force] ACS-123: trigger downstream CI"
+    export TRIGGER_RELEASE_ON_FORCE="true"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force][release][skip tests] Update community-repo version to 1.2.3" ]
+}
+
+@test "trigger-release-on-force=true with [force] still sets allow-empty-commit=true" {
+    export COMMIT_TITLE="[force] ACS-123: trigger downstream CI"
+    export TRIGGER_RELEASE_ON_FORCE="true"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output allow-empty-commit)" = "true" ]
+}
+
+@test "trigger-release-on-force=true with versioned [force 26.3.0-A.7] appends [release][skip tests]" {
+    export COMMIT_TITLE="ACS-123 bump [force 26.3.0-A.7]"
+    export TRIGGER_RELEASE_ON_FORCE="true"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force 26.3.0-A.7][release][skip tests] Update community-repo version to 1.2.3" ]
+}
+
+@test "trigger-release-on-force=true without [force] produces plain message" {
+    export COMMIT_TITLE="ACS-123: regular change"
+    export TRIGGER_RELEASE_ON_FORCE="true"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "Update community-repo version to 1.2.3" ]
+    [ "$(get_output allow-empty-commit)" = "false" ]
+}
+
+@test "trigger-release-on-force=true combined with pending-downstream produces correct message" {
+    export COMMIT_TITLE="[force] ACS-123: trigger downstream CI"
+    export TRIGGER_RELEASE_ON_FORCE="true"
+    export PENDING_DOWNSTREAM="alfresco-enterprise-share"
+    export BRANCH_NAME="master"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    expected="[force][release][skip tests] Update community-repo version to 1.2.3
+
+[skip docker_latest] until alfresco-enterprise-share triggers the build or it is built manually"
+    [ "$(get_output message)" = "$expected" ]
+}
+
+# directives tests
+
+@test "directives empty produces no directives prefix" {
+    export DIRECTIVES=""
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "Update community-repo version to 1.2.3" ]
+}
+
+@test "directives omitted produces no directives prefix" {
+    unset DIRECTIVES
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "Update community-repo version to 1.2.3" ]
+}
+
+@test "directives=[release] without [publish] produces '[release] Update...' message" {
+    export DIRECTIVES="[release]"
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[release] Update community-repo version to 26.3.0-A.4" ]
+}
+
+@test "directives=[release] with [publish] in title produces '[release][publish] Update...' message" {
+    export DIRECTIVES="[release]"
+    export COMMIT_TITLE="ACS-123: release [publish]"
+    export VERSION="26.2.0"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[release][publish] Update community-repo version to 26.2.0" ]
+}
+
+@test "directives=[release] with [publish] at start of title is detected" {
+    export DIRECTIVES="[release]"
+    export COMMIT_TITLE="[publish] ACS-123: release at start"
+    export VERSION="26.2.0"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[release][publish] Update community-repo version to 26.2.0" ]
+}
+
+@test "directives without [publish] in title does not append [publish]" {
+    export DIRECTIVES="[release]"
+    export COMMIT_TITLE="ACS-123: regular release, no publish"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$(get_output message)" != *"[publish]"* ]]
+}
+
+@test "directives=[release] combined with [force] prefixes force before directives" {
+    export DIRECTIVES="[release]"
+    export COMMIT_TITLE="[force] ACS-123: force and release"
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force] [release] Update community-repo version to 26.3.0-A.4" ]
+    [ "$(get_output allow-empty-commit)" = "true" ]
+}
+
+@test "directives=[release] with [publish] combined with [force] produces correct message" {
+    export DIRECTIVES="[release]"
+    export COMMIT_TITLE="[force] ACS-123: force and publish [publish]"
+    export VERSION="26.3.0-A.4"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [ "$(get_output message)" = "[force] [release][publish] Update community-repo version to 26.3.0-A.4" ]
+    [ "$(get_output allow-empty-commit)" = "true" ]
+}
+
+@test "directives=[release] combined with pending-downstream appends skip directive" {
+    export DIRECTIVES="[release]"
+    export VERSION="26.3.0-A.4"
+    export PENDING_DOWNSTREAM="alfresco-enterprise-share"
+    export BRANCH_NAME="feature/ACS-123"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    expected="[release] Update community-repo version to 26.3.0-A.4
+
+[skip docker_release] until alfresco-enterprise-share triggers the build or it is built manually"
+    [ "$(get_output message)" = "$expected" ]
+}
+
+@test "directives=[release] combined with downstream-repo omitted and pending-downstream appends skip directive" {
+    unset DOWNSTREAM_REPO
+    export DIRECTIVES="[release]"
+    export VERSION="26.3.0-A.4"
+    export PENDING_DOWNSTREAM="acs-community-packaging"
+    export BRANCH_NAME="master"
+
+    run bash "$ACTION_SCRIPT"
+
+    [ "$status" -eq 0 ]
+    expected="[release] 26.3.0-A.4
+
+[skip docker_latest] until acs-community-packaging triggers the build or it is built manually"
+    [ "$(get_output message)" = "$expected" ]
 }

--- a/.github/actions/get-downstream-commit-message/tests/get-downstream-commit-message.bats
+++ b/.github/actions/get-downstream-commit-message/tests/get-downstream-commit-message.bats
@@ -391,7 +391,7 @@ get_output() {
     [[ "$(get_output message)" != *"[publish]"* ]]
 }
 
-@test "directives=[release] combined with [force] prefixes force before directives" {
+@test "directives=[release] combined with [force] prefixes force before directives without space" {
     export DIRECTIVES="[release]"
     export COMMIT_TITLE="[force] ACS-123: force and release"
     export VERSION="26.3.0-A.4"
@@ -399,7 +399,7 @@ get_output() {
     run bash "$ACTION_SCRIPT"
 
     [ "$status" -eq 0 ]
-    [ "$(get_output message)" = "[force] [release] Update community-repo version to 26.3.0-A.4" ]
+    [ "$(get_output message)" = "[force][release] Update community-repo version to 26.3.0-A.4" ]
     [ "$(get_output allow-empty-commit)" = "true" ]
 }
 
@@ -411,7 +411,7 @@ get_output() {
     run bash "$ACTION_SCRIPT"
 
     [ "$status" -eq 0 ]
-    [ "$(get_output message)" = "[force] [release][publish] Update community-repo version to 26.3.0-A.4" ]
+    [ "$(get_output message)" = "[force][release][publish] Update community-repo version to 26.3.0-A.4" ]
     [ "$(get_output allow-empty-commit)" = "true" ]
 }
 


### PR DESCRIPTION
# Enhance `get-downstream-commit-message` action

Extends the action with three new capabilities needed by `alfresco-enterprise-share` and `acs-packaging` when propagating version bumps downstream.

## Changes

### New inputs

| Input | Default | Purpose |
|---|---|---|
| `trigger-release-on-force` | `false` | When `true` and a `[force...]` token is present, appends `[release][skip tests]` after the force token so the downstream repo triggers its own release. |
| `directives` | `""` | Base directives prepended to the message (e.g. `[release]`). `[publish]` is appended automatically when the upstream commit title contains `[publish]`. |
| `downstream-repo` now optional | `""` | When omitted the message body is the bare version string instead of `Update <repo> version to <version>`. |

All changes are backward-compatible — existing callers with none of these inputs produce identical output.

---

## Usage examples

### `alfresco-enterprise-share` → `acs-packaging`

The share release triggers a release in acs-packaging when a `[force]` commit is pushed.
`trigger-release-on-force: "true"` injects `[release][skip tests]` into the downstream commit.

```yaml
- uses: Alfresco/alfresco-community-repo/.github/actions/get-downstream-commit-message@HEAD
  id: commit-meta
  with:
    commit-title: ${{ github.event.head_commit.message }}
    version: ${{ steps.update-downstream.outputs.version }}
    downstream-repo: "enterprise-share"
    trigger-release-on-force: "true"
```

| `commit-title` | produced `message` | `allow-empty-commit` |
|---|---|---|
| `ACS-123: bump` | `Update enterprise-share version to 26.0.3.15` | `false` |
| `ACS-123: bump [force]` | `[force][release][skip tests] Update enterprise-share version to 26.0.3.15` | `true` |

---

### `acs-packaging` → `acs-community-packaging`

acs-packaging always prepends `[release]` and conditionally appends `[publish]` when the upstream commit contains `[publish]`.
`downstream-repo` is omitted so the message body is the bare version string.

```yaml
- uses: Alfresco/alfresco-community-repo/.github/actions/get-downstream-commit-message@HEAD
  id: commit-meta
  with:
    commit-title: ${{ needs.commit_parser.outputs.title }}
    version: ${{ env.RELEASE_VERSION }}
    directives: "[release]"
```

| `commit-title` | produced `message` | `allow-empty-commit` |
|---|---|---|
| `ACS-123: bump` | `[release] 26.3.0-A.4` | `false` |
| `ACS-123: bump [publish]` | `[release][publish] 26.2.0` | `false` |
| `ACS-123: bump [force]` | `[force] [release] 26.3.0-A.4` | `true` |
| `ACS-123: bump [force] [publish]` | `[force] [release][publish] 26.2.0` | `true` |
