### PR TITLE
ACS-12630 Bump Alfresco Transform Service (ATS) versions for 25.N

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>7.0.4</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.4.4-A.5</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.4.4-A.6</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.4.4-A.6</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.4.4-A.7</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.0.11</dependency.acs-event-model.version>
 


### PR DESCRIPTION
### Summary
Bumps the Alfresco Transform dependency versions in `pom.xml` for the 25.N release line.

### Changes
| Dependency | Old version | New version |
|---|---|---|
| `dependency.alfresco-transform-core.version` | `5.4.4-A.5` | `5.4.4-A.6` |
| `dependency.alfresco-transform-service.version` | `4.4.4-A.6` | `4.4.4-A.7` |

### Details
- Updated `alfresco-transform-core` from `5.4.4-A.5` to `5.4.4-A.6`.
- Updated `alfresco-transform-service` from `4.4.4-A.6` to `4.4.4-A.7`.

### JIRA
ACS-12630

### Testing
- CI build and existing transform integration tests should validate compatibility with the new versions.