### PR TITLE
ACS-12750 : Bump ATS GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <dependency.alfresco-server-root.version>8.0.1</dependency.alfresco-server-root.version>
         <dependency.activiti-engine.version>5.23.0</dependency.activiti-engine.version>
         <dependency.activiti.version>5.23.0</dependency.activiti.version>
-        <dependency.alfresco-transform-core.version>5.4.4-A.6</dependency.alfresco-transform-core.version>
-        <dependency.alfresco-transform-service.version>4.4.4-A.7</dependency.alfresco-transform-service.version>
+        <dependency.alfresco-transform-core.version>5.4.4</dependency.alfresco-transform-core.version>
+        <dependency.alfresco-transform-service.version>4.4.4</dependency.alfresco-transform-service.version>
         <dependency.alfresco-greenmail.version>7.1</dependency.alfresco-greenmail.version>
         <dependency.acs-event-model.version>1.1.0-A.1</dependency.acs-event-model.version>
 


### PR DESCRIPTION
## Bump Alfresco Transform Core and Transform Service to stable releases

### Summary
This PR updates the Alfresco Transform Service (ATS) dependencies from pre-release/alpha versions to their final stable releases.

### Changes
| Dependency | Old Version | New Version |
|------------|-------------|-------------|
| `alfresco-transform-core` | `5.4.4-A.6` | `5.4.4` |
| `alfresco-transform-service` | `4.4.4-A.7` | `4.4.4` |

### Details
- Updated `dependency.alfresco-transform-core.version` in `pom.xml` from `5.4.4-A.6` to the GA release `5.4.4`.
- Updated `dependency.alfresco-transform-service.version` in `pom.xml` from `4.4.4-A.7` to the GA release `4.4.4`.

Moving off the alpha (`-A.x`) builds to the finalized releases ensures the repository builds and ships against stable, supported artifacts.

### JIRA
ACS-12750

### Testing
- [ ] CI build passes with the updated transform dependencies
- [ ] Transform-related integration tests pass