### PR TITLE
ACS-12750 : Bump ATS GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>7.0.4</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.4.4-A.5</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.4.4-A.6</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.4.4</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.4.4</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.0.11</dependency.acs-event-model.version>
 


### PR DESCRIPTION
## ACS-12750: Bump Alfresco Transform Service (ATS) versions for 25.N

### Summary
This PR bumps the Alfresco Transform Core and Alfresco Transform Service dependencies from pre-release (alpha) versions to their final released versions for the 25.N release line.

### Changes
Updated the following dependency versions in `pom.xml`:

| Dependency | Old Version | New Version |
|------------|-------------|-------------|
| `dependency.alfresco-transform-core.version` | `5.4.4-A.5` | `5.4.4` |
| `dependency.alfresco-transform-service.version` | `4.4.4-A.6` | `4.4.4` |

### Motivation
The transform dependencies were previously pinned to alpha (`-A.x`) builds. Now that the final `5.4.4` (Transform Core) and `4.4.4` (Transform Service) releases are available, this PR promotes them to the stable, released versions ahead of the 25.N release.

### Type of Change
- [x] Dependency / version bump

### Testing
- [ ] Verify CI build passes with the updated transform dependencies
- [ ] Confirm transform-related functionality (rendition/transformation flows) works as expected against the released ATS versions

### Related
- Jira: **ACS-12750**