### PR TITLE
ACS-12543 - Bump api-explorer to 25.5.0-A.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency.json-smart.version>2.5.2</dependency.json-smart.version>
         <alfresco.googledrive.version>5.0.0-A2</alfresco.googledrive.version>
         <alfresco.aos-module.version>3.4.2-A.3</alfresco.aos-module.version>
-        <alfresco.api-explorer.version>25.4.1-A.1</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
+        <alfresco.api-explorer.version>25.5.0-A.1</alfresco.api-explorer.version> <!-- Also in alfresco-enterprise-share -->
 
         <alfresco.maven-plugin.version>2.2.0</alfresco.maven-plugin.version>
         <license-maven-plugin.version>2.4.0</license-maven-plugin.version>


### PR DESCRIPTION
Bumping api-explorer alpha version to 25.5.0-A.1 in the community repo.