### PR TITLE
ACS-12551 Bump Alfresco Transform Service (ATS) and Transform Core versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>8.0.1</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.4.3</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.4.3</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.4.4-A.5</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.4.4-A.6</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.1.0-A.1</dependency.acs-event-model.version>
 


### PR DESCRIPTION
## Summary

Bumps the Alfresco Transform dependency versions in `pom.xml`:

## Changes

- Updated `dependency.alfresco-transform-core.version` from `5.4.3` to `5.4.4-A.5` in `pom.xml`.
- Updated `dependency.alfresco-transform-service.version` from `4.4.3` to `4.4.4-A.6` in `pom.xml`.

## JIRA

[ACS-12551](https://alfresco.atlassian.net/browse/ACS-12551)

## Testing

- CI build / pipeline verification with the updated transform dependencies.

[ACS-12551]: https://hyland.atlassian.net/browse/ACS-12551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ