### PR TITLE
ACS-12551 Bump ATS to 25.N

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>7.0.4</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.4.2</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.4.2</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.4.4-A.5</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.4.4-A.6</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.0.11</dependency.acs-event-model.version>
 


### PR DESCRIPTION
## Summary

Bumps the Alfresco Transform Service (ATS) / Transform Core dependencies to the latest 25.N-line versions.

## Changes

In the root `pom.xml`:

| Property | Old | New |
| --- | --- | --- |
| `dependency.alfresco-transform-core.version` | `5.4.2` | `5.4.4-A.5` |
| `dependency.alfresco-transform-service.version` | `4.4.2` | `4.4.4-A.6` |

## Testing
- CI pipeline (build + transform-related integration tests) validates the upgraded ATS versions.