### PR TITLE
ACS-12630 Bump Alfresco Transform Core and Service versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>8.0.1</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.4.4-A.5</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.4.4-A.6</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.4.4-A.6</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.4.4-A.7</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.1.0-A.1</dependency.acs-event-model.version>
 


### PR DESCRIPTION
### What
Bumps the Alfresco Transform dependency versions in `pom.xml`:

| Dependency | From | To |
|---|---|---|
| `dependency.alfresco-transform-core.version` | `5.4.4-A.5` | `5.4.4-A.6` |
| `dependency.alfresco-transform-service.version` | `4.4.4-A.6` | `4.4.4-A.7` |

### Why
Keeps the repository aligned with the latest Alfresco Transform Core and Transform Service releases, picking up the newest fixes/improvements shipped in those artifacts.

### How
- Updated the two version properties in `pom.xml`.

### Testing
- CI build to confirm dependency resolution and that existing transform-related tests pass.

### Jira
ACS-12630